### PR TITLE
Fix misaligned SFX in battle in widescreen mode

### DIFF
--- a/Assembly-CSharp/Global/SFXRender/SFXRender.cs
+++ b/Assembly-CSharp/Global/SFXRender/SFXRender.cs
@@ -44,7 +44,7 @@ public class SFXRender
 		if (SFX.SFX_BeginRender())
 		{
 			SFXRender.primCount = 0;
-			SFXMeshBase.drOffsetX = (FieldMap.PsxFieldWidth - 320) / 2; // Widescreen offset
+			SFXMeshBase.drOffsetX = CalculateWidescreenOffsetX();
 			SFXMeshBase.drOffsetY = 0;
 			SFXRender.meshEmpty = new List<SFXMesh>(SFXRender.meshOrigin);
 			for (Int32 i = 0; i < SFXRender.MESH_MAX; i++)
@@ -307,7 +307,7 @@ public class SFXRender
 
 	private unsafe static void DR_OFFSET(PSX_LIBGPU.DR_OFFSET* obj)
 	{
-		SFXMeshBase.drOffsetX = (Int32)(obj->code[1] & 65535u);
+		SFXMeshBase.drOffsetX = (Int32)(obj->code[1] & 65535u) + CalculateWidescreenOffsetX();
 		SFXMeshBase.drOffsetY = (Int32)(obj->code[1] >> 16);
 	}
 
@@ -317,7 +317,7 @@ public class SFXRender
 		Int32 num = (Int32)(obj->code[1] >> 16);
 		if (num != 0)
 		{
-			SFXMeshBase.drOffsetX -= PSXTextureMgr.GEN_TEXTURE_X;
+			SFXMeshBase.drOffsetX -= PSXTextureMgr.GEN_TEXTURE_X + CalculateWidescreenOffsetX();
 			SFXMeshBase.drOffsetY -= PSXTextureMgr.GEN_TEXTURE_Y;
 			SFXRender.commandBuffer.Add(new SFXRenderTextureBegin());
 		}
@@ -545,6 +545,11 @@ public class SFXRender
 		list.Add(sfxmesh2);
 		sfxmesh2.Setup(meshKey, code);
 		return sfxmesh2;
+	}
+
+	private static int CalculateWidescreenOffsetX()
+	{
+		return (FieldMap.PsxFieldWidth - 320) / 2;
 	}
 
 	public static Int32 primCount;


### PR DESCRIPTION
I haven't tested this too much, but it seems to fix the issue #125 

(ignore the post processing shader difference in the comparison screenshots)

### Float
#### Before
![FF9 2021-10-12 16-24-17](https://user-images.githubusercontent.com/59185507/137024215-bb041bf7-1233-4ad6-888f-3f341b641221.png)
#### After


![FF9 2021-10-12 16-21-34](https://user-images.githubusercontent.com/59185507/137023986-47be6746-115f-4011-bfcd-63ee27bff657.png)

### Might
#### Before
![FF9 2021-10-12 16-24-44](https://user-images.githubusercontent.com/59185507/137024091-11f456a0-7977-495b-a3a2-569c6343c37d.png)
#### After
![FF9 2021-10-12 16-22-33](https://user-images.githubusercontent.com/59185507/137024115-25365faf-ee4f-468b-a27b-391129cc317d.png)

### Flare
#### Before

![FF9 2021-10-12 17-10-08](https://user-images.githubusercontent.com/59185507/137024153-ca50a356-ca89-4796-ab0b-a22923558c04.png)
 
#### After
![FF9 2021-10-12 17-11-56](https://user-images.githubusercontent.com/59185507/137024174-54a2ea57-0d35-46fa-8211-968544e60b0f.png)

