### PR TITLE
Don't reset SkipIntros

### DIFF
--- a/Assembly-CSharp/Global/TitleUI.cs
+++ b/Assembly-CSharp/Global/TitleUI.cs
@@ -1349,7 +1349,6 @@ public class TitleUI : UIScene
             this.ShowMenuPanel();
             this.idleScreenType = SlideShow.Type.Sequence1;
             ButtonGroupState.ActiveGroup = MenuGroupButton;
-            Configuration.Graphics.SkipIntros = 0;
             this.timer.Start();
             if (this.IsJustLaunchApp)
             {

--- a/Assembly-CSharp/Global/TitleUI.cs
+++ b/Assembly-CSharp/Global/TitleUI.cs
@@ -1349,6 +1349,10 @@ public class TitleUI : UIScene
             this.ShowMenuPanel();
             this.idleScreenType = SlideShow.Type.Sequence1;
             ButtonGroupState.ActiveGroup = MenuGroupButton;
+            
+            if (Configuration.Graphics.SkipIntros > 2)
+                Configuration.Graphics.SkipIntros = 0;
+                
             this.timer.Start();
             if (this.IsJustLaunchApp)
             {


### PR DESCRIPTION
This prevents SkipIntros from being reset when using “Exit To Title Screen”

Fixes #41 