### PR TITLE
Memoria.Patcher.exe copy should compare last written rather than first created for changes

### DIFF
--- a/Memoria.Patcher/Program.cs
+++ b/Memoria.Patcher/Program.cs
@@ -167,9 +167,9 @@ namespace Memoria.Patcher
 
             foreach (String sourceFile in Directory.EnumerateFiles(sourceDirectory, extensions, SearchOption.AllDirectories))
             {
-                DateTime sourceFileTime = File.GetCreationTimeUtc(sourceFile);
+                DateTime sourceFileTime = File.GetLastWriteTimeUtc(sourceFile);
                 String targetFile = targetDirectory + sourceFile.Substring(sourceDirectory.Length);
-                if (File.Exists(targetFile) && File.GetCreationTimeUtc(targetFile) == sourceFileTime)
+                if (File.Exists(targetFile) && File.GetLastWriteTimeUtc(targetFile) == sourceFileTime)
                     continue;
 
                 String directoryName = Path.GetDirectoryName(targetFile);


### PR DESCRIPTION
If you modify a file (e.g. Data/Battle/Actions.csv) and run the patcher, it won't replace the file with the updated version because the creation times match. We should instead compare last written.