### PR TITLE
Sound importer / AKB Generator updates, more SDLib methods exposed 

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -15,6 +15,8 @@
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <FrameworkPathOverride>$(SolutionDir)\References\</FrameworkPathOverride>
     <LangVersion>latest</LangVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -1369,10 +1371,18 @@
     <None Include="Memoria\Characters\AnimationList.csv" />
     <EmbeddedResource Include="Memoria\Configuration\Memoria.ini" />
     <None Include="NCalc\Grammar\NCalc.g" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
     <Deploy SolutionDir="$(SolutionDir)" TargetPath="$(TargetPath)" TargetDir="$(TargetDir)" TargetName="$(TargetName)" />
+  </Target>
+  <Import Project="..\packages\VideoLAN.LibVLC.Windows.3.0.20\build\VideoLAN.LibVLC.Windows.targets" Condition="Exists('..\packages\VideoLAN.LibVLC.Windows.3.0.20\build\VideoLAN.LibVLC.Windows.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\VideoLAN.LibVLC.Windows.3.0.20\build\VideoLAN.LibVLC.Windows.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\VideoLAN.LibVLC.Windows.3.0.20\build\VideoLAN.LibVLC.Windows.targets'))" />
   </Target>
 </Project>

--- a/Assembly-CSharp/Global/ISd/ISdLibAPI.cs
+++ b/Assembly-CSharp/Global/ISd/ISdLibAPI.cs
@@ -73,6 +73,12 @@ public class ISdLibAPI
         return false;
     }
 
+	public virtual Int32 SdSoundSystem_Akb_GetSoundPlayTime(IntPtr akb, Int32 offset)// is this an offset?
+    {
+        SoundLib.Log("No Implementation");
+        return 0;
+    }
+
 
     public virtual Int32 SdSoundSystem_SoundCtrl_GetElapsedPlaybackTime(Int32 soundID)
 	{

--- a/Assembly-CSharp/Global/ISd/ISdLibAPI.cs
+++ b/Assembly-CSharp/Global/ISd/ISdLibAPI.cs
@@ -25,7 +25,25 @@ public class ISdLibAPI
 		return 0;
 	}
 
-	public virtual Int32 SdSoundSystem_AddData(IntPtr akb)
+	public virtual Int32 SdSoundSystem_GetSoundsCount()
+    {
+        SoundLib.Log("No Implementation");
+        return 0;
+    }
+
+    public virtual Int32 SdSoundSystem_GetSoundsLimit()
+    {
+        SoundLib.Log("No Implementation");
+        return 0;
+    }
+
+    public virtual Int32 SdSoundSystem_Akb_GetNumSounds(IntPtr akb)
+    {
+        SoundLib.Log("No Implementation");
+        return 0;
+    }
+
+    public virtual Int32 SdSoundSystem_AddData(IntPtr akb)
 	{
 		SoundLib.Log("No Implementation");
 		return 0;

--- a/Assembly-CSharp/Global/ISd/ISdLibAPI.cs
+++ b/Assembly-CSharp/Global/ISd/ISdLibAPI.cs
@@ -67,7 +67,14 @@ public class ISdLibAPI
 		return 0;
 	}
 
-	public virtual Int32 SdSoundSystem_SoundCtrl_GetElapsedPlaybackTime(Int32 soundID)
+	public virtual bool SdSoundSystem_SoundCtrl_IsLoop(Int32 SoundID)
+	{
+        SoundLib.Log("No Implementation");
+        return false;
+    }
+
+
+    public virtual Int32 SdSoundSystem_SoundCtrl_GetElapsedPlaybackTime(Int32 soundID)
 	{
 		SoundLib.Log("No Implementation");
 		return 0;

--- a/Assembly-CSharp/Global/Sd/SdLibAPIWithProLicense.cs
+++ b/Assembly-CSharp/Global/Sd/SdLibAPIWithProLicense.cs
@@ -9,6 +9,15 @@ public class SdLibAPIWithProLicense : ISdLibAPI
 	[DllImport("SdLib", CharSet = CharSet.Ansi, EntryPoint = "SdSoundSystem_SoundCtrl_GetPlayTime")]
 	private static extern Int32 DLLSdSoundSystem_SoundCtrl_GetPlayTime(Int32 soundID);
 
+    [DllImport("SdLib", CharSet = CharSet.Ansi, EntryPoint = "SdSoundSystem_Akb_GetNumSounds")]
+    private static extern Int32 DLLSdSoundSystem_Akb_GetNumSounds(IntPtr akb);
+
+    [DllImport("SdLib", CharSet = CharSet.Ansi, EntryPoint = "SdSoundSystem_GetSoundsCount")]
+    private static extern Int32 DLLSdSoundSystem_GetSoundsCount();
+
+    [DllImport("SdLib", CharSet = CharSet.Ansi, EntryPoint = "SdSoundSystem_GetSoundsLimit")]
+    private static extern Int32 DLLSdSoundSystem_GetSoundsLimit();
+
     public override Int32 SdSoundSystem_SoundCtrl_GetElapsedPlaybackTime(Int32 soundID)
     {
 		// The duration during which the sound has played; it turns back to 0 when the sound stops
@@ -46,7 +55,21 @@ public class SdLibAPIWithProLicense : ISdLibAPI
 		return SdLibAPI.SdSoundSystem_AddData(akb);
 	}
 
-	public override Int32 SdSoundSystem_AddStreamDataFromPath(String akbpath)
+    public override Int32 SdSoundSystem_GetSoundsCount()
+    {
+        return DLLSdSoundSystem_GetSoundsCount();
+    }
+
+    public override Int32 SdSoundSystem_GetSoundsLimit()
+    {
+		return DLLSdSoundSystem_GetSoundsLimit();
+    }
+
+    public override Int32 SdSoundSystem_Akb_GetNumSounds(IntPtr akb)
+    {
+		return DLLSdSoundSystem_Akb_GetNumSounds(akb);
+    }
+    public override Int32 SdSoundSystem_AddStreamDataFromPath(String akbpath)
 	{
 		return SdLibAPI.SdSoundSystem_AddStreamDataFromPath(akbpath);
 	}

--- a/Assembly-CSharp/Global/Sd/SdLibAPIWithProLicense.cs
+++ b/Assembly-CSharp/Global/Sd/SdLibAPIWithProLicense.cs
@@ -18,6 +18,9 @@ public class SdLibAPIWithProLicense : ISdLibAPI
     [DllImport("SdLib", CharSet = CharSet.Ansi, EntryPoint = "SdSoundSystem_GetSoundsLimit")]
     private static extern Int32 DLLSdSoundSystem_GetSoundsLimit();
 
+	[DllImport("SdLib", CharSet = CharSet.Ansi, EntryPoint = "SdSoundSystem_SoundCtrl_IsLoop")]
+    private static extern bool DLLSdSoundSystem_SoundCtrl_IsLoop();
+
     public override Int32 SdSoundSystem_SoundCtrl_GetElapsedPlaybackTime(Int32 soundID)
     {
 		// The duration during which the sound has played; it turns back to 0 when the sound stops
@@ -84,7 +87,14 @@ public class SdLibAPIWithProLicense : ISdLibAPI
 		return SdLibAPI.SdSoundSystem_CreateSound(bankID, 0);
 	}
 
-	public override Int32 SdSoundSystem_SoundCtrl_Start(Int32 soundID, Int32 offsetTimeMSec)
+	public override bool SdSoundSystem_SoundCtrl_IsLoop(Int32 SoundID)
+	{
+		return DLLSdSoundSystem_SoundCtrl_IsLoop(SoundID);
+
+    }
+
+
+    public override Int32 SdSoundSystem_SoundCtrl_Start(Int32 soundID, Int32 offsetTimeMSec)
 	{
 		return SdLibAPI.SdSoundSystem_SoundCtrl_Start(soundID, offsetTimeMSec);
 	}

--- a/Assembly-CSharp/Global/Sd/SdLibAPIWithProLicense.cs
+++ b/Assembly-CSharp/Global/Sd/SdLibAPIWithProLicense.cs
@@ -19,7 +19,7 @@ public class SdLibAPIWithProLicense : ISdLibAPI
     private static extern Int32 DLLSdSoundSystem_GetSoundsLimit();
 
 	[DllImport("SdLib", CharSet = CharSet.Ansi, EntryPoint = "SdSoundSystem_SoundCtrl_IsLoop")]
-    private static extern bool DLLSdSoundSystem_SoundCtrl_IsLoop();
+    private static extern bool DLLSdSoundSystem_SoundCtrl_IsLoop(Int32 SoundID);
 
     public override Int32 SdSoundSystem_SoundCtrl_GetElapsedPlaybackTime(Int32 soundID)
     {

--- a/Assembly-CSharp/Global/Sd/SdLibAPIWithProLicense.cs
+++ b/Assembly-CSharp/Global/Sd/SdLibAPIWithProLicense.cs
@@ -21,19 +21,24 @@ public class SdLibAPIWithProLicense : ISdLibAPI
 	[DllImport("SdLib", CharSet = CharSet.Ansi, EntryPoint = "SdSoundSystem_SoundCtrl_IsLoop")]
     private static extern bool DLLSdSoundSystem_SoundCtrl_IsLoop(Int32 SoundID);
 
-    public override Int32 SdSoundSystem_SoundCtrl_GetElapsedPlaybackTime(Int32 soundID)
-    {
-		// The duration during which the sound has played; it turns back to 0 when the sound stops
-		return DLLSdSoundSystem_SoundCtrl_GetElapsedPlaybackTime(soundID);
-	}
+    [DllImport("SdLib", CharSet = CharSet.Ansi, EntryPoint = "SdSoundSystem_Akb_GetSoundPlayTime")]
+	private static extern Int32 DLLSdSoundSystem_Akb_GetSoundPlayTime(IntPtr akb, Int32 offset);
 
-	public override Int32 SdSoundSystem_SoundCtrl_GetPlayTime(Int32 soundID)
-	{
-		// Some loop duration (either the time at which the sound loops or the loop duration); 0 if it doesn't loop
-		return DLLSdSoundSystem_SoundCtrl_GetPlayTime(soundID);
-	}
+	public override Int32 SdSoundSystem_Akb_GetSoundPlayTime(IntPtr akb, Int32 offset) => DLLSdSoundSystem_Akb_GetSoundPlayTime(akb, offset);
 
-	public override Int32 SdSoundSystem_Create(String config)
+    public override Int32 SdSoundSystem_SoundCtrl_GetElapsedPlaybackTime(Int32 soundID) => DLLSdSoundSystem_SoundCtrl_GetElapsedPlaybackTime(soundID);
+
+	public override Int32 SdSoundSystem_SoundCtrl_GetPlayTime(Int32 soundID) => DLLSdSoundSystem_SoundCtrl_GetPlayTime(soundID);
+
+    public override Int32 SdSoundSystem_GetSoundsCount() => DLLSdSoundSystem_GetSoundsCount();
+
+    public override Int32 SdSoundSystem_GetSoundsLimit() => DLLSdSoundSystem_GetSoundsLimit();
+
+    public override Int32 SdSoundSystem_Akb_GetNumSounds(IntPtr akb) => DLLSdSoundSystem_Akb_GetNumSounds(akb);
+
+    public override bool SdSoundSystem_SoundCtrl_IsLoop(Int32 SoundID) => DLLSdSoundSystem_SoundCtrl_IsLoop(SoundID);
+
+    public override Int32 SdSoundSystem_Create(String config)
 	{
 		return SdLibAPI.SdSoundSystem_Create(config);
 	}
@@ -58,20 +63,6 @@ public class SdLibAPIWithProLicense : ISdLibAPI
 		return SdLibAPI.SdSoundSystem_AddData(akb);
 	}
 
-    public override Int32 SdSoundSystem_GetSoundsCount()
-    {
-        return DLLSdSoundSystem_GetSoundsCount();
-    }
-
-    public override Int32 SdSoundSystem_GetSoundsLimit()
-    {
-		return DLLSdSoundSystem_GetSoundsLimit();
-    }
-
-    public override Int32 SdSoundSystem_Akb_GetNumSounds(IntPtr akb)
-    {
-		return DLLSdSoundSystem_Akb_GetNumSounds(akb);
-    }
     public override Int32 SdSoundSystem_AddStreamDataFromPath(String akbpath)
 	{
 		return SdLibAPI.SdSoundSystem_AddStreamDataFromPath(akbpath);
@@ -86,13 +77,6 @@ public class SdLibAPIWithProLicense : ISdLibAPI
 	{
 		return SdLibAPI.SdSoundSystem_CreateSound(bankID, 0);
 	}
-
-	public override bool SdSoundSystem_SoundCtrl_IsLoop(Int32 SoundID)
-	{
-		return DLLSdSoundSystem_SoundCtrl_IsLoop(SoundID);
-
-    }
-
 
     public override Int32 SdSoundSystem_SoundCtrl_Start(Int32 soundID, Int32 offsetTimeMSec)
 	{

--- a/Assembly-CSharp/Global/Sound/Loader/SoundImporter.cs
+++ b/Assembly-CSharp/Global/Sound/Loader/SoundImporter.cs
@@ -193,7 +193,8 @@ namespace Memoria
 
             using (VorbisReader vorbis = new VorbisReader(input, false))
             {
-                //header->SampleCount = checked((UInt32)vorbis.TotalSamples);
+                header->SampleCount = checked((UInt32)vorbis.TotalSamples);
+                header->LengthMS = checked((Double)vorbis.TotalTime.TotalMilliseconds);
                 header->SampleRate = checked((UInt16)vorbis.SampleRate);
 
                 foreach (String comment in vorbis.Comments)

--- a/Assembly-CSharp/Global/Sound/Loader/SoundLoaderResources.cs
+++ b/Assembly-CSharp/Global/Sound/Loader/SoundLoaderResources.cs
@@ -138,7 +138,8 @@ public class SoundLoaderResources : ISoundLoader
 
 		using (VorbisReader vorbis = new VorbisReader(input, false))
 		{
-			//header->SampleCount = checked((UInt32)vorbis.TotalSamples);
+			header->SampleCount = checked((UInt32)vorbis.TotalSamples);
+			header->LengthMS = checked((Double)vorbis.TotalTime.TotalMilliseconds);
 			header->SampleRate = checked((UInt16)vorbis.SampleRate);
 
 			foreach (String comment in vorbis.Comments)

--- a/Assembly-CSharp/Memoria/VoiceActing/VoicePlayer.cs
+++ b/Assembly-CSharp/Memoria/VoiceActing/VoicePlayer.cs
@@ -76,6 +76,7 @@ public class VoicePlayer : SoundPlayer
 			soundProfile.SoundID = 0;
 			return;
 		}
+
 		ISdLibAPIProxy.Instance.SdSoundSystem_SoundCtrl_SetVolume(soundProfile.SoundID, soundProfile.SoundVolume * this.Volume, 0);
 		SoundLib.Log("Panning: " + soundProfile.Panning);
 		ISdLibAPIProxy.Instance.SdSoundSystem_SoundCtrl_SetPanning(soundProfile.SoundID, soundProfile.Panning, 0);

--- a/Memoria.Prime/OggFile/AKB2/AKB2Header.cs
+++ b/Memoria.Prime/OggFile/AKB2/AKB2Header.cs
@@ -5,58 +5,61 @@ namespace Memoria.Prime.AKB2
 {
     public struct AKB2Header
     {
-        public UInt32 Signature;
-        public UInt32 Constant01;
-        public UInt32 FileSize;
-        public UInt32 Constant02;
+        public UInt32 Signature;    //0x0
+        public UInt32 Constant01;   //0x4
+        public UInt32 FileSize;     //0x8
+        public UInt32 Constant02;   //0xc
 
-        public UInt32 Constant03;
-        public UInt32 Constant04;
-        public UInt32 Zero05;
-        public UInt32 Zero06;
 
-        public UInt32 Constant07;
-        public UInt32 Constant08;
-        public UInt32 Unknown09; // looks like a sound ID
-        public UInt32 Constant10;
+        public UInt32 Constant03;   //0x10
+        public UInt32 Constant04;   //0x14
+        public UInt32 Zero05;       //0x18
+        public UInt32 Zero06;       //0x1c
 
-        public UInt32 Constant11;
-        public UInt32 Constant12;
-        public UInt32 Zero13;
-        public UInt32 Constant14;
+        public UInt32 Constant07;   //0x20
+        public UInt32 Constant08;   //0x24
+        public UInt32 Unknown09;    //0x28 // looks like a sound ID
+        public UInt32 Constant10;   //0x2c
 
-        public UInt32 Zero15;
-        public UInt32 Zero16;
-        public UInt32 Zero17;
-        public UInt32 Zero18;
+        public UInt32 Constant11;   //0x30
+        public UInt32 Constant12;   //0x34
+        public UInt32 Zero13;       //0x38
+        public UInt32 Constant14;   //0x3c
 
-        public UInt32 Constant19;
-        public UInt32 Constant20;
-        public UInt32 Zero21;
-        public UInt32 Zero22;
+        public double LengthMS;     //0x40
+        public UInt32 Zero17;       //0x48
+        public UInt32 Zero18;       //0x4c
 
-        public UInt32 Constant23;
-        public UInt32 Zero24;
-        public UInt32 Zero25;
-        public UInt32 Zero26;
+        public UInt32 Constant19;   //0x50
+        public UInt32 Constant20;   //0x54
+        public UInt32 Zero21;       //0x58
+        public UInt32 Zero22;       //0x5c
 
-        public UInt32 Zero27;
-        public UInt32 Zero28;
-        public UInt32 Zero29;
+        public UInt32 Constant23;   //0x60
+        public UInt32 Zero24;       //0x64
+        public UInt32 Zero25;       //0x68
+        public UInt32 Zero26;       //0x6c
 
-        public AKB2UnknownSection Section1;
-        public AKB2UnknownSection Section2;
-        public AKB2UnknownSection Section3;
-        public AKB2UnknownSection Section4;
+        public UInt32 Zero27;        //0x70
+        public UInt32 Zero28;        //0x74
+        public UInt32 Zero29;        //0x78
 
-        public UInt32 Zero31;
-        public UInt16 Constant32;
-        public UInt16 Unknown33;
-        public UInt16 Constant34;
-        public UInt16 SampleRate;
-        public UInt32 ContentSize;
-        public UInt32 SampleCount; // Ignored?
-        public UInt32 LoopStart; // Samples
+        public AKB2UnknownSection Section1;   //0x7c
+        public AKB2UnknownSection Section2;   //0x94
+        public AKB2UnknownSection Section3;   //0xAC
+        public AKB2UnknownSection Section4;   //0xC4
+
+        public UInt32 Zero31;        //0xDC
+
+
+        public UInt16 Constant32;    //0xE0
+        public UInt16 Unknown33;     //0xE2
+        public UInt16 Constant34;    //0xE4
+        public UInt16 SampleRate;    //0xE6
+        public UInt32 ContentSize;   //0xE8
+        public UInt32 SampleCount;   //0xEC   // Ignored?
+
+        public UInt32 LoopStart;     //0xF0   // Samples
         public UInt32 LoopEnd; // Samples
         public UInt16 Constant36;
         public UInt32 LoopStartAlternate; // Samples; used when there are several loop regions (Final Battle)
@@ -72,6 +75,12 @@ namespace Memoria.Prime.AKB2
         public UInt32 Optional46; // Loop?
         public UInt32 Optional47; // Can be zero
         public UInt32 Zero48;
+
+        public UInt32 LengthInSeconds { get
+            {
+                return SampleCount / SampleRate;
+            } 
+        }
 
         public static unsafe void Initialize(AKB2Header* header)
         {

--- a/Memoria.Prime/OggFile/AKB2/AKB2Header.cs
+++ b/Memoria.Prime/OggFile/AKB2/AKB2Header.cs
@@ -26,7 +26,7 @@ namespace Memoria.Prime.AKB2
         public UInt32 Zero13;       //0x38
         public UInt32 Constant14;   //0x3c
 
-        public double LengthMS;     //0x40
+        public Double LengthMS;     //0x40
         public UInt32 Zero17;       //0x48
         public UInt32 Zero18;       //0x4c
 

--- a/Memoria.Prime/OggFile/AKB2/AKB2Header.cs
+++ b/Memoria.Prime/OggFile/AKB2/AKB2Header.cs
@@ -142,8 +142,7 @@ namespace Memoria.Prime.AKB2
                 this.Constant12 = binaryReader.ReadUInt32();
                 this.Zero13 = binaryReader.ReadUInt32();
                 this.Constant14 = binaryReader.ReadUInt32();
-                this.Zero15 = binaryReader.ReadUInt32();
-                this.Zero16 = binaryReader.ReadUInt32();
+                this.LengthMS = binaryReader.ReadDouble();
                 this.Zero17 = binaryReader.ReadUInt32();
                 this.Zero18 = binaryReader.ReadUInt32();
                 this.Constant19 = binaryReader.ReadUInt32();
@@ -228,8 +227,7 @@ namespace Memoria.Prime.AKB2
                 binaryWriter.Write(this.Constant12);
                 binaryWriter.Write(this.Zero13);
                 binaryWriter.Write(this.Constant14);
-                binaryWriter.Write(this.Zero15);
-                binaryWriter.Write(this.Zero16);
+                binaryWriter.Write(this.LengthMS);
                 binaryWriter.Write(this.Zero17);
                 binaryWriter.Write(this.Zero18);
                 binaryWriter.Write(this.Constant19);

--- a/Memoria.Prime/OggFile/AKB2/AKB2UnknownSection.cs
+++ b/Memoria.Prime/OggFile/AKB2/AKB2UnknownSection.cs
@@ -4,12 +4,13 @@ namespace Memoria.Prime.AKB2
 {
     public struct AKB2UnknownSection
     {
-        public UInt32 Constant01;
-        public UInt32 Zero02;
-        public UInt32 Zero03;
-        public UInt32 Zero04;
-        public UInt32 Zero05;
-        public UInt32 Zero06;
+        public UInt32 Constant01; //0x0
+        public UInt32 Zero02;     //0x4
+        public UInt32 Zero03;     //0x8
+        public UInt32 Zero04;     //0xc
+        public UInt32 Zero05;     //0x10
+        public UInt32 Zero06;     //0x14
+                                  //0x18  
 
         public static unsafe void Initialize(AKB2UnknownSection* section)
         {


### PR DESCRIPTION
Added support for AKB files to get there sample rate added to them, also used some of the unused space in AKB Header to put the length of the audio in milliseconds in so it's easier to get at.

These changes will allow us to be able to in Memoria engine sync the playback rate of an FMV with the audio play rate hopefully.