### PR TITLE
Fix for difficult to load project

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Assembly-CSharp</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile>Unity Full v3.5</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <FrameworkPathOverride>$(SolutionDir)\References\</FrameworkPathOverride>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/Memoria.Prime/Memoria.Prime.csproj
+++ b/Memoria.Prime/Memoria.Prime.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Memoria.Prime</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile>Unity Full v3.5</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <FrameworkPathOverride>$(SolutionDir)\References\</FrameworkPathOverride>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/Memoria.Scripts/Memoria.Scripts.csproj
+++ b/Memoria.Scripts/Memoria.Scripts.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Memoria.Scripts</AssemblyName>
 	<TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile>Unity Full v3.5</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <FrameworkPathOverride>$(SolutionDir)\References\</FrameworkPathOverride>
     <AllowedReferenceRelatedFileExtensions>.pdb</AllowedReferenceRelatedFileExtensions>
     <LangVersion>latest</LangVersion>

--- a/Memoria.XInputDotNetPure/Memoria.XInputDotNetPure.csproj
+++ b/Memoria.XInputDotNetPure/Memoria.XInputDotNetPure.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>XInputDotNetPure</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile>Unity Full v3.5</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Changed 4 csproj files TargetFrameworkProfile from "Unity Full v3.5", which is impossible to fetch anymore, to a default "Client". This should make the repo easier to install.