### PR TITLE
Bugfixes reported in Hades Workshop's Thread.

### DIFF
--- a/Assembly-CSharp/Global/AbilityUI.cs
+++ b/Assembly-CSharp/Global/AbilityUI.cs
@@ -26,6 +26,8 @@ using UnityEngine;
 public class AbilityUI : UIScene
 {
     public const Int32 FF9FABIL_EVENT_NOMAGIC = 227;
+    private static readonly Int32 AbilFenril = 66;
+    private static readonly Int32 AbilCarbuncle = 68;
     public GameObject TransitionGroup;
     public GameObject UseSubMenu;
     public GameObject EquipSubMenu;
@@ -763,7 +765,8 @@ public class AbilityUI : UIScene
             itemListDetailHud.Content.SetActive(true);
             ButtonGroupState.SetButtonAnimation(itemListDetailHud.Self, abilityListData.Type == AbilityType.Enable);
             Int32 mp = GetMp(FF9StateSystem.Battle.FF9Battle.aa_data[abilityListData.Id]);
-            itemListDetailHud.NameLabel.text = FF9TextTool.ActionAbilityName(abilityListData.Id);
+            Int32 patchedId = this.PatchAbility(abilityListData.Id);	
+            itemListDetailHud.NameLabel.text = FF9TextTool.ActionAbilityName(patchedId);
             itemListDetailHud.NumberLabel.text = mp != 0 ? mp.ToString() : String.Empty;
             if (abilityListData.Type == AbilityType.CantSpell)
             {
@@ -776,8 +779,36 @@ public class AbilityUI : UIScene
                 itemListDetailHud.NumberLabel.color = FF9TextTool.White;
             }
             itemListDetailHud.Button.Help.Enable = true;
-            itemListDetailHud.Button.Help.Text = FF9TextTool.ActionAbilityHelpDescription(abilityListData.Id);
+            itemListDetailHud.Button.Help.Text = FF9TextTool.ActionAbilityHelpDescription(patchedId);
         }
+    }
+    
+    private Int32 PatchAbility(Int32 id)
+    {
+        if (AbilityUI.AbilCarbuncle == id)
+        {
+            switch (FF9StateSystem.Common.FF9.party.member[this.currentPartyIndex].equip[4])
+            {
+            case 227:
+                id += 3;
+                break;
+            case 228:
+                id++;
+                break;
+            case 229:
+                id += 2;
+                break;
+            }
+        }
+        else
+        {
+            if (AbilityUI.AbilFenril == id)
+            {
+                byte b = FF9StateSystem.Common.FF9.party.member[this.currentPartyIndex].equip[4];
+                id += ((b != 222) ? 0 : 1);
+            }
+        }
+        return id;
     }
 
     private void DisplaySA()

--- a/Assembly-CSharp/Global/EquipUI.cs
+++ b/Assembly-CSharp/Global/EquipUI.cs
@@ -111,6 +111,7 @@ public class EquipUI : UIScene
 					ButtonGroupState.HoldActiveStateOnGroup(EquipUI.SubMenuGroupButton);
 					this.DisplaySubMenuArrow(false);
 					this.DisplayEquiptmentInfo();
+					this.DisplayParameter();
 					break;
 				case EquipUI.SubMenu.Optimize:
 				    if (_equipForAbilityLearning)
@@ -1541,7 +1542,21 @@ public class EquipUI : UIScene
 				}
 				i++;
 			}
+			NewParameterLabel[3].gameObject.AddComponent<FixSpiritSkillNumberLabelPos>();
 		}
+		
+		public class FixSpiritSkillNumberLabelPos : MonoBehaviour
+    {
+        void Start()
+        {
+            transform.localPosition = Vector2.right * 292;
+        }
+
+        void OnEnable()
+        {
+            transform.localPosition = Vector2.right * 292;
+        }
+    }
 
 		public GameObject Self;
 

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
@@ -619,7 +619,9 @@ public partial class BattleHUD : UIScene
         else
         {
             itemListDetailHud.Content.SetActive(true);
-            itemListDetailHud.NameLabel.text = FF9TextTool.ActionAbilityName(abilityId);
+						
+						int patchedID = this.PatchAbility(abilityId);
+            itemListDetailHud.NameLabel.text = FF9TextTool.ActionAbilityName(patchedID);
             Int32 mp = GetActionMpCost(aaData);
             itemListDetailHud.NumberLabel.text = mp == 0 ? String.Empty : mp.ToString();
 
@@ -637,7 +639,7 @@ public partial class BattleHUD : UIScene
             }
 
             itemListDetailHud.Button.Help.TextKey = String.Empty;
-            itemListDetailHud.Button.Help.Text = FF9TextTool.ActionAbilityHelpDescription(abilityId);
+            itemListDetailHud.Button.Help.Text = FF9TextTool.ActionAbilityHelpDescription(patchedID);
         }
     }
 


### PR DESCRIPTION
Bugs fixed:
- Spirit value when changing equipment is not X-aligned with the other numbers above it
- When removing equipment, stat changes won't be displayed until you switch to another piece of equipment, for example by pressing up or down.
- Eiko's description for Fenrir and Carbuncle doesn't update both in and out of battle to reflect the effect change from equipping certain accessories.

Code changes described here
http://forums.qhimm.com/index.php?topic=14315.msg273804#msg273804
http://forums.qhimm.com/index.php?topic=14315.msg277655#msg277655

Alignment issue shown here:
https://imgur.com/a/WvbXtHI