### PR TITLE
Moves ChocographLocationPanel below miniMapWidget for a better visibility

### DIFF
--- a/Assembly-CSharp/Global/World/WorldHUD.cs
+++ b/Assembly-CSharp/Global/World/WorldHUD.cs
@@ -1269,6 +1269,7 @@ public class WorldHUD : UIScene
 		uieventListener6.onClick = (UIEventListener.VoidDelegate)Delegate.Combine(uieventListener6.onClick, new UIEventListener.VoidDelegate(this.onClick));
 		this.PlaneButtonPanel.GetChild(0).GetComponent<OnScreenButton>().SetHighlightKeyCommand(Control.Down);
 		this.PlaneButtonPanel.GetChild(1).GetComponent<OnScreenButton>().SetHighlightKeyCommand(Control.Up);
+		this.ChocographLocationPanel.transform.localPosition += new Vector3(158f, -708f, 0f);
 		// Todo: see with TehMighty for a proper and unified UI mod
 		//this.ChocographLocationPanel.transform.localPosition = new Vector3(600f, 0f, 0f);
 		//this.miniMapWidget.transform.parent.localPosition = new Vector3(250f, -500f, 0f);


### PR DESCRIPTION
Currently, minimap and chocograph are placed in different spots than in original but also in places which obscures player's view.

Original HUD:
![image](https://user-images.githubusercontent.com/23423558/148979482-03375e04-bf15-4a45-a3ca-749ffce232d4.png)

Now, chocograph is moved below minimap for a better visibility. Unfortunately, I wasn't able to completely recreate original HUD using methods described in the issue.

New HUD:
![image](https://user-images.githubusercontent.com/23423558/148979677-683c24fa-925d-4796-b322-4b290e585b48.png)

For additional information see issue [Fix map position like in PSX #179](https://github.com/Albeoris/Memoria/issues/179)
