### PR TITLE
More NCalc improvements

### DIFF
--- a/Assembly-CSharp/NCalc/NCalcUtility.cs
+++ b/Assembly-CSharp/NCalc/NCalcUtility.cs
@@ -91,7 +91,7 @@ namespace NCalc
             else if (name == "GetPartyMemberLevel" && args.Parameters.Length == 1)
                 args.Result = GameState.PartyLevel((Int32)NCalcUtility.ConvertNCalcResult(args.Parameters[0].Evaluate(), -1));
             else if (name == "GetPartyMemberIndex" && args.Parameters.Length == 1)
-                args.Result = GameState.PartyCharacterId((Int32)NCalcUtility.ConvertNCalcResult(args.Parameters[0].Evaluate(), -1));
+                args.Result = (Int32)GameState.PartyCharacterId((Int32)NCalcUtility.ConvertNCalcResult(args.Parameters[0].Evaluate(), -1));
             else if (name == "IsCharacterInParty" && args.Parameters.Length == 1)
             {
                 CharacterId index = (CharacterId)NCalcUtility.ConvertNCalcResult(args.Parameters[0].Evaluate(), Byte.MaxValue);

--- a/Assembly-CSharp/NCalc/NCalcUtility.cs
+++ b/Assembly-CSharp/NCalc/NCalcUtility.cs
@@ -92,6 +92,22 @@ namespace NCalc
                 args.Result = GameState.PartyLevel((Int32)NCalcUtility.ConvertNCalcResult(args.Parameters[0].Evaluate(), -1));
             else if (name == "GetPartyMemberIndex" && args.Parameters.Length == 1)
                 args.Result = GameState.PartyCharacterId((Int32)NCalcUtility.ConvertNCalcResult(args.Parameters[0].Evaluate(), -1));
+            else if (name == "IsCharacterInParty" && args.Parameters.Length == 1)
+            {
+                CharacterId index = (CharacterId)NCalcUtility.ConvertNCalcResult(args.Parameters[0].Evaluate(), Byte.MaxValue);
+                args.Result = 0;
+                if (index != CharacterId.NONE)
+                {
+                    for (int i = 0; i < 4; i++)
+                    {
+                        if (FF9StateSystem.Common.FF9.party.GetCharacterId(i) == index)
+                        {
+                            args.Result = 1;
+                            break;
+                        }
+                    }
+                }
+            }
             else if (name == "GetCategoryKillCount" && args.Parameters.Length == 1)
             {
                 Int32 index = (Int32)NCalcUtility.ConvertNCalcResult(args.Parameters[0].Evaluate(), -1);

--- a/Assembly-CSharp/NCalc/NCalcUtility.cs
+++ b/Assembly-CSharp/NCalc/NCalcUtility.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Linq;
 using FF9;
 using Memoria;
 using Memoria.Data;
@@ -95,18 +96,7 @@ namespace NCalc
             else if (name == "IsCharacterInParty" && args.Parameters.Length == 1)
             {
                 CharacterId index = (CharacterId)NCalcUtility.ConvertNCalcResult(args.Parameters[0].Evaluate(), Byte.MaxValue);
-                args.Result = 0;
-                if (index != CharacterId.NONE)
-                {
-                    for (int i = 0; i < 4; i++)
-                    {
-                        if (FF9StateSystem.Common.FF9.party.GetCharacterId(i) == index)
-                        {
-                            args.Result = 1;
-                            break;
-                        }
-                    }
-                }
+                args.Result = index != CharacterId.NONE && FF9StateSystem.Common.FF9.party.member.Any(p => p.Index == index);
             }
             else if (name == "GetCategoryKillCount" && args.Parameters.Length == 1)
             {


### PR DESCRIPTION
### Added missing cast in 'GetPartyMemberIndex' NCalc function

Fixes a bug where NCalc would throw an exception when using GetPartyMemberIndex.

### Add 'IsCharacterInParty' function to NCalc

While it is possible get that information by checking every spots individually with GetPartyMemberIndex, it is highly inconvenient.

Specifying multiple characters in the battle voice system is possible (ie. >Act Zidane Vivi). But this also ensures every characters is able to talk, which is not always desired (ie. I don't care if Vivi can talk, I just want to check if he is in the party). Besides it's not possible to exclude a character with this method.