### PR TITLE
Change Thunder Slash from Gravity to Magic Weapon to fix hit rate

### DIFF
--- a/Memoria.Patcher/Data/Battle/Actions.csv
+++ b/Memoria.Patcher/Data/Battle/Actions.csv
@@ -153,7 +153,7 @@
  Mental Break;146;None(0);SingleEnemy(2);0;0;0;0;209;209;35;0;0;50;12;0;8;0;# Mental Break
  Magic Break;147;None(0);SingleEnemy(2);0;0;0;0;46;46;36;0;0;50;12;0;4;0;# Magic Break
  Charge!;148;None(0);RandomEnemy(11);0;0;0;0;398;398;61;0;0;0;12;0;10;0;# Charge!
- Thunder Slash;149;None(0);SingleEnemy(2);0;0;0;0;191;412;17;19;4;0;12;0;24;0;# Thunder Slash
+ Thunder Slash;149;None(0);SingleEnemy(2);0;0;0;0;191;412;20;19;4;0;12;0;24;0;# Thunder Slash
  Stock Break;150;None(0);AllEnemy(8);0;0;0;0;207;414;19;15;0;0;12;0;26;0;# Stock Break
  Climhazzard;151;None(0);AllEnemy(8);0;0;0;0;397;417;20;20;0;0;12;0;32;0;# Climhazzard
  Shock;152;None(0);SingleEnemy(2);0;0;0;0;192;413;19;30;0;0;12;0;46;0;# Shock

--- a/Memoria.Scripts/Sources/Battle/0017_MagicProportionHpDmageScript.cs
+++ b/Memoria.Scripts/Sources/Battle/0017_MagicProportionHpDmageScript.cs
@@ -3,7 +3,7 @@ using System;
 namespace Memoria.Scripts.Battle
 {
     /// <summary>
-    /// Demi, Aqua Breath, Demi Shock, Thunder Slash, Worm Hole
+    /// Demi, Aqua Breath, Demi Shock, Worm Hole
     /// </summary>
     [BattleScript(Id)]
     public sealed class MagicProportionHpDmageScript : IBattleScript


### PR DESCRIPTION
http://finalfantasy.wikia.com/wiki/Thunder_Slash_glitch

This change fixes the Thunder Slash glitch by changing the attack type from gravity to magic weapon allowing the attack to actually hit and do damage.