### PR TITLE
Added 'StealableItemCount' to NCalc

### DIFF
--- a/Assembly-CSharp/NCalc/NCalcUtility.cs
+++ b/Assembly-CSharp/NCalc/NCalcUtility.cs
@@ -375,6 +375,7 @@ namespace NCalc
             expr.Parameters[prefix + "BonusExp"] = (Int32)(unit.IsPlayer ? 0 : enemy.bonus_exp);
             expr.Parameters[prefix + "BonusGil"] = (Int32)(unit.IsPlayer ? 0 : enemy.bonus_gil);
             expr.Parameters[prefix + "BonusCard"] = (Int32)(unit.IsPlayer ? 0 : enemy.bonus_card);
+            expr.Parameters[prefix + "StealableItemCount"] = unit.IsPlayer ? 0 : enemy.steal_item.Count(p => p != RegularItem.NoItem);
             expr.EvaluateFunction += delegate (String name, FunctionArgs args)
             {
                 if (name == prefix + "HasSA" && args.Parameters.Length == 1)
@@ -459,6 +460,7 @@ namespace NCalc
             expr.Parameters[prefix + "BonusExp"] = 0;
             expr.Parameters[prefix + "BonusGil"] = 0;
             expr.Parameters[prefix + "BonusCard"] = (Int32)TetraMasterCardId.NONE;
+            expr.Parameters[prefix + "StealableItemCount"] = 0;
             expr.EvaluateFunction += delegate (String name, FunctionArgs args)
             {
                 if (name == prefix + "HasSA" && args.Parameters.Length == 1)
@@ -497,7 +499,6 @@ namespace NCalc
             expr.Parameters["DamageModifierCount"] = (Int32)context.DamageModifierCount;
             expr.Parameters["TranceIncrease"] = (Int32)context.TranceIncrease;
             expr.Parameters["ItemSteal"] = (Int32)context.ItemSteal;
-            expr.Parameters["StealableItemCount"] = target.IsPlayer ? 0 : target.Enemy.StealableItems.Count(p => p != RegularItem.NoItem);
             expr.Parameters["IsDrain"] = context.IsDrain;
             InitializeExpressionCommand(ref expr, calc.Command);
         }

--- a/Assembly-CSharp/NCalc/NCalcUtility.cs
+++ b/Assembly-CSharp/NCalc/NCalcUtility.cs
@@ -497,6 +497,7 @@ namespace NCalc
             expr.Parameters["DamageModifierCount"] = (Int32)context.DamageModifierCount;
             expr.Parameters["TranceIncrease"] = (Int32)context.TranceIncrease;
             expr.Parameters["ItemSteal"] = (Int32)context.ItemSteal;
+            expr.Parameters["StealableItemCount"] = target.IsPlayer ? 0 : target.Enemy.StealableItems.Count(p => p != RegularItem.NoItem);
             expr.Parameters["IsDrain"] = context.IsDrain;
             InitializeExpressionCommand(ref expr, calc.Command);
         }


### PR DESCRIPTION
I initially added it to 'InitializeExpressionAbilityContext' but moved it to 'InitializeExpressionUnit' to also make it available in BattleInOut. This allows Zidane to say "This guy looks loaded" at the start of a battle for example.