### PR TITLE
Add new feature : Trance for monsters !

### DIFF
--- a/Assembly-CSharp/FF9/btl_mot.cs
+++ b/Assembly-CSharp/FF9/btl_mot.cs
@@ -5,9 +5,8 @@ using Memoria;
 using Memoria.Data;
 using Memoria.Assets;
 using Memoria.Prime;
-using Memoria.Prime.CSV;
-using Memoria.Prime.Collections;
 using UnityEngine;
+using NCalc;
 
 namespace FF9
 {
@@ -358,7 +357,30 @@ namespace FF9
 								if (btl_util.CheckEnemyCategory(btl, 8) && ff.dragon_no < 9999)
 									ff.dragon_no++;
 								if (ff.btl_result != 4)
-									btl_sys.SetBonus(enemyPtr.et);
+								{
+                                    if (Configuration.TranceMonster.OverTrance && btl.tranceglowenabled)
+                                    {
+                                        if (Configuration.TranceMonster.BonusOverTranceEXP.Length > 0)
+                                        {
+                                            Expression e = new Expression(Configuration.TranceMonster.BonusOverTranceEXP);
+                                            e.EvaluateFunction += NCalcUtility.commonNCalcFunctions;
+                                            e.Parameters["EXP"] = enemyPtr.et.bonus.exp;
+                                            Int64 val = NCalcUtility.ConvertNCalcResult(e.Evaluate(), -1);
+                                            if (val >= 0)
+                                                enemyPtr.et.bonus.exp = (uint)val;
+                                        }
+                                        if (Configuration.TranceMonster.BonusOverTranceGils.Length > 0)
+                                        {
+                                            Expression e = new Expression(Configuration.TranceMonster.BonusOverTranceGils);
+                                            e.EvaluateFunction += NCalcUtility.commonNCalcFunctions;
+                                            e.Parameters["Gils"] = enemyPtr.et.bonus.gil;
+                                            Int64 val = NCalcUtility.ConvertNCalcResult(e.Evaluate(), -1);
+                                            if (val >= 0)
+                                                enemyPtr.et.bonus.gil = (uint)val;
+                                        }
+                                    }
+                                    btl_sys.SetBonus(enemyPtr.et);
+                                }		
 								btl.die_seq++;
 								if (ff9Battle.btl_phase != 5 || (ff9Battle.btl_seq != 3 && ff9Battle.btl_seq != 2))
 									btl_sys.CheckBattlePhase(btl);

--- a/Assembly-CSharp/Global/BONUS.cs
+++ b/Assembly-CSharp/Global/BONUS.cs
@@ -19,4 +19,5 @@ public class BONUS
 	public List<RegularItem> item;
 	public TetraMasterCardId card;
 	public Boolean escape_gil;
+    public Boolean monsterovertrance;
 }

--- a/Assembly-CSharp/Global/BTL_DATA.cs
+++ b/Assembly-CSharp/Global/BTL_DATA.cs
@@ -119,8 +119,10 @@ public partial class BTL_DATA
 	public ItemAttack weapon = null;
 
 	public Byte trance;
+	public Byte[] trancecolor;
+	public Boolean tranceglowenabled;
 
-	public Byte p_up_attr;
+    public Byte p_up_attr;
 
 	public Byte level;
 

--- a/Assembly-CSharp/Global/BTL_SCENE.cs
+++ b/Assembly-CSharp/Global/BTL_SCENE.cs
@@ -1,8 +1,8 @@
 using System;
 using System.IO;
+using System.Linq;
 using Memoria;
 using Memoria.Data;
-using UnityEngine;
 
 public class BTL_SCENE
 {
@@ -119,7 +119,17 @@ public class BTL_SCENE
 				sb2_MON_PARM.Pad0 = binaryReader.ReadByte();
 				sb2_MON_PARM.Pad1 = binaryReader.ReadUInt16();
 				sb2_MON_PARM.Pad2 = binaryReader.ReadUInt16();
-			}
+                sb2_MON_PARM.TranceGlowColor = new byte[] { 255, 96, 96 };
+                if (Configuration.TranceMonster.ColorTranceMonster.Length > 0)
+                {
+					byte[] NewTranceGlowColor = Configuration.TranceMonster.ColorTranceMonster.Split(' ').Select(byte.Parse).ToArray();
+					for (Int32 j = 0; j < NewTranceGlowColor.Length; j++)
+					{
+                        sb2_MON_PARM.TranceGlowColor[j] = NewTranceGlowColor[j];
+                    }
+						
+                }
+            }
 			binaryReader.BaseStream.Seek(8 + 56 * this.header.PatCount + 116 * this.header.TypCount, SeekOrigin.Begin);
 			for (Int32 i = 0; i < this.header.AtkCount; i++)
 			{
@@ -160,7 +170,13 @@ public class BTL_SCENE
 					if (sequenceText != null)
 						aa.Info.VfxAction = new UnifiedBattleSequencer.BattleAction(sequenceText);
 				}
-			}
+                if (!String.IsNullOrEmpty(aa.Info.TranceSequenceFile))
+                {
+                    String TrancesequenceText = AssetManager.LoadString(aa.Info.TranceSequenceFile);
+                    if (TrancesequenceText != null)
+                        aa.Info.VfxTranceAction = new UnifiedBattleSequencer.BattleAction(TrancesequenceText);
+                }
+            }
 		}
 	}
 

--- a/Assembly-CSharp/Global/BattleCommandInfo.cs
+++ b/Assembly-CSharp/Global/BattleCommandInfo.cs
@@ -22,7 +22,11 @@ public class BattleCommandInfo
 	public String SequenceFile;
 	public UnifiedBattleSequencer.BattleAction VfxAction;
 
-	public BattleCommandInfo()
+    [Memoria.PatchableFieldAttribute]
+    public String TranceSequenceFile;
+    public UnifiedBattleSequencer.BattleAction VfxTranceAction;
+
+    public BattleCommandInfo()
 	{
 		Target = 0;
 		DefaultAlly = false;
@@ -33,7 +37,9 @@ public class BattleCommandInfo
 		DefaultOnDead = false;
 		SequenceFile = null;
 		VfxAction = null;
-	}
+        TranceSequenceFile = null;
+        VfxTranceAction = null;
+    }
 
 	public BattleCommandInfo(TargetType target, Boolean defaultAlly, TargetDisplay displayStats, Int16 vfxIndex, Boolean forDead, Boolean defaultCamera, Boolean defaultOnDead)
 	{
@@ -46,5 +52,7 @@ public class BattleCommandInfo
 		DefaultOnDead = defaultOnDead;
 		SequenceFile = null;
 		VfxAction = null;
-	}
+        TranceSequenceFile = null;
+        VfxTranceAction = null;
+    }
 }

--- a/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
+++ b/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
@@ -421,7 +421,7 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
         Int32 battleSpeed = Configuration.Battle.Speed;
 
         BTL_DATA source = btl;
-        Boolean canContinute = false;
+        Boolean canContinue = false;
         Boolean needContinue = battleSpeed == 1 || battleSpeed == 2;
         do
         {
@@ -452,7 +452,7 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
                 if (current.at < maximum.at)
                 {
                     if (btl.bi.player != 0)
-                        canContinute = true;
+                        canContinue = true;
 
                     changed = true;
                     current.at += (Int16)Math.Max(1, current.at_coef * 4 );
@@ -533,7 +533,7 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
                         break;
                 }
             }
-        } while (canContinute && needContinue);
+        } while (canContinue && needContinue);
     }
 
     private void Update()

--- a/Assembly-CSharp/Global/SB2/SB2_MON_PARM.cs
+++ b/Assembly-CSharp/Global/SB2/SB2_MON_PARM.cs
@@ -144,8 +144,10 @@ public class SB2_MON_PARM
 	public UInt16 Pad1;
 
 	public UInt16 Pad2;
+    [Memoria.PatchableFieldAttribute]
+    public Byte[] TranceGlowColor;
 
-	[Memoria.PatchableFieldAttribute]
+    [Memoria.PatchableFieldAttribute]
 	public Boolean OutOfReach;
 
 	[Memoria.PatchableFieldAttribute]

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
@@ -100,7 +100,11 @@ public partial class BattleHUD : UIScene
     public String GetBattleCommandTitle(CMD_DATA pCmd)
     {
         if (pCmd.regist != null && pCmd.regist.bi.player == 0)
-            return pCmd.aa.Name;
+        { // TODO : I will improve that
+            BTL_DATA caster = pCmd.regist;
+            BattleUnit unit = new BattleUnit(caster);
+            return (unit.IsUnderStatus(BattleStatus.Trance) & !String.IsNullOrEmpty(Configuration.TranceMonster.ColorTextTranceCMD)) ? "["+Configuration.TranceMonster.ColorTextTranceCMD+ "][HSHD]" + pCmd.aa.Name + "[383838][HSHD]" : pCmd.aa.Name;
+        }
         if (btl_util.IsCommandMonsterTransform(pCmd))
         {
             AA_DATA aaData = btl_util.GetCommandMonsterAttack(pCmd);

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
@@ -100,10 +100,10 @@ public partial class BattleHUD : UIScene
     public String GetBattleCommandTitle(CMD_DATA pCmd)
     {
         if (pCmd.regist != null && pCmd.regist.bi.player == 0)
-        { // TODO : I will improve that
+        {
             BTL_DATA caster = pCmd.regist;
             BattleUnit unit = new BattleUnit(caster);
-            return (unit.IsUnderStatus(BattleStatus.Trance) & !String.IsNullOrEmpty(Configuration.TranceMonster.ColorTextTranceCMD)) ? "["+Configuration.TranceMonster.ColorTextTranceCMD+ "][HSHD]" + pCmd.aa.Name + "[383838][HSHD]" : pCmd.aa.Name;
+            return (unit.IsUnderStatus(BattleStatus.Trance) & !String.IsNullOrEmpty(Configuration.TranceMonster.ColorTextTranceCMD)) ? "["+Configuration.TranceMonster.ColorTextTranceCMD+"][HSHD]" + pCmd.aa.Name + "[383838][HSHD]" : pCmd.aa.Name;
         }
         if (btl_util.IsCommandMonsterTransform(pCmd))
         {

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
@@ -346,6 +346,8 @@ public partial class BattleHUD : UIScene
             _commandPanel.SetCaptionColor(FF9TextTool.White);
             _isTranceMenu = false;
         }
+        if (Configuration.Mod.TranceSeek) // TRANCE SEEK - Zidane mechanic switch weapon.
+            CharacterCommands.CommandSets[CharacterPresetId.Zidane].Regular2 = btl_util.getSerialNumber(btl) == CharacterSerialNumber.ZIDANE_DAGGER ? BattleCommandId.SecretTrick : (BattleCommandId)1001;
 
         if (btl.Data.is_monster_transform && transform.base_command == command1)
             command1 = transform.new_command;

--- a/Assembly-CSharp/Global/battle/Result/BattleResultUI.cs
+++ b/Assembly-CSharp/Global/battle/Result/BattleResultUI.cs
@@ -547,7 +547,7 @@ public class BattleResultUI : UIScene
 	{
 		this.AnalyzeParty();
 		this.defaultExp = (UInt32)(this.remainPlayerCounter == 0 ? 0u : battle.btl_bonus.exp / this.remainPlayerCounter);
-		this.defaultAp = battle.btl_bonus.ap;
+		this.defaultAp = battle.btl_bonus.monsterovertrance ? (uint)(battle.btl_bonus.ap * Configuration.TranceMonster.BonusOverTranceAP) : battle.btl_bonus.ap;
 		this.defaultGil = battle.btl_bonus.gil;
 		this.defaultCard = QuadMistDatabase.MiniGame_GetAllCardCount() < Configuration.TetraMaster.MaxCardCount ? battle.btl_bonus.card : TetraMasterCardId.NONE;
 	}

--- a/Assembly-CSharp/Global/btl_vfx.cs
+++ b/Assembly-CSharp/Global/btl_vfx.cs
@@ -131,6 +131,12 @@ public static class btl_vfx
         {
             if (cmd.cmd_no != BattleCommandId.MagicCounter)
             {
+                if ((cmd.aa.Info.VfxTranceAction != null) && ((regist.stat.cur & BattleStatus.Trance) != 0) && !String.IsNullOrEmpty(cmd.aa.Info.TranceSequenceFile))
+                {
+                    UnifiedBattleSequencer.BattleAction action = new UnifiedBattleSequencer.BattleAction(cmd.aa.Info.VfxTranceAction);
+                    action.Execute(cmd);
+                    return;
+                }
                 if (cmd.aa.Info.VfxAction == null && !String.IsNullOrEmpty(cmd.aa.Info.SequenceFile))
                 {
                     String sequenceText = AssetManager.LoadString(cmd.aa.Info.SequenceFile);
@@ -199,6 +205,10 @@ public static class btl_vfx
     public static void SetTranceModel(BTL_DATA btl, Boolean isTrance)
     {
         CharacterSerialNumber serialNo = btl_util.getSerialNumber(btl);
+        if (serialNo == CharacterSerialNumber.NONE)
+        {
+            return;
+        }
         if (isTrance)
         {
             btl.battleModelIsRendering = true;

--- a/Assembly-CSharp/Memoria/Battle/Calculator/BattleCaster.cs
+++ b/Assembly-CSharp/Memoria/Battle/Calculator/BattleCaster.cs
@@ -33,7 +33,7 @@ namespace Memoria
         {
             if (IsUnderAnyStatus(BattleStatus.Mini))
                 _context.Attack = 1;
-            else if (IsUnderAnyStatus(BattleStatus.Berserk | BattleStatus.Trance))
+            else if (IsUnderAnyStatus(BattleStatus.Berserk) || (IsUnderAnyStatus(BattleStatus.Trance) && Data.bi.player != 0))
                 _context.Attack = (Int16)(_context.Attack * 3 >> 1);
         }
 

--- a/Assembly-CSharp/Memoria/Battle/Calculator/SBattleCalculator.cs
+++ b/Assembly-CSharp/Memoria/Battle/Calculator/SBattleCalculator.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Reflection;
-using System.Collections.Generic;
 using FF9;
 using Memoria.Data;
 using Memoria.Prime;
@@ -121,7 +120,7 @@ namespace Memoria
                 saFeature.TriggerOnAbility(v, "BattleScriptEnd", true);
             v.ConsumeMpAttack();
             if ((v.Context.Flags & BattleCalcFlags.Guard) != 0)
-                target.fig_info |= Param.FIG_INFO_GUARD;
+            target.fig_info |= Param.FIG_INFO_GUARD;
             else if ((v.Context.Flags & BattleCalcFlags.Miss) != 0)
             {
                 target.fig_info |= Param.FIG_INFO_MISS;
@@ -325,11 +324,8 @@ namespace Memoria
         {
             if (!UIManager.Battle.FF9BMenu_IsEnable())
                 return;
-            if (v.Target.Data.bi.player == 0 || v.Caster.Data.bi.player != 0)
+            if ((v.Caster.Data.bi.player != 0 && v.Target.Data.bi.player != 0) || v.Target.Data.bi.t_gauge == 0 || v.Target.Data.cur.hp <= 0 || btl_stat.CheckStatus(v.Target.Data, BattleStatusConst.CannotTrance))
                 return;
-            if (v.Target.Data.bi.t_gauge == 0 || v.Target.Data.cur.hp <= 0 || btl_stat.CheckStatus(v.Target.Data, BattleStatusConst.CannotTrance)) // TRANCE SEEK - VENOM
-                return;
-
             if (v.Target.Trance + v.Context.TranceIncrease < 0)
             {
                 v.Target.Trance = 0;

--- a/Assembly-CSharp/Memoria/Battle/SFX/BattleActionCode.cs
+++ b/Assembly-CSharp/Memoria/Battle/SFX/BattleActionCode.cs
@@ -72,7 +72,7 @@ public class BattleActionCode
 		{ "ResetCamera", null },
 		{ "PlaySound", new String[]{ "Sound", "SoundType", "Volume", "Pitch", "Panning", "Start" } },
 		{ "StopSound", new String[]{ "Sound", "SoundType" } },
-		{ "EffectPoint", new String[]{ "Char", "Type" } },
+		{ "EffectPoint", new String[]{ "Char", "Type", "EffectGlow" } },
 		{ "Message", new String[]{ "Text", "Title", "Priority" } },
 		{ "SetBackgroundIntensity", new String[]{ "Intensity", "Time", "HoldDuration" } },
 		{ "SetVariable", new String[]{ "Variable", "Value", "Index" } },
@@ -80,7 +80,7 @@ public class BattleActionCode
 		{ "ActivateReflect", null },
 		{ "StartThread", new String[]{ "Condition", "LoopCount", "Target", "TargetLoop", "Chain", "Sync" } },
 		{ "MOVE_WATER", new String[]{ "Char", "Type", "Time" } }
-	};
+    };
 
 	public Boolean TryGetArgSingle(String key, out Single value)
 	{

--- a/Assembly-CSharp/Memoria/Battle/SFX/UnifiedBattleSequencer.cs
+++ b/Assembly-CSharp/Memoria/Battle/SFX/UnifiedBattleSequencer.cs
@@ -918,7 +918,17 @@ public static class UnifiedBattleSequencer
 								c.fig_info = 0;
 								c.fig = c.m_fig = 0;
 							}
-						}
+                            if (code.TryGetArgBoolean("EffectGlow", out tmpBool))
+							{
+                                if (btl.bi.player == 0)
+                                {
+                                    BONUS btlBonus = battle.btl_bonus;
+                                    btlBonus.monsterovertrance = true;
+
+                                }
+                                btl.tranceglowenabled = tmpBool;
+                            }
+                        }
 					}
 					if (tmpStr == "Figure" || tmpStr == "Both")
 					{
@@ -985,7 +995,7 @@ public static class UnifiedBattleSequencer
 						break;
 					ActivateReflect();
 					break;
-				case "RunThread":
+                case "RunThread":
 					if (code.TryGetArgInt32("Thread", out tmpInt) && tmpInt >= 0)
 					{
 						Boolean dontCopyThread;

--- a/Assembly-CSharp/Memoria/Configuration/Access/TranceMonster.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Access/TranceMonster.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+
+namespace Memoria
+{
+    public sealed partial class Configuration
+    {
+        public static class TranceMonster
+        {
+            public static Boolean Enabled => Instance._trancemonster.Enabled;
+            public static Boolean ActiveTranceAllMobs => Instance._trancemonster.ActiveTranceAllMobs;
+            public static String TranceValueInit => Instance._trancemonster.TranceValueInit;
+            public static String TranceIncreaseMonster => Instance._trancemonster.TranceIncreaseMonster;
+            public static String DeltaTranceMonster => Instance._trancemonster.DeltaTranceMonster;
+            public static String BonusDamageTranceMonster => Instance._trancemonster.BonusDamageTranceMonster;
+            public static String ColorTranceMonster => Instance._trancemonster.ColorTranceMonster;
+            public static String ColorTextTranceCMD => Instance._trancemonster.ColorTextTranceCMD;
+            public static Boolean OverTrance => Instance._trancemonster.OverTrance;
+            public static Int32 OverTranceChance => Instance._trancemonster.OverTranceChance;
+            public static String BonusOverTranceEXP => Instance._trancemonster.BonusOverTranceEXP;
+            public static Int32 BonusOverTranceAP => Instance._trancemonster.BonusOverTranceAP;
+            public static String BonusOverTranceGils => Instance._trancemonster.BonusOverTranceGils;
+            public static String TranceMobsExclusion => Instance._trancemonster.TranceMobsExclusion;
+        }
+    }
+}

--- a/Assembly-CSharp/Memoria/Configuration/Memoria.ini
+++ b/Assembly-CSharp/Memoria/Configuration/Memoria.ini
@@ -125,7 +125,7 @@ MagicStoneStockFormula = Min(99, MagicStoneBase + Level * 4 / 10 + (MagicStoneBo
 	; TranceValueInit (default : GetRandom(0, 128)) Trance value for each monster at each battle (you can use expression like GetRandom)
 	; TranceIncreaseMonster (default : GetRandom(0, TargetWill)) Trance gain each time a monster receives damage
 	; DeltaTranceMonster (default : (300 - CasterLevel) / (CasterSpirit * 10)) Loss of trance value every time a monster in Trance performs an action.
-	; BonusDamageTranceMonster (default : (25 * HPDamage) / 100) Bonus damage (Context.Attack) when a monster is under Trance. 
+	; BonusDamageTranceMonster (default : (25 * Attack) / 100) Bonus damage (Context.Attack) when a monster is under Trance. 
 	; ColorTranceMonster (default : 255 96 96) Set RGB value of glow trance for monsters. You can also use the parameter TranceGlowColor in BattlePatch.txt for specific monsters.
 	; ColorTextTranceCMD (default : empty) Changes the colour of the attack name in the dialogue box if a monster is under trance.
 	; OverTrance (default : 0) An enemy will trance randomly in battle instead of using a Trance bar. The Trance will be effective until the end of the fight (inspired from FFX-2 oversoul)
@@ -139,7 +139,7 @@ ActiveTranceAllMobs = 1
 TranceValueInit = GetRandom(0, 128)
 TranceIncreaseMonster = GetRandom(0, TargetWill)
 DeltaTranceMonster = (300 - CasterLevel) / (CasterSpirit * 10)
-BonusDamageTranceMonster = (25 * HPDamage) / 100
+BonusDamageTranceMonster = (25 * Attack) / 100
 ColorTranceMonster = 255 96 96
 ColorTextTranceCMD =
 OverTrance = 0

--- a/Assembly-CSharp/Memoria/Configuration/Memoria.ini
+++ b/Assembly-CSharp/Memoria/Configuration/Memoria.ini
@@ -120,6 +120,35 @@ MagicStatFormula = Min(99, MagicBase + Level * 3 / 10 + (MagicBonus >> 5))
 SpiritStatFormula = Min(50, SpiritBase + Level * 3 / 20 + (SpiritBonus >> 5))
 MagicStoneStockFormula = Min(99, MagicStoneBase + Level * 4 / 10 + (MagicStoneBonus >> 5))
 
+[TranceMonster]
+	; ActiveTranceAllMobs (default : 1) Remove or not BattleStatus_Trance from resistance on every monsters.
+	; TranceValueInit (default : GetRandom(0, 128)) Trance value for each monster at each battle (you can use expression like GetRandom)
+	; TranceIncreaseMonster (default : GetRandom(0, TargetWill)) Trance gain each time a monster receives damage
+	; DeltaTranceMonster (default : (300 - CasterLevel) / (CasterSpirit * 10)) Loss of trance value every time a monster in Trance performs an action.
+	; BonusDamageTranceMonster (default : (25 * HPDamage) / 100) Bonus damage (Context.Attack) when a monster is under Trance. 
+	; ColorTranceMonster (default : 255 96 96) Set RGB value of glow trance for monsters. You can also use the parameter TranceGlowColor in BattlePatch.txt for specific monsters.
+	; ColorTextTranceCMD (default : empty) Changes the colour of the attack name in the dialogue box if a monster is under trance.
+	; OverTrance (default : 0) An enemy will trance randomly in battle instead of using a Trance bar. The Trance will be effective until the end of the fight (inspired from FFX-2 oversoul)
+	; OverTranceChance (default : 8192) Chance for an enemy to Trance when OverTrance is activated (1 chance in [YOUR VALUE])
+	; BonusOverTranceEXP (default : EXP * 2) EXP when you defeated an enemy in OverTrance.
+	; BonusOverTranceAP (default : 2) AP multiplier when you defeated an enemy trigger his OverTrance.
+	; BonusOverTranceGils (default : Gils * 2) Gils when you defeated an enemy in OverTrance.
+	; TranceMobsExclusion (default : EasyKill) Prevent precise mobs to Trance (use EasyKill for all ennemies using BattleStatus_EasyKill or BTL_DATA.dms_geo_id). Exemple with Kuja and Kuja_Trance => 5 566 567
+Enabled = 0
+ActiveTranceAllMobs = 1
+TranceValueInit = GetRandom(0, 128)
+TranceIncreaseMonster = GetRandom(0, TargetWill)
+DeltaTranceMonster = (300 - CasterLevel) / (CasterSpirit * 10)
+BonusDamageTranceMonster = (25 * HPDamage) / 100
+ColorTranceMonster = 255 96 96
+ColorTextTranceCMD =
+OverTrance = 0
+OverTranceChance = 8192
+BonusOverTranceEXP = EXP * 2
+BonusOverTranceAP = 2
+BonusOverTranceGils = Gils * 2
+TranceMobsExclusion = EasyKill
+
 [Icons]
 	; HideCursor (default 0) Hides "I'm here" hand
 	; HideCards (default 0) Hides card speech bubbles

--- a/Assembly-CSharp/Memoria/Configuration/Structure/Configuration.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Structure/Configuration.cs
@@ -19,6 +19,7 @@ namespace Memoria
         private volatile FixesSection _fixes;
         private volatile HacksSection _hacks;
         private volatile BattleSection _battle;
+        private volatile TranceMonsterSection _trancemonster;
         private volatile IconsSection _icons;
         private volatile AudioSection _audio;
         private volatile VoiceActingSection _voiceActing;
@@ -41,6 +42,7 @@ namespace Memoria
             BindingSection(out _fixes, v => _fixes = v);
             BindingSection(out _hacks, v => _hacks = v);
             BindingSection(out _battle, v => _battle = v);
+            BindingSection(out _trancemonster, v => _trancemonster = v);
             BindingSection(out _icons, v => _icons = v);
             BindingSection(out _audio, v => _audio = v);
             BindingSection(out _voiceActing, v => _voiceActing = v);

--- a/Assembly-CSharp/Memoria/Configuration/Structure/TranceMonsterSection.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Structure/TranceMonsterSection.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using Memoria.Prime.Ini;
+
+namespace Memoria
+{
+    public sealed partial class Configuration
+    {
+        private sealed class TranceMonsterSection : IniSection
+        {
+            public readonly IniValue<Boolean> ActiveTranceAllMobs;
+            public readonly IniValue<String> TranceValueInit;
+            public readonly IniValue<String> TranceIncreaseMonster;
+            public readonly IniValue<String> DeltaTranceMonster;
+            public readonly IniValue<String> BonusDamageTranceMonster;
+            public readonly IniValue<String> ColorTranceMonster;
+            public readonly IniValue<String> ColorTextTranceCMD;
+            public readonly IniValue<Boolean> OverTrance;
+            public readonly IniValue<Int32> OverTranceChance;
+            public readonly IniValue<String> BonusOverTranceEXP;
+            public readonly IniValue<Int32> BonusOverTranceAP;
+            public readonly IniValue<String> BonusOverTranceGils;
+            public readonly IniValue<String> TranceMobsExclusion;
+
+            public TranceMonsterSection() : base(nameof(TranceMonsterSection), false)
+            {
+                ActiveTranceAllMobs = BindBoolean(nameof(ActiveTranceAllMobs), true);
+                TranceValueInit = BindString(nameof(TranceValueInit), "");
+                TranceIncreaseMonster = BindString(nameof(TranceIncreaseMonster), "");
+                DeltaTranceMonster = BindString(nameof(DeltaTranceMonster), "");
+                BonusDamageTranceMonster = BindString(nameof(BonusDamageTranceMonster), "");
+                ColorTranceMonster = BindString(nameof(ColorTranceMonster), "");
+                ColorTextTranceCMD = BindString(nameof(ColorTextTranceCMD), "");
+                OverTrance = BindBoolean(nameof(OverTrance), false);
+                OverTranceChance = BindInt32(nameof(OverTranceChance), 1024);
+                BonusOverTranceEXP = BindString(nameof(BonusOverTranceEXP), "");
+                BonusOverTranceAP = BindInt32(nameof(BonusOverTranceAP), 1);
+                BonusOverTranceGils = BindString(nameof(BonusOverTranceGils), "");
+                TranceMobsExclusion = BindString(nameof(TranceMobsExclusion), "5 566 567");
+            }
+        }
+    }
+}

--- a/Memoria.Launcher/Ini/Memoria.ini
+++ b/Memoria.Launcher/Ini/Memoria.ini
@@ -125,7 +125,7 @@ MagicStoneStockFormula = Min(99, MagicStoneBase + Level * 4 / 10 + (MagicStoneBo
 	; TranceValueInit (default : GetRandom(0, 128)) Trance value for each monster at each battle (you can use expression like GetRandom)
 	; TranceIncreaseMonster (default : GetRandom(0, TargetWill)) Trance gain each time a monster receives damage
 	; DeltaTranceMonster (default : (300 - CasterLevel) / (CasterSpirit * 10)) Loss of trance value every time a monster in Trance performs an action.
-	; BonusDamageTranceMonster (default : (25 * HPDamage) / 100) Bonus damage (Context.Attack) when a monster is under Trance. 
+	; BonusDamageTranceMonster (default : (25 * Attack) / 100) Bonus damage (Context.Attack) when a monster is under Trance. 
 	; ColorTranceMonster (default : 255 96 96) Set RGB value of glow trance for monsters. You can also use the parameter TranceGlowColor in BattlePatch.txt for specific monsters.
 	; ColorTextTranceCMD (default : empty) Changes the colour of the attack name in the dialogue box if a monster is under trance.
 	; OverTrance (default : 0) An enemy will trance randomly in battle instead of using a Trance bar. The Trance will be effective until the end of the fight (inspired from FFX-2 oversoul)
@@ -139,7 +139,7 @@ ActiveTranceAllMobs = 1
 TranceValueInit = GetRandom(0, 128)
 TranceIncreaseMonster = GetRandom(0, TargetWill)
 DeltaTranceMonster = (300 - CasterLevel) / (CasterSpirit * 10)
-BonusDamageTranceMonster = (25 * HPDamage) / 100
+BonusDamageTranceMonster = (25 * Attack) / 100
 ColorTranceMonster = 255 96 96
 ColorTextTranceCMD =
 OverTrance = 0

--- a/Memoria.Launcher/Ini/Memoria.ini
+++ b/Memoria.Launcher/Ini/Memoria.ini
@@ -120,6 +120,35 @@ MagicStatFormula = Min(99, MagicBase + Level * 3 / 10 + (MagicBonus >> 5))
 SpiritStatFormula = Min(50, SpiritBase + Level * 3 / 20 + (SpiritBonus >> 5))
 MagicStoneStockFormula = Min(99, MagicStoneBase + Level * 4 / 10 + (MagicStoneBonus >> 5))
 
+[TranceMonster]
+	; ActiveTranceAllMobs (default : 1) Remove or not BattleStatus_Trance from resistance on every monsters.
+	; TranceValueInit (default : GetRandom(0, 128)) Trance value for each monster at each battle (you can use expression like GetRandom)
+	; TranceIncreaseMonster (default : GetRandom(0, TargetWill)) Trance gain each time a monster receives damage
+	; DeltaTranceMonster (default : (300 - CasterLevel) / (CasterSpirit * 10)) Loss of trance value every time a monster in Trance performs an action.
+	; BonusDamageTranceMonster (default : (25 * HPDamage) / 100) Bonus damage (Context.Attack) when a monster is under Trance. 
+	; ColorTranceMonster (default : 255 96 96) Set RGB value of glow trance for monsters. You can also use the parameter TranceGlowColor in BattlePatch.txt for specific monsters.
+	; ColorTextTranceCMD (default : empty) Changes the colour of the attack name in the dialogue box if a monster is under trance.
+	; OverTrance (default : 0) An enemy will trance randomly in battle instead of using a Trance bar. The Trance will be effective until the end of the fight (inspired from FFX-2 oversoul)
+	; OverTranceChance (default : 8192) Chance for an enemy to Trance when OverTrance is activated (1 chance in [YOUR VALUE])
+	; BonusOverTranceEXP (default : EXP * 2) EXP when you defeated an enemy in OverTrance.
+	; BonusOverTranceAP (default : 2) AP multiplier when you defeated an enemy trigger his OverTrance.
+	; BonusOverTranceGils (default : Gils * 2) Gils when you defeated an enemy in OverTrance.
+	; TranceMobsExclusion (default : EasyKill) Prevent precise mobs to Trance (use EasyKill for all ennemies using BattleStatus_EasyKill or BTL_DATA.dms_geo_id). Exemple with Kuja and Kuja_Trance => 5 566 567
+Enabled = 0
+ActiveTranceAllMobs = 1
+TranceValueInit = GetRandom(0, 128)
+TranceIncreaseMonster = GetRandom(0, TargetWill)
+DeltaTranceMonster = (300 - CasterLevel) / (CasterSpirit * 10)
+BonusDamageTranceMonster = (25 * HPDamage) / 100
+ColorTranceMonster = 255 96 96
+ColorTextTranceCMD =
+OverTrance = 0
+OverTranceChance = 8192
+BonusOverTranceEXP = EXP * 2
+BonusOverTranceAP = 2
+BonusOverTranceGils = Gils * 2
+TranceMobsExclusion = EasyKill
+
 [Icons]
 	; HideCursor (default 0) Hides "I'm here" hand
 	; HideCards (default 0) Hides card speech bubbles

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef257/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef257/PlayerSequence.seq
@@ -8,7 +8,7 @@ LoadSFX: SFX=Special_Trance_Activate
 WaitSFXLoaded: SFX=Special_Trance_Activate
 PlaySFX: SFX=Special_Trance_Activate
 Wait: Time=40
-StartThread: Condition=!CheckAnyStatus(CasterCurrentStatus, 1, 2, 256, 4096, 1 << 17, 1 << 25, 1 << 30)
+StartThread: Condition=!CheckAnyStatus(CasterCurrentStatus, BattleStatus_CannotAct) && CasterIsPlayer
 	PlayAnimation: Char=Caster ; Anim=MP_MAGIC
 EndThread
 WaitSFXDone: SFX=Special_Trance_Activate

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef257/Sequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef257/Sequence.seq
@@ -5,15 +5,23 @@ PlaySound: Sound=926
 PlaySound: Sound=927
 PlaySound: Sound=928
 Wait: Time=16
-ShowMesh: Char=Caster ; Enable=False ; IsDisappear=True
+StartThread: CasterIsPlayer
+	ShowMesh: Char=Caster ; Enable=False ; IsDisappear=True
+EndThread
 Wait: Time=19
 PlaySound: Sound=929
 PlaySound: Sound=930
 PlaySound: Sound=931
-ShowMesh: Char=Caster ; Enable=False ; IsDisappear=True
-EffectPoint: Char=AllTargets ; Type=Effect
+StartThread: CasterIsPlayer
+	EffectPoint: Char=AllTargets ; Type=Effect
+EndThread
+StartThread: !CasterIsPlayer
+	EffectPoint: Char=AllTargets ; Type=Effect ; EffectGlow=True
+EndThread
 Wait: Time=1
-ShowMesh: Char=Caster ; Enable=True ; IsDisappear=True
+StartThread: CasterIsPlayer
+	ShowMesh: Char=Caster ; Enable=True ; IsDisappear=True
+EndThread
 Wait: Time=26
 SetBackgroundIntensity: Intensity=1 ; Time=16
 Wait: Time=19

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef489/Sequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef489/Sequence.seq
@@ -4,12 +4,21 @@ PlaySound: Sound=926
 PlaySound: Sound=927
 PlaySound: Sound=928
 Wait: Time=16
-ShowMesh: Char=Caster ; Enable=False ; IsDisappear=True
+StartThread: CasterIsPlayer
+	ShowMesh: Char=Caster ; Enable=False ; IsDisappear=True
+EndThread
 Wait: Time=19
 PlaySound: Sound=935
 PlaySound: Sound=936
 PlaySound: Sound=937
-EffectPoint: Char=AllTargets ; Type=Effect
+StartThread: CasterIsPlayer
+	EffectPoint: Char=AllTargets ; Type=Effect
+EndThread
+StartThread: !CasterIsPlayer
+	EffectPoint: Char=AllTargets ; Type=Effect ; EffectGlow=False
+EndThread
 Wait: Time=1
-ShowMesh: Char=Caster ; Enable=True ; IsDisappear=True
+StartThread: CasterIsPlayer
+	ShowMesh: Char=Caster ; Enable=True ; IsDisappear=True
+EndThread
 Wait: Time=47


### PR DESCRIPTION
Add a new feature in the Memoria.ini to activate trance for monsters. 
This means that monsters can have a Trance mechanic just like characters, or activate the OverTrance system, which is inspired to the Oversoul in FFX-2.
Here are the some explanations about this commit :

**################################  Memoria.ini ################################**

`ActiveTranceAllMobs = 1`
Remove the BattleStatus_Trance for every monstres in the game. If you leave it at 0, you will have to activate them manually via HW or BattlePatch.txt.

`TranceValueInit = GetRandom(0, 128)`
Put the Trance value of the monster (max is 255). Expressions supported.

`TranceIncreaseMonster = GetRandom(0, TargetWill)`
Define the formula for the Trance rise value each time a monster takes damage. Expressions supported.

`DeltaTranceMonster = (300 - CasterLevel) / (CasterSpirit * 10)`
Define the formula for the Trance loss value each time a monster does damage (when he is under Trance ofc). Expressions supported.

`BonusDamageTranceMonster = (25 * HPDamage) / 100`
Add a damage bonus when a monster is under Trance. You can use expressions.

`ColorTranceMonster = 255 96 96`
Choose the colour of the aura when a monster is under Trance (format: R G B)

`ColorTextTranceCMD =`
Changes the colour of the Battle Text if an enemy is in Trance (TODO : needs to be upgraded under certain conditions).

`OverTrance = 0`
Activate or not the OverTrance mode.
If this mode is activated, monsters can no longer have their Trance naturally. Instead, Trance is obtained randomly for a monster in combat.

`OverTranceChance = 8192`
Chance for a monster to get into OverTrance. The chance by default is 1/8192 for each ticks in battle.

```
BonusOverTranceEXP = EXP * 2
BonusOverTranceAP = 2
BonusOverTranceGils = Gils * 2
```
If you defeat a monster that has triggered his OverTrance in battle, you can increase the gain in EXP, AP and Gils.
The AP bonus is just a multiplier and does not support expressions.

`TranceMobsExclusion = EasyKill`
Removes Trance from certain monsters: this does not give them resistance to BattleStatus_Trance, but instead prevents them from activating it naturally or triggering OverTrance.
You can use "EasyKill" to prevent every monsters using BattleStatus_EasyKill in the game or using ID (based on BTL_DATA.dms_geo_id). You can mix both if you want.

**################################  BattlePatch.txt  ################################**
Two news parameters :
`TranceGlowColor:` => Used in `Enemy `tags, you can change the glow color if the monster get into Trance. 
Exemple for a White Trance glow :
```
= Enemy: 0 =
TranceGlowColor: 255 255 255
```

`TranceSequenceFile:` => Used in `Attack` tags, you can precise an another sequence file for an attack when the monster get into Trance.
Exemple with Cannon from Armstrong.
```
= Attack: 0 =
TranceSequenceFile: CustomSequences/TranceMonster/Armstrong/Cannon.seq
```

 **################################  Miscellaneous  ################################**

- [Trance Seek] Remove auto status when a character get into Trance in btl_stat => Move to my AbilityFeatures.txt
- [Trance Seek] Move Zidane condition about his ability, from btl_cmd to Battle.HUD (didn't work in btl_cmd, bad call)
- [Trance Seek] Remove fake Trance from two bosses in btl_stat (no needed anymore with TranceMonster feature)
- Clean up the PlayerSequence.seq file in ef257.
- Fix a tiny tipo in HonoluluBattleMain