### PR TITLE
Unit tests and further refactoring

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -392,6 +392,7 @@
     <Compile Include="Memoria\Data\Battle\AccessoryItem.cs" />
     <Compile Include="Memoria\Data\Battle\BattleAbilityHelper.cs" />
     <Compile Include="Memoria\Data\Battle\BattleStatusDataEntry.cs" />
+    <Compile Include="Memoria\Data\ByteExtensions.cs" />
     <Compile Include="Memoria\Data\Charactes\EquipmentSetId.cs" />
     <Compile Include="Memoria\Data\ff9itemHelpers.cs" />
     <Compile Include="Memoria\Field\TileMap.cs" />

--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Assembly-CSharp</RootNamespace>
     <AssemblyName>Assembly-CSharp</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -12,7 +12,8 @@
     <AssemblyName>Assembly-CSharp</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile>Unity Full v3.5</TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
     <FrameworkPathOverride>$(SolutionDir)\References\</FrameworkPathOverride>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
@@ -392,6 +393,7 @@
     <Compile Include="Memoria\Data\Battle\BattleAbilityHelper.cs" />
     <Compile Include="Memoria\Data\Battle\BattleStatusDataEntry.cs" />
     <Compile Include="Memoria\Data\Charactes\EquipmentSetId.cs" />
+    <Compile Include="Memoria\Data\ff9itemHelpers.cs" />
     <Compile Include="Memoria\Field\TileMap.cs" />
     <Compile Include="Memoria\Field\TileCoordinates.cs" />
     <Compile Include="Memoria\Test\Commands\CommandMessageType.cs" />

--- a/Assembly-CSharp/Global/PLAYER.cs
+++ b/Assembly-CSharp/Global/PLAYER.cs
@@ -1,25 +1,27 @@
-﻿using System;
-using Assets.Sources.Scripts.UI.Common;
+﻿using Assets.Sources.Scripts.UI.Common;
 using FF9;
 using Memoria.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 public class PLAYER
 {
     public PLAYER()
-	{
-		this.cur = new POINTS();
-		this.max = new POINTS();
-		this.elem = new ELEMENT();
-		this.defence = new ItemDefence();
-		this.basis = new PLAYER_BASE();
-	    this.equip = new CharacterEquipment();
-		this.bonus = new FF9LEVEL_BONUS();
-		this.pa = new Byte[48];
-		this.sa = new UInt32[2];
-		this.sa[0] = 0u;
-		this.sa[1] = 0u;
-		this.mpCostFactor = 100;
-	}
+    {
+        this.cur = new POINTS();
+        this.max = new POINTS();
+        this.elem = new ELEMENT();
+        this.defence = new ItemDefence();
+        this.basis = new PLAYER_BASE();
+        this.equip = new CharacterEquipment();
+        this.bonus = new FF9LEVEL_BONUS();
+        this.pa = new Byte[48];
+        this.sa = new UInt32[2];
+        this.sa[0] = 0u;
+        this.sa[1] = 0u;
+        this.mpCostFactor = 100;
+    }
 
     public CharacterIndex Index => info.slot_no;
     public Boolean IsSubCharacter => (Category & CharacterCategory.Subpc) == CharacterCategory.Subpc;
@@ -39,75 +41,75 @@ public class PLAYER
     }
 
     public void ValidateSupportAbility()
-	{
-		Int32 activeSupportAbilityPoint = this.GetActiveSupportAbilityPoint();
-		if ((Int32)this.cur.capa != (Int32)this.max.capa - activeSupportAbilityPoint)
-		{
-			this.cur.capa = this.max.capa;
-			this.sa[0] = 0u;
-			this.sa[1] = 0u;
-		}
-	}
+    {
+        Int32 activeSupportAbilityPoint = this.GetActiveSupportAbilityPoint();
+        if ((Int32)this.cur.capa != (Int32)this.max.capa - activeSupportAbilityPoint)
+        {
+            this.cur.capa = this.max.capa;
+            this.sa[0] = 0u;
+            this.sa[1] = 0u;
+        }
+    }
 
-	public void ValidateBasisStatus()
-	{
-		if (this.level == 99 && this.SetMaxBonusBasisStatus())
-		{
-			ff9play.FF9Play_Build((Int32)this.info.slot_no, (Int32)this.level, (PLAYER_INFO)null, false);
-		}
-	}
+    public void ValidateBasisStatus()
+    {
+        if (this.level == 99 && this.SetMaxBonusBasisStatus())
+        {
+            ff9play.FF9Play_Build((Int32)this.info.slot_no, (Int32)this.level, (PLAYER_INFO)null, false);
+        }
+    }
 
-	public Boolean SetMaxBonusBasisStatus()
-	{
-		Boolean result = false;
-		if (this.bonus.str < 294)
-		{
-			result = true;
-			this.bonus.str = 294;
-		}
-		if (this.bonus.mgc < 294)
-		{
-			result = true;
-			this.bonus.mgc = 294;
-		}
-		if (this.bonus.wpr < 98)
-		{
-			result = true;
-			this.bonus.wpr = 98;
-		}
-		return result;
-	}
+    public Boolean SetMaxBonusBasisStatus()
+    {
+        Boolean result = false;
+        if (this.bonus.str < 294)
+        {
+            result = true;
+            this.bonus.str = 294;
+        }
+        if (this.bonus.mgc < 294)
+        {
+            result = true;
+            this.bonus.mgc = 294;
+        }
+        if (this.bonus.wpr < 98)
+        {
+            result = true;
+            this.bonus.wpr = 98;
+        }
+        return result;
+    }
 
-	public void ValidateMaxStone()
-	{
-		if (this.max.capa < (Byte)ff9level.FF9Level_GetCap((Int32)this.info.slot_no, (Int32)this.level, false))
-		{
-			ff9play.FF9Play_Build((Int32)this.info.slot_no, (Int32)this.level, (PLAYER_INFO)null, false);
-		}
-	}
+    public void ValidateMaxStone()
+    {
+        if (this.max.capa < (Byte)ff9level.FF9Level_GetCap((Int32)this.info.slot_no, (Int32)this.level, false))
+        {
+            ff9play.FF9Play_Build((Int32)this.info.slot_no, (Int32)this.level, (PLAYER_INFO)null, false);
+        }
+    }
 
-	public Int32 GetActiveSupportAbilityPoint()
-	{
-		Int32 num = 0;
-		Int32 num2 = 0;
-		UInt32[] array = this.sa;
-		for (Int32 i = 0; i < (Int32)array.Length; i++)
-		{
-			UInt32 num3 = array[i];
-			UInt32 num4 = num3;
-			for (Int32 j = 0; j < 32; j++)
-			{
-				if (num4 % 2u == 1u)
-				{
-					CharacterAbilityGems sa_DATA = ff9abil._FF9Abil_SaData[num2];
-					num += (Int32)sa_DATA.GemsCount;
-				}
-				num4 >>= 1;
-				num2++;
-			}
-		}
-		return num;
-	}
+    public Int32 GetActiveSupportAbilityPoint()
+    {
+        Int32 num = 0;
+        Int32 num2 = 0;
+        UInt32[] array = this.sa;
+        for (Int32 i = 0; i < (Int32)array.Length; i++)
+        {
+            UInt32 num3 = array[i];
+            UInt32 num4 = num3;
+            for (Int32 j = 0; j < 32; j++)
+            {
+                if (num4 % 2u == 1u)
+                {
+                    CharacterAbilityGems sa_DATA = ff9abil._FF9Abil_SaData[num2];
+                    num += (Int32)sa_DATA.GemsCount;
+                }
+                num4 >>= 1;
+                num2++;
+            }
+        }
+        return num;
+    }
 
     private String _name;
 
@@ -118,62 +120,62 @@ public class PLAYER
 
     public void SetRealName(String name)
     {
-	    _name = name;
+        _name = name;
     }
 
     private String GetName()
     {
-	    if ((category & 16) == 16)
+        if ((category & 16) == 16)
         {
-	        GetDefaultName(out _, out var altName);
-	        return altName;
+            GetDefaultName(out _, out var altName);
+            return altName;
         }
 
-	    SplitName(out var mainName, out _);
-	    return mainName;
+        SplitName(out var mainName, out _);
+        return mainName;
     }
 
     public const Byte PLAYER_CATEGORY_MALE = 1;
 
-	public const Byte PLAYER_CATEGORY_FEMALE = 2;
+    public const Byte PLAYER_CATEGORY_FEMALE = 2;
 
-	public const Byte PLAYER_CATEGORY_GAIA = 4;
+    public const Byte PLAYER_CATEGORY_GAIA = 4;
 
-	public const Byte PLAYER_CATEGORY_TERRA = 8;
+    public const Byte PLAYER_CATEGORY_TERRA = 8;
 
-	public const Byte PLAYER_CATEGORY_SUBPC = 16;
+    public const Byte PLAYER_CATEGORY_SUBPC = 16;
 
-	public const Byte PLAYER_CATEGORY_RESERVE1 = 32;
+    public const Byte PLAYER_CATEGORY_RESERVE1 = 32;
 
-	public const Byte PLAYER_CATEGORY_RESERVE2 = 64;
+    public const Byte PLAYER_CATEGORY_RESERVE2 = 64;
 
-	public const Byte PLAYER_CATEGORY_RESERVE3 = 128;
+    public const Byte PLAYER_CATEGORY_RESERVE3 = 128;
 
-	public const Byte ADVANCED_GUARD = 1;
+    public const Byte ADVANCED_GUARD = 1;
 
-	public const Byte REAR_GUARD = 0;
+    public const Byte REAR_GUARD = 0;
 
-	public const Int32 TRANCE_MODEL_ID_OFS = 19;
+    public const Int32 TRANCE_MODEL_ID_OFS = 19;
 
-	public const Int32 SLOT_MAX = 9;
+    public const Int32 SLOT_MAX = 9;
 
-	public const Int32 PARTY_MAX = 4;
+    public const Int32 PARTY_MAX = 4;
 
     // CharacterIndex
 
     public const Int32 PLAYER_NAME_MAX = 10;
 
-	public const Int32 EQUIP_WEAPON = 0;
+    public const Int32 EQUIP_WEAPON = 0;
 
-	public const Int32 EQUIP_ARMOR_HEAD = 1;
+    public const Int32 EQUIP_ARMOR_HEAD = 1;
 
-	public const Int32 EQUIP_ARMOR_WRIST = 2;
+    public const Int32 EQUIP_ARMOR_WRIST = 2;
 
-	public const Int32 EQUIP_ARMOR_BODY = 3;
+    public const Int32 EQUIP_ARMOR_BODY = 3;
 
-	public const Int32 EQUIP_ACCESSORY = 4;
+    public const Int32 EQUIP_ACCESSORY = 4;
 
-	public const Int32 EQUIP_MAX = 5;
+    public const Int32 EQUIP_MAX = 5;
 
     public String name
     {
@@ -183,26 +185,26 @@ public class PLAYER
 
     private void SetName(String value)
     {
-	    if ((category & 16) == 16)
-	    {
-		    // We cannot change the names of alternative characters
-		    if (String.IsNullOrEmpty(_name))
-		    {
-			    GetDefaultName(out var mainName, out _);
-			    _name = mainName;
-		    }
-	    }
-	    else
-	    {
-		    _name = value;
-		    SplitName(out var mainName, out _);
-		    _name = mainName;
-	    }
+        if ((category & 16) == 16)
+        {
+            // We cannot change the names of alternative characters
+            if (String.IsNullOrEmpty(_name))
+            {
+                GetDefaultName(out var mainName, out _);
+                _name = mainName;
+            }
+        }
+        else
+        {
+            _name = value;
+            SplitName(out var mainName, out _);
+            _name = mainName;
+        }
     }
 
     private void SplitName(out String mainName, out String altName)
     {
-	    if (String.IsNullOrEmpty(_name))
+        if (String.IsNullOrEmpty(_name))
         {
             GetDefaultName(out mainName, out altName);
         }
@@ -255,36 +257,55 @@ public class PLAYER
 
     public Byte category;
 
-	public Byte level;
+    public Byte level;
 
-	public UInt32 exp;
+    public UInt32 exp;
 
-	public POINTS cur;
+    public POINTS cur;
 
-	public POINTS max;
+    public POINTS max;
 
-	public Byte trance;
+    public Byte trance;
 
-	public Byte wep_bone;
+    public Byte wep_bone;
 
-	public ELEMENT elem;
+    public ELEMENT elem;
 
-	public ItemDefence defence;
+    public ItemDefence defence;
 
-	public PLAYER_BASE basis;
+    public PLAYER_BASE basis;
 
-	public PLAYER_INFO info;
+    public PLAYER_INFO info;
 
-	public Byte status;
+    public Byte status;
 
-	public CharacterEquipment equip;
+    public CharacterEquipment equip;
 
-	public FF9LEVEL_BONUS bonus;
+    public FF9LEVEL_BONUS bonus;
 
-	public Byte[] pa;
+    public Byte[] pa;
 
-	public UInt32[] sa;
+    public UInt32[] sa;
 
-	// Custom fields
-	public Int16 mpCostFactor;
+    // Custom fields
+    public Int16 mpCostFactor;
+
+    /// <summary>
+    /// Calculates how many time item is equipped by character in weapon, head, body, writs or
+    /// accessory slot.
+    /// </summary>
+    /// <param name="itemId">Item to check</param>
+    /// <returns>Occurrence number of an item on character.</returns>
+    public int GetEquipmentCount(int itemId)
+    {
+        var equipParts = new List<FF9FEQP_EQUIP>()
+        {
+            FF9FEQP_EQUIP.FF9FEQP_EQUIP_WEAPON, FF9FEQP_EQUIP.FF9FEQP_EQUIP_WRIST,
+            FF9FEQP_EQUIP.FF9FEQP_EQUIP_HEAD,   FF9FEQP_EQUIP.FF9FEQP_EQUIP_BODY,
+            FF9FEQP_EQUIP.FF9FEQP_EQUIP_ACCESSORY
+        };
+
+        int output = equipParts.Count(part => equip[(int)part] == itemId);
+        return output;
+    }
 }

--- a/Assembly-CSharp/Memoria/Data/ByteExtensions.cs
+++ b/Assembly-CSharp/Memoria/Data/ByteExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Memoria.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Memoria
+{
+    public static class ByteExtensions
+    {
+        public static bool HasFlag(this byte value, byte flag)
+        {
+            return (value & flag) != 0;
+        }
+
+        public static bool HasFlag(this byte value, ItemType flag)
+        {
+            return HasFlag(value, (byte)flag);
+        }
+    }
+}

--- a/Assembly-CSharp/Memoria/Data/IItemAchievementManager.cs
+++ b/Assembly-CSharp/Memoria/Data/IItemAchievementManager.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Memoria.Data
+{
+    public interface IItemAchievementManager
+    {
+        void FF9Item_Achievement(Int32 id, Int32 count, FF9ITEM[] items, PLAYER[] party);
+    }
+}

--- a/Assembly-CSharp/Memoria/Data/ff9item.2.cs
+++ b/Assembly-CSharp/Memoria/Data/ff9item.2.cs
@@ -168,18 +168,6 @@ public class ff9item
         return null;
     }
 
-    public static FF9ITEM FF9Item_GetPtr(Int32 id, FF9ITEM[] ff9Items)
-    {
-        FF9ITEM[] ff9ItemArray = ff9Items;
-        for (Int32 index = 0; index < 256; ++index)
-        {
-            FF9ITEM ff9Item = ff9ItemArray[index];
-            if (ff9Item.count != 0 && ff9Item.id == id)
-                return ff9Item;
-        }
-        return null;
-    }
-
     public static Int32 FF9Item_GetCount(Int32 id)
     {
         FF9ITEM ptr = FF9Item_GetPtr(id);

--- a/Assembly-CSharp/Memoria/Data/ff9item.2.cs
+++ b/Assembly-CSharp/Memoria/Data/ff9item.2.cs
@@ -224,20 +224,7 @@ public class ff9item
     public static Int32 FF9Item_GetEquipPart(Int32 id)
     {
         FF9ITEM_DATA ff9ItemData = _FF9Item_Data[id];
-        Byte[] numArray = new Byte[5]
-        {
-            128,
-            32,
-            64,
-            16,
-            8
-        };
-        for (Int32 index = 0; index < 5; ++index)
-        {
-            if ((ff9ItemData.type & numArray[index]) != 0)
-                return index;
-        }
-        return -1;
+        return ff9itemHelpers.FF9Item_GetEquipPart(ff9ItemData);
     }
 
     public static Int32 FF9Item_GetEquipCount(Int32 id)

--- a/Assembly-CSharp/Memoria/Data/ff9item.2.cs
+++ b/Assembly-CSharp/Memoria/Data/ff9item.2.cs
@@ -158,14 +158,7 @@ public class ff9item
 
     public static FF9ITEM FF9Item_GetPtr(Int32 id)
     {
-        FF9ITEM[] ff9ItemArray = FF9StateSystem.Common.FF9.item;
-        for (Int32 index = 0; index < 256; ++index)
-        {
-            FF9ITEM ff9Item = ff9ItemArray[index];
-            if (ff9Item.count != 0 && ff9Item.id == id)
-                return ff9Item;
-        }
-        return null;
+        return ff9itemHelpers.FF9Item_GetPtr(id, FF9StateSystem.Common.FF9.item);
     }
 
     public static Int32 FF9Item_GetCount(Int32 id)

--- a/Assembly-CSharp/Memoria/Data/ff9item.2.cs
+++ b/Assembly-CSharp/Memoria/Data/ff9item.2.cs
@@ -229,19 +229,7 @@ public class ff9item
 
     public static Int32 FF9Item_GetEquipCount(Int32 id)
     {
-        Int32 num = 0;
-        for (Int32 index1 = 0; index1 < 9; ++index1)
-        {
-            if (FF9StateSystem.Common.FF9.player[index1].info.party != 0)
-            {
-                for (Int32 index2 = 0; index2 < 5; ++index2)
-                {
-                    if (id == FF9StateSystem.Common.FF9.player[index1].equip[index2])
-                        ++num;
-                }
-            }
-        }
-        return num;
+        return ff9itemHelpers.FF9Item_GetEquipCount(id, FF9StateSystem.Common.FF9.player);
     }
 
     public static void FF9Item_AddImportant(Int32 id)

--- a/Assembly-CSharp/Memoria/Data/ff9item.2.cs
+++ b/Assembly-CSharp/Memoria/Data/ff9item.2.cs
@@ -163,10 +163,7 @@ public class ff9item
 
     public static Int32 FF9Item_GetCount(Int32 id)
     {
-        FF9ITEM ptr = FF9Item_GetPtr(id);
-        if (ptr == null)
-            return 0;
-        return ptr.count;
+        return ff9itemHelpers.FF9Item_GetCount(id, FF9StateSystem.Common.FF9.item);
     }
 
     public static Int32 FF9Item_Add(Int32 id, Int32 count)
@@ -206,19 +203,7 @@ public class ff9item
 
     public static Int32 FF9Item_Remove(Int32 id, Int32 count)
     {
-        FF9ITEM[] ff9ItemArray = FF9StateSystem.Common.FF9.item;
-        for (Int32 index = 0; index < 256; ++index)
-        {
-            FF9ITEM ff9Item = ff9ItemArray[index];
-            if (ff9Item.count != 0 && ff9Item.id == id)
-            {
-                if (ff9Item.count < count)
-                    count = ff9Item.count;
-                ff9Item.count -= (Byte)count;
-                return count;
-            }
-        }
-        return 0;
+        return ff9itemHelpers.FF9Item_Remove(id, count, FF9StateSystem.Common.FF9.item);
     }
 
     public static Int32 FF9Item_GetEquipPart(Int32 id)

--- a/Assembly-CSharp/Memoria/Data/ff9item.2.cs
+++ b/Assembly-CSharp/Memoria/Data/ff9item.2.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.IO;
-using Assets.SiliconSocial;
+﻿using Assets.SiliconSocial;
 using FF9;
 using Memoria;
 using Memoria.Assets;
 using Memoria.Data;
 using Memoria.Prime;
 using Memoria.Prime.CSV;
+using System;
+using System.IO;
 
 // ReSharper disable FieldCanBeMadeReadOnly.Global
 // ReSharper disable UnusedMember.Global
@@ -159,6 +159,18 @@ public class ff9item
     public static FF9ITEM FF9Item_GetPtr(Int32 id)
     {
         FF9ITEM[] ff9ItemArray = FF9StateSystem.Common.FF9.item;
+        for (Int32 index = 0; index < 256; ++index)
+        {
+            FF9ITEM ff9Item = ff9ItemArray[index];
+            if (ff9Item.count != 0 && ff9Item.id == id)
+                return ff9Item;
+        }
+        return null;
+    }
+
+    public static FF9ITEM FF9Item_GetPtr(Int32 id, FF9ITEM[] ff9Items)
+    {
+        FF9ITEM[] ff9ItemArray = ff9Items;
         for (Int32 index = 0; index < 256; ++index)
         {
             FF9ITEM ff9Item = ff9ItemArray[index];

--- a/Assembly-CSharp/Memoria/Data/ff9itemHelpers.cs
+++ b/Assembly-CSharp/Memoria/Data/ff9itemHelpers.cs
@@ -1,4 +1,5 @@
-﻿using FF9;
+﻿using Assets.SiliconSocial;
+using FF9;
 using Memoria;
 using Memoria.Data;
 using System;
@@ -20,19 +21,19 @@ public static class ff9itemHelpers
     public static Int32 FF9Item_GetEquipPart(FF9ITEM_DATA item)
     {
         if (item.type.HasFlag(ItemType.Weapon))
-            return (int)FF9FEQP_EQUIP.FF9FEQP_EQUIP_WEAPON;
+            return (Int32)FF9FEQP_EQUIP.FF9FEQP_EQUIP_WEAPON;
 
         if (item.type.HasFlag(ItemType.Armlet))
-            return (int)FF9FEQP_EQUIP.FF9FEQP_EQUIP_WRIST;
+            return (Int32)FF9FEQP_EQUIP.FF9FEQP_EQUIP_WRIST;
 
         if (item.type.HasFlag(ItemType.Helmet))
-            return (int)FF9FEQP_EQUIP.FF9FEQP_EQUIP_HEAD;
+            return (Int32)FF9FEQP_EQUIP.FF9FEQP_EQUIP_HEAD;
 
         if (item.type.HasFlag(ItemType.Armor))
-            return (int)FF9FEQP_EQUIP.FF9FEQP_EQUIP_BODY;
+            return (Int32)FF9FEQP_EQUIP.FF9FEQP_EQUIP_BODY;
 
         if (item.type.HasFlag(ItemType.Accessory))
-            return (int)FF9FEQP_EQUIP.FF9FEQP_EQUIP_ACCESSORY;
+            return (Int32)FF9FEQP_EQUIP.FF9FEQP_EQUIP_ACCESSORY;
 
         return -1;
     }
@@ -43,10 +44,29 @@ public static class ff9itemHelpers
     /// <param name="itemId">Item to search</param>
     /// <param name="party">Collection of party members</param>
     /// <returns>Count of item occurrences across party</returns>
-    public static int FF9Item_GetEquipCount(int itemId, PLAYER[] party)
+    public static Int32 FF9Item_GetEquipCount(Int32 itemId, PLAYER[] party)
     {
         IEnumerable<PLAYER> charsInParty = party.Where(c => c.info.party != 0);
-        int count = charsInParty.Select(c => c.GetEquipmentCount(itemId)).Sum();
+        Int32 count = charsInParty.Select(c => c.GetEquipmentCount(itemId)).Sum();
         return count;
+    }
+
+    public static Int32 FF9Item_Remove(Int32 id, Int32 count, FF9ITEM[] ff9ItemArray)
+    {
+        FF9ITEM item = ff9ItemArray.FirstOrDefault(x => x.count != 0 && x.id == id);
+        if (item == null)
+            return 0;
+
+        // Prevents removing more items than available.
+        Int32 removeCount = item.count >= count ? count : item.count;
+        item.count -= (Byte)removeCount;
+        return removeCount;
+
+    }
+
+    public static Int32 FF9Item_GetCount(Int32 id, FF9ITEM[] items)
+    {
+        FF9ITEM item = FF9Item_GetPtr(id, items);
+        return item == null ? 0 : item.count;
     }
 }

--- a/Assembly-CSharp/Memoria/Data/ff9itemHelpers.cs
+++ b/Assembly-CSharp/Memoria/Data/ff9itemHelpers.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿using FF9;
+using Memoria;
+using Memoria.Data;
+using System;
 using System.Linq;
 
 public static class ff9itemHelpers
@@ -6,5 +9,30 @@ public static class ff9itemHelpers
     public static FF9ITEM FF9Item_GetPtr(Int32 id, FF9ITEM[] ff9Items)
     {
         return ff9Items.FirstOrDefault(x => x?.count != 0 && x?.id == id);
+    }
+
+    /// <summary>
+    /// Defines, based on equipment type, where item should go (weapon, wrist, head ect.)
+    /// </summary>
+    /// <param name="item">Item under inspection</param>
+    /// <returns><see cref="FF9FEQP_EQUIP"/> value of equipment slot</returns>
+    public static Int32 FF9Item_GetEquipPart(FF9ITEM_DATA item)
+    {
+        if (item.type.HasFlag(ItemType.Weapon))
+            return (int)FF9FEQP_EQUIP.FF9FEQP_EQUIP_WEAPON;
+
+        if (item.type.HasFlag(ItemType.Armlet))
+            return (int)FF9FEQP_EQUIP.FF9FEQP_EQUIP_WRIST;
+
+        if (item.type.HasFlag(ItemType.Helmet))
+            return (int)FF9FEQP_EQUIP.FF9FEQP_EQUIP_HEAD;
+
+        if (item.type.HasFlag(ItemType.Armor))
+            return (int)FF9FEQP_EQUIP.FF9FEQP_EQUIP_BODY;
+
+        if (item.type.HasFlag(ItemType.Accessory))
+            return (int)FF9FEQP_EQUIP.FF9FEQP_EQUIP_ACCESSORY;
+
+        return -1;
     }
 }

--- a/Assembly-CSharp/Memoria/Data/ff9itemHelpers.cs
+++ b/Assembly-CSharp/Memoria/Data/ff9itemHelpers.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+public static class ff9itemHelpers
+{
+
+    public static FF9ITEM FF9Item_GetPtr(Int32 id, FF9ITEM[] ff9Items)
+    {
+        FF9ITEM[] ff9ItemArray = ff9Items;
+        for (Int32 index = 0; index < 256; ++index)
+        {
+            FF9ITEM ff9Item = ff9ItemArray[index];
+            if (ff9Item.count != 0 && ff9Item.id == id)
+                return ff9Item;
+        }
+        return null;
+    }
+}

--- a/Assembly-CSharp/Memoria/Data/ff9itemHelpers.cs
+++ b/Assembly-CSharp/Memoria/Data/ff9itemHelpers.cs
@@ -2,6 +2,7 @@
 using Memoria;
 using Memoria.Data;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 public static class ff9itemHelpers
@@ -34,5 +35,18 @@ public static class ff9itemHelpers
             return (int)FF9FEQP_EQUIP.FF9FEQP_EQUIP_ACCESSORY;
 
         return -1;
+    }
+
+    /// <summary>
+    /// Determines, how many times item is equipped across the entire party.
+    /// </summary>
+    /// <param name="itemId">Item to search</param>
+    /// <param name="party">Collection of party members</param>
+    /// <returns>Count of item occurrences across party</returns>
+    public static int FF9Item_GetEquipCount(int itemId, PLAYER[] party)
+    {
+        IEnumerable<PLAYER> charsInParty = party.Where(c => c.info.party != 0);
+        int count = charsInParty.Select(c => c.GetEquipmentCount(itemId)).Sum();
+        return count;
     }
 }

--- a/Assembly-CSharp/Memoria/Data/ff9itemHelpers.cs
+++ b/Assembly-CSharp/Memoria/Data/ff9itemHelpers.cs
@@ -9,7 +9,7 @@ public static class ff9itemHelpers
         for (Int32 index = 0; index < 256; ++index)
         {
             FF9ITEM ff9Item = ff9ItemArray[index];
-            if (ff9Item.count != 0 && ff9Item.id == id)
+            if (ff9Item?.count != 0 && ff9Item?.id == id)
                 return ff9Item;
         }
         return null;

--- a/Assembly-CSharp/Memoria/Data/ff9itemHelpers.cs
+++ b/Assembly-CSharp/Memoria/Data/ff9itemHelpers.cs
@@ -1,17 +1,11 @@
 ﻿using System;
+using System.Linq;
 
 public static class ff9itemHelpers
 {
 
     public static FF9ITEM FF9Item_GetPtr(Int32 id, FF9ITEM[] ff9Items)
     {
-        FF9ITEM[] ff9ItemArray = ff9Items;
-        for (Int32 index = 0; index < 256; ++index)
-        {
-            FF9ITEM ff9Item = ff9ItemArray[index];
-            if (ff9Item?.count != 0 && ff9Item?.id == id)
-                return ff9Item;
-        }
-        return null;
+        return ff9Items.FirstOrDefault(x => x?.count != 0 && x?.id == id);
     }
 }

--- a/Assembly-CSharp/Memoria/Data/ff9itemHelpers.cs
+++ b/Assembly-CSharp/Memoria/Data/ff9itemHelpers.cs
@@ -3,7 +3,6 @@ using System.Linq;
 
 public static class ff9itemHelpers
 {
-
     public static FF9ITEM FF9Item_GetPtr(Int32 id, FF9ITEM[] ff9Items)
     {
         return ff9Items.FirstOrDefault(x => x?.count != 0 && x?.id == id);

--- a/Memoria.Prime/Memoria.Prime.csproj
+++ b/Memoria.Prime/Memoria.Prime.csproj
@@ -10,9 +10,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Memoria.Prime</RootNamespace>
     <AssemblyName>Memoria.Prime</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile>Unity Full v3.5</TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
     <FrameworkPathOverride>$(SolutionDir)\References\</FrameworkPathOverride>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/Memoria.Scripts/Memoria.Scripts.csproj
+++ b/Memoria.Scripts/Memoria.Scripts.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Memoria.Scripts</RootNamespace>
     <AssemblyName>Memoria.Scripts</AssemblyName>
-	<TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile>Unity Full v3.5</TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
     <FrameworkPathOverride>$(SolutionDir)\References\</FrameworkPathOverride>
     <AllowedReferenceRelatedFileExtensions>.pdb</AllowedReferenceRelatedFileExtensions>
     <LangVersion>latest</LangVersion>

--- a/Memoria.Tests/Memoria.Tests.csproj
+++ b/Memoria.Tests/Memoria.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/Memoria.Tests/Memoria.Tests.csproj
+++ b/Memoria.Tests/Memoria.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Assembly-CSharp\Assembly-CSharp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Memoria.Tests/Usings.cs
+++ b/Memoria.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Memoria.Tests/ff9ItemHelpersTests.cs
+++ b/Memoria.Tests/ff9ItemHelpersTests.cs
@@ -1,3 +1,5 @@
+using FF9;
+using Memoria.Data;
 using Moq;
 
 namespace Memoria.Tests
@@ -68,6 +70,22 @@ namespace Memoria.Tests
         private static FF9ITEM CreateRandomZeroCountItem()
         {
             return new FF9ITEM((byte)rnd.Next(1, byte.MaxValue), count: 0);
+        }
+
+        [Theory]
+        [InlineData(ItemType.Weapon, FF9FEQP_EQUIP.FF9FEQP_EQUIP_WEAPON)]
+        [InlineData(ItemType.Armlet, FF9FEQP_EQUIP.FF9FEQP_EQUIP_WRIST)]
+        [InlineData(ItemType.Helmet, FF9FEQP_EQUIP.FF9FEQP_EQUIP_HEAD)]
+        [InlineData(ItemType.Armor, FF9FEQP_EQUIP.FF9FEQP_EQUIP_BODY)]
+        [InlineData(ItemType.Accessory, FF9FEQP_EQUIP.FF9FEQP_EQUIP_ACCESSORY)]
+        public void GetEquipPart_WhenItemTypeHasEquipPart_ReturnsEquipPart(ItemType itemType, FF9FEQP_EQUIP expected)
+        {
+            FF9ITEM_DATA item = CreateRandomItemData();
+            item.type = (byte)itemType;
+
+            int actual = ff9itemHelpers.FF9Item_GetEquipPart(item);
+
+            Assert.Equal(expected, (FF9FEQP_EQUIP)actual);
         }
     }
 }

--- a/Memoria.Tests/ff9ItemHelpersTests.cs
+++ b/Memoria.Tests/ff9ItemHelpersTests.cs
@@ -1,0 +1,73 @@
+using Moq;
+
+namespace Memoria.Tests
+{
+    public class ff9ItemHelpersTests
+    {
+        private const int maxItemCount = byte.MaxValue + 1;
+        private static readonly Random rnd = new();
+
+        [Fact]
+        public void GetPtr_WhenInventoryContainsItem_ReturnsItem()
+        {
+            FF9ITEM? item = CreateRandomNonZeroCountItem();
+
+            var inventory = new FF9ITEM[maxItemCount];
+            inventory[0] = item;
+
+            FF9ITEM? actual = ff9itemHelpers.FF9Item_GetPtr(item.id, inventory);
+
+            Assert.Same(item, actual);
+        }
+
+        [Fact]
+        public void GetPtr_WhenInventoryNotContainsItem_ReturnsNull()
+        {
+            FF9ITEM item = CreateRandomNonZeroCountItem();
+            var inventory = new FF9ITEM[maxItemCount];
+
+            FF9ITEM? actual = ff9itemHelpers.FF9Item_GetPtr(item.id, inventory);
+
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void GetPtr_WhenInventoryContainsZeroItem_ReturnsNull()
+        {
+            FF9ITEM? item = CreateRandomZeroCountItem();
+
+            var inventory = new FF9ITEM[maxItemCount];
+            inventory[0] = item;
+
+            FF9ITEM? actual = ff9itemHelpers.FF9Item_GetPtr(item.id, inventory);
+
+            Assert.Null(actual);
+        }
+
+        private static FF9ITEM_DATA CreateRandomItemData()
+        {
+            return new FF9ITEM_DATA(name: It.IsAny<ushort>(),
+                                    help: It.IsAny<ushort>(),
+                                    price: It.IsAny<ushort>(),
+                                    equip: It.IsAny<ushort>(),
+                                    shape: It.IsAny<byte>(),
+                                    color: It.IsAny<byte>(),
+                                    eq_lv: It.IsAny<byte>(),
+                                    bonus: It.IsAny<byte>(),
+                                    ability: It.IsAny<byte[]>(),
+                                    type: It.IsAny<byte>(),
+                                    sort: It.IsAny<byte>(),
+                                    pad: It.IsAny<byte>());
+        }
+
+        private static FF9ITEM CreateRandomNonZeroCountItem()
+        {
+            return new FF9ITEM((Byte)rnd.Next(1, byte.MaxValue), (Byte)rnd.Next(1, 99));
+        }
+
+        private static FF9ITEM CreateRandomZeroCountItem()
+        {
+            return new FF9ITEM((Byte)rnd.Next(1, byte.MaxValue), count: 0);
+        }
+    }
+}

--- a/Memoria.Tests/ff9ItemHelpersTests.cs
+++ b/Memoria.Tests/ff9ItemHelpersTests.cs
@@ -87,5 +87,73 @@ namespace Memoria.Tests
 
             Assert.Equal(expected, (FF9FEQP_EQUIP)actual);
         }
+
+        [Fact]
+        // Creates party, where everyone is not in the party. Therefor item count
+        // can't be made.
+        public void GetEquipCount_WhenPartyIsZero_ReturnsZero()
+        {
+            PLAYER[] party = new PLAYER[]
+            {
+                CreateNewPlayer(),
+                CreateNewPlayer(),
+                CreateNewPlayer(),
+                CreateNewPlayer(),
+                CreateNewPlayer(),
+                CreateNewPlayer(),
+                CreateNewPlayer(),
+                CreateNewPlayer(),
+                CreateNewPlayer()
+            };
+
+            const int itemId = 1;
+            int actual = ff9itemHelpers.FF9Item_GetEquipCount(itemId, party);
+            Assert.Equal(0, actual);
+        }
+
+
+        [Fact]
+        // Creates party, where everyone, expect one member is in the party, with
+        // one item equipped as a weapon.
+        public void GetEquipCount_WhenGivenIdExists_ReturnsEquipCount()
+        {
+            const int itemId = 1;
+
+            PLAYER[] party = new PLAYER[]
+            {
+                CreateNewPlayer(party:1, itemId: itemId, equipPart:(byte)FF9FEQP_EQUIP.FF9FEQP_EQUIP_WEAPON),
+                CreateNewPlayer(),
+                CreateNewPlayer(),
+                CreateNewPlayer(),
+                CreateNewPlayer(),
+                CreateNewPlayer(),
+                CreateNewPlayer(),
+                CreateNewPlayer(),
+                CreateNewPlayer()
+            };
+
+            int actual = ff9itemHelpers.FF9Item_GetEquipCount(itemId, party);
+            Assert.Equal(1, actual);
+        }
+
+        private static PLAYER CreateNewPlayer(byte party = 0, byte itemId = 0, byte equipPart = byte.MaxValue)
+        {
+            var equipment = new CharacterEquipment();
+            if (equipPart != byte.MaxValue && itemId != 0)
+            {
+                equipment[equipPart] = itemId;
+            }
+
+            return new PLAYER()
+            {
+                info = new PLAYER_INFO(It.IsAny<byte>(),
+                                       It.IsAny<byte>(),
+                                       It.IsAny<byte>(),
+                                       It.IsAny<byte>(),
+                                       party,
+                                       It.IsAny<byte>()),
+                equip = equipment
+            };
+        }
     }
 }

--- a/Memoria.Tests/ff9ItemHelpersTests.cs
+++ b/Memoria.Tests/ff9ItemHelpersTests.cs
@@ -62,12 +62,12 @@ namespace Memoria.Tests
 
         private static FF9ITEM CreateRandomNonZeroCountItem()
         {
-            return new FF9ITEM((Byte)rnd.Next(1, byte.MaxValue), (Byte)rnd.Next(1, 99));
+            return new FF9ITEM((byte)rnd.Next(1, byte.MaxValue), (byte)rnd.Next(1, 99));
         }
 
         private static FF9ITEM CreateRandomZeroCountItem()
         {
-            return new FF9ITEM((Byte)rnd.Next(1, byte.MaxValue), count: 0);
+            return new FF9ITEM((byte)rnd.Next(1, byte.MaxValue), count: 0);
         }
     }
 }

--- a/Memoria.sln
+++ b/Memoria.sln
@@ -74,7 +74,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Utils", "Utils", "{9A4F68D4
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Memoria.SteamFix", "Memoria.SteamFix\Memoria.SteamFix.csproj", "{8E82C124-FFC6-4B99-B5A9-F65B657E3822}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Memoria.Tests", "Memoria.Tests\Memoria.Tests.csproj", "{BB7FECFD-9DFC-4CA6-840E-55A801E4EFC7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Memoria.Tests", "Memoria.Tests\Memoria.Tests.csproj", "{BB7FECFD-9DFC-4CA6-840E-55A801E4EFC7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Memoria.sln
+++ b/Memoria.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30011.22
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32516.85
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Assembly-CSharp", "Assembly-CSharp\Assembly-CSharp.csproj", "{3FE6492C-C2E2-48EE-9AD6-B2D9A7D43C93}"
 EndProject
@@ -73,6 +73,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Utils", "Utils", "{9A4F68D4
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Memoria.SteamFix", "Memoria.SteamFix\Memoria.SteamFix.csproj", "{8E82C124-FFC6-4B99-B5A9-F65B657E3822}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Memoria.Tests", "Memoria.Tests\Memoria.Tests.csproj", "{BB7FECFD-9DFC-4CA6-840E-55A801E4EFC7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -222,6 +224,18 @@ Global
 		{8E82C124-FFC6-4B99-B5A9-F65B657E3822}.Release|x64.Build.0 = Release|Any CPU
 		{8E82C124-FFC6-4B99-B5A9-F65B657E3822}.Release|x86.ActiveCfg = Release|Any CPU
 		{8E82C124-FFC6-4B99-B5A9-F65B657E3822}.Release|x86.Build.0 = Release|Any CPU
+		{BB7FECFD-9DFC-4CA6-840E-55A801E4EFC7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB7FECFD-9DFC-4CA6-840E-55A801E4EFC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB7FECFD-9DFC-4CA6-840E-55A801E4EFC7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BB7FECFD-9DFC-4CA6-840E-55A801E4EFC7}.Debug|x64.Build.0 = Debug|Any CPU
+		{BB7FECFD-9DFC-4CA6-840E-55A801E4EFC7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BB7FECFD-9DFC-4CA6-840E-55A801E4EFC7}.Debug|x86.Build.0 = Debug|Any CPU
+		{BB7FECFD-9DFC-4CA6-840E-55A801E4EFC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB7FECFD-9DFC-4CA6-840E-55A801E4EFC7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BB7FECFD-9DFC-4CA6-840E-55A801E4EFC7}.Release|x64.ActiveCfg = Release|Any CPU
+		{BB7FECFD-9DFC-4CA6-840E-55A801E4EFC7}.Release|x64.Build.0 = Release|Any CPU
+		{BB7FECFD-9DFC-4CA6-840E-55A801E4EFC7}.Release|x86.ActiveCfg = Release|Any CPU
+		{BB7FECFD-9DFC-4CA6-840E-55A801E4EFC7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/UnityEngine.UI/UnityEngine.UI.csproj
+++ b/UnityEngine.UI/UnityEngine.UI.csproj
@@ -1,9 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <UsingTask AssemblyFile="$(SolutionDir)\References\Memoria.MSBuild.dll" TaskName="Memoria.MSBuild.Deploy" />
-
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -12,14 +10,14 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UnityEngine.UI</RootNamespace>
     <AssemblyName>UnityEngine.UI</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProductVersion>10.0.0</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <FrameworkPathOverride>$(SolutionDir)\References\</FrameworkPathOverride>
     <LangVersion>latest</LangVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
-  
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
@@ -28,6 +26,7 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,9 +35,10 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-	<Reference Include="mscorlib">
+    <Reference Include="mscorlib">
       <HintPath>..\References\mscorlib.dll</HintPath>
       <Private>False</Private>
     </Reference>
@@ -302,9 +302,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
   </PropertyGroup>
-
   <Target Name="AfterBuild">
-	<Deploy SolutionDir="$(SolutionDir)" TargetPath="$(TargetPath)" TargetDir="$(TargetDir)" TargetName="$(TargetName)" />
+    <Deploy SolutionDir="$(SolutionDir)" TargetPath="$(TargetPath)" TargetDir="$(TargetDir)" TargetName="$(TargetName)" />
   </Target>
-  
 </Project>


### PR DESCRIPTION
In this PR I would like to open a possibility to start including unit tests into project. This PR contains:
- xUnit project which is the base of test suite. `ff9ItemHelpersTests` class which has test methods.
- `ff9ItemHelpers` class contains pure method `GetPtr`. This class enables method to be tested.

Reason why I had to move method `GetPtr` outside of `ff9Item` is because, I'm having hard time instantizing `ff9Item` due it's dependency on Unity and file system.

This setup will encourage to write more tests in the future with close to minimal drawbacks. If this PR gets accepted then, I will start working on covering more code base with testes without affecting API. 