### PR TITLE
Fix for scenes where widescreen shouldn't be active

### DIFF
--- a/Assembly-CSharp/Global/Field/Map/NarrowMapList.cs
+++ b/Assembly-CSharp/Global/Field/Map/NarrowMapList.cs
@@ -2,33 +2,89 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Memoria;
+using Memoria.Prime;
 public static class NarrowMapList
 {
-    public static Boolean IsCurrentMapNarrow() => IsNarrowMap(FF9StateSystem.Common.FF9.fldMapNo, PersistenSingleton<EventEngine>.Instance?.fieldmap?.camIdx ?? -1);
-    public static Boolean IsNarrowMap(Int32 mapId, Int32 camId)
+    public static Boolean IsCurrentMapNarrow(Int32 ScreenWidth) => IsNarrowMap(FF9StateSystem.Common.FF9.fldMapNo, PersistenSingleton<EventEngine>.Instance?.fieldmap?.camIdx ?? -1, ScreenWidth);
+    public static Boolean IsNarrowMap(Int32 mapId, Int32 camId, Int32 ScreenWidth)
     {
-        if (_ScreenIs16to10 && ListWideWhen16to10.Contains(mapId))
-            return false;
-        if (ListFullNarrow.Contains(mapId))
-            return true;
         
-        if (ListPartialNarrow.TryGetValue(mapId, out HashSet<Int32> narrowCams) && narrowCams.Contains(camId))
+        if (SpecificScenesNarrow(mapId))
             return true;
+
+        if (MapWidth(mapId) <= ScreenWidth)
+            return true;
+
+
+        //if (ListFullNarrow.Contains(mapId))
+        //    return true;
+        
+        //if (ListPartialNarrow.TryGetValue(mapId, out HashSet<Int32> narrowCams) && narrowCams.Contains(camId))
+        //    return true;
+        //Log.Message("camId:" + camId + ", mapid:" + mapId);
+
+        return false;
+    }
+    public static Boolean SpecificScenesNarrow(Int32 mapId)
+    {
+        Int32 currIndex = PersistenSingleton<EventEngine>.Instance.eBin.getVarManually(EBin.MAP_INDEX_SVR);
+        foreach (KeyValuePair<int, int> entry in SpecificScenesNarrow_List)
+        {
+            if (mapId == entry.Key && currIndex == entry.Value)
+                return true;
+        }
         return false;
     }
 
-    private static readonly Boolean _ScreenIs16to10 = Configuration.Graphics.ScreenIs16to10();
+    public static readonly Dictionary<int, int> SpecificScenesNarrow_List = new Dictionary<int, int>
+    {
+        // {mapNo,index}
+        {352,3},    // Arrival at Dali: vivi visible before sleeping
+        {1602,16},  // scene at Madain Sari night w/ Vivi/Zidane/Eiko eavesdropping, bugged if you see too much
+        {1823,331}, // Garnet coronation, garnet visible
+        {1815,0},   // Love quiproquo at the docks
+        {1816,315}, // Love quiproquo at the docks
+        {2211,8},   // Lindblum meeting after Alexander scene: ATE with kuja at his ship, Zorn & Thorn visible too soon and blending
+        {2705,-1},  // Pandemonium, you're not alone sequence, several glitches
+        {2706,-1},  // Pandemonium, you're not alone sequence, several glitches
+        {2707,-1},  // Pandemonium, you're not alone sequence, several glitches
+        {2708,-1}   // Pandemonium, you're not alone sequence, several glitches
+    };
 
-    private static readonly Dictionary<Int32, HashSet<Int32>> ListPartialNarrow = new Dictionary<Int32, HashSet<Int32>>()
+    public static Int32 MapWidth(int mapId)
+    {
+        Int32 width = 500;
+
+        if (ListFullNarrow.Contains(mapId) || SpecificScenesNarrow(mapId))
+            width = 320;
+
+        foreach (KeyValuePair<int, int> entry in actualNarrowMapWidthDict)
+        {
+            if (mapId == entry.Key && !SpecificScenesNarrow(entry.Key))
+                width = (Int32)entry.Value;
+        }
+
+        //if (mapId == 153 && PersistenSingleton<EventEngine>.Instance?.fieldmap?.camIdx == 0)
+        //    width = 320;
+        //if (mapId == 154 && PersistenSingleton<EventEngine>.Instance?.fieldmap?.camIdx == 1)
+        //    width = 640;
+
+        //Log.Message("width:" + width + "PersistenSingleton<EventEngine>.Instance?.fieldmap?.camIdx" + PersistenSingleton<EventEngine>.Instance?.fieldmap?.camIdx);
+        return width;
+    }
+
+
+    public static readonly Dictionary<Int32, HashSet<Int32>> ListPartialNarrow = new Dictionary<Int32, HashSet<Int32>>()
     {
         // Not yet implemented
         // For now, using this "per camera" narrow list bugs, surely because of the camera position shift in FieldMap.CenterCameraOnPlayer
         //{ 0154, new HashSet<Int32>() { 0 } }, // A. Castle/Hallway
         //{ 1215, new HashSet<Int32>() { 0 } }, // A. Castle/Hallway
         //{ 1807, new HashSet<Int32>() { 0 } }, // A. Castle/Hallway
+
     };
 
-    private static readonly HashSet<Int32> ListFullNarrow = new HashSet<Int32>()
+    public static readonly HashSet<Int32> ListFullNarrow = new HashSet<Int32>()
     {
         0052, // Prima Vista/Meeting Rm
         0053, // Prima Vista/Meeting Rm
@@ -56,6 +112,7 @@ public static class NarrowMapList
         0150, // A. Castle/Guardhouse
         0151, // A. Castle/Throne
         0153, // A. Castle/Hallway
+        //0154,
         0157, // A. Castle/Kitchen
         0160, // A. Castle/Courtyard
         0161, // A. Castle/Courtyard
@@ -280,7 +337,7 @@ public static class NarrowMapList
         1810,
         1813, // A. Castle/Courtyard
         1814, // A. Castle/Courtyard
-        1816, // A. Castle/Courtyard
+        //1816, // A. Castle/Courtyard
         1817, // A. Castle/Neptune
         1818, // A. Castle/Neptune
         1820, // A. Castle/West Tower
@@ -430,138 +487,214 @@ public static class NarrowMapList
         3056, // Mage Village/Rooftop
         3057,
         3058, // Mage Village/Water Mil
-        3100,
+        3100, // Mog Post
     };
 
-    private static readonly HashSet<Int32> ListWideWhen16to10 = new HashSet<Int32>()
+    public static readonly Dictionary<int, int> mapCameraMargin = new Dictionary<int, int>
     {
-        55,
-        60,
-        102,
-        109,
-        150,
-        157,
-        161,
-        162,
-        201,
-        206,
-        207,
-        251,
-        252,
-        262,
-        405,
-        407,
-        456,
-        505,
-        553,
-        556,
-        561,
-        565,
-        566,
-        568,
-        569,
-        571,
-        613,
-        656,
-        657,
-        658,
-        659,
-        663,
-        705,
-        751,
-        753,
-        755,
-        806,
-        813,
-        851,
-        855,
-        901,
-        911,
-        913,
-        950,
-        1017,
-        1018,
-        1054,
-        1058,
-        1104,
-        1108,
-        1153,
-        1201,
-        1205,
-        1210,
-        1213,
-        1218,
-        1222,
-        1251,
-        1254,
-        1303,
-        1312,
-        1313,
-        1363,
-        1403,
-        1404,
-        1408,
-        1414,
-        1424,
-        1452,
-        1453,
-        1456,
-        1509,
-        1600,
-        1601,
-        1602,
-        1656,
-        1700,
-        1701,
-        1702,
-        1803,
-        1810,
-        1814,
-        1817,
-        1820,
-        1852,
-        1858,
-        1901,
-        1911,
-        1913,
-        1953,
-        2002,
-        2004,
-        2006,
-        2052,
-        2103,
-        2112,
-        2113,
-        2163,
-        2200,
-        2212,
-        2213,
-        2222,
-        2352,
-        2353,
-        2355,
-        2400,
-        2406,
-        2451,
-        2502,
-        2503,
-        2551,
-        2601,
-        2650,
-        2657,
-        2658,
-        2706,
-        2851,
-        2855,
-        2856,
-        2904,
-        2906,
-        2913,
-        2915,
-        2928,
-        3005,
-        3052,
-        3055,
-        3100,
+        //{mapNo,pixels on each side to crop because of scrollable}
+        {1051,8},
+        {1057,16},
+        {1058,16},
+        {1060,16},
+        {1652,16},
+        {1653,16},
+        //{154,16},
+    };
+
+    public static readonly Dictionary<int, int> actualNarrowMapWidthDict = new Dictionary<int, int>
+    {
+        //{mapNo,(actualWidth - 2)}
+        //{153,430},
+        {203,334},
+        {502,334},
+        {503,334},
+        {760,334},
+        {814,334},
+        {816,334},
+        {1151,334},
+        {1458,334},
+        {1500,334},
+        {1506,334},
+        {1605,334},
+        {1606,334},
+        {1608,334},
+        {1660,334},
+        {1661,334},
+        {1662,334},
+        {1705,334},
+        {1707,334},
+        {1751,334},
+        {2202,334},
+        {2204,334},
+        {2205,334},
+        {2208,334},
+        {2254,334},
+        {2257,334},
+        {2303,334},
+        {2365,334},
+        {2513,334},
+        {2756,334},
+        {2932,334},
+        {3057,334},
+        {114,350},
+        {550,350},
+        {620,350},
+        {802,350},
+        {803,350},
+        {1212,350},
+        {1300,350},
+        {1370,350},
+        {1508,350},
+        {1650,350},
+        {1752,350},
+        {1757,350},
+        {1863,350},
+        {1951,350},
+        {1952,350},
+        {2000,350},
+        {2055,350},
+        {2771,350},
+        {2203,350},
+        {2261,350},
+        {2356,350},
+        {2362,350},
+        {2500,350},
+        {2501,350},
+        {2654,350},
+        {60,366},
+        {150,366},
+        {161,366},
+        {201,366},
+        {262,366},
+        {565,366},
+        {911,366},
+        {1213,366},
+        {1222,366},
+        {1251,366},
+        {1254,366},
+        {1312,366},
+        {1403,366},
+        {1803,366},
+        {1814,366},
+        {1817,366},
+        {1911,366},
+        {1953,366},
+        {2002,366},
+        {2004,366},
+        {2006,366},
+        {2112,366},
+        {2400,366},
+        {2502,366},
+        {2503,366},
+        {2650,366},
+        {2904,366},
+        {2913,366},
+        {2928,366},
+        {3100,366},
+        {102,382},
+        {109,382},
+        {162,382},
+        {206,382},
+        {207,382},
+        {251,382},
+        {252,382},
+        {407,382},
+        {553,382},
+        {556,382},
+        {705,382},
+        {751,382},
+        {813,382},
+        {950,382},
+        {1017,382},
+        {1018,382},
+        {1058,380},
+        {1108,380},
+        {1201,382},
+        {1210,382},
+        {1303,382},
+        {1404,382},
+        {1452,382},
+        {1453,382},
+        {1509,382},
+        {1656,382},
+        {1820,382},
+        {1852,382},
+        {1858,382},
+        {2052,382},
+        {2103,382},
+        {2200,382},
+        {2222,382},
+        {2355,382},
+        {2406,382},
+        {2451,382},
+        {2657,382},
+        {2851,382},
+        {2855,382},
+        {2856,382},
+        {2915,382},
+        {3052,382},
+        {55,398},
+        {157,398},
+        {405,398},
+        {456,398},
+        {505,398},
+        {561,398},
+        {566,398},
+        {568,398},
+        {569,398},
+        {571,398},
+        {613,398},
+        {656,398},
+        {657,398},
+        {658,398},
+        {659,398},
+        {663,398},
+        {753,398},
+        {755,398},
+        {806,398},
+        {851,398},
+        {855,398},
+        {901,398},
+        {913,398},
+        {1054,398},
+        {1104,398},
+        {1153,398},
+        {1218,398},
+        {1313,398},
+        {1363,398},
+        {1408,398},
+        {1414,398},
+        {1424,398},
+        {1456,398},
+        {1600,398},
+        {1601,398},
+        {1602,398},
+        {1700,398},
+        {1701,398},
+        {1702,398},
+        {1810,398},
+        {1901,398},
+        {1913,398},
+        {2113,398},
+        {2163,398},
+        {2212,398},
+        {2213,398},
+        {2352,398},
+        {2353,398},
+        {2551,398},
+        {2601,398},
+        {2658,398},
+        {2706,398},
+        {2906,398},
+        {3005,398},
+        {3055,398},
+        {1205,384},
+        //{154,352},
+        {1215,352},
+        {1805,352},
+        {1807,352},
+        {1652,336},
+        {2552,352},
     };
 }

--- a/Assembly-CSharp/Global/Honolulu/HonoluluFieldMain.cs
+++ b/Assembly-CSharp/Global/Honolulu/HonoluluFieldMain.cs
@@ -145,7 +145,7 @@ public class HonoluluFieldMain : HonoBehavior
 			allSoundDispatchPlayer.FF9SOUND_SNDEFFECTRES_RESTORE(0);
 		if (sndEffectResSoundID2 != -1 && sndEffectResSoundID2 == sndEffectResSoundID4)
 			allSoundDispatchPlayer.FF9SOUND_SNDEFFECTRES_RESTORE(1);
-		PlayerWindow.Instance.SetTitle($"Map: {FF9StateSystem.Common.FF9.fldMapNo}, Loc: {FF9StateSystem.Common.FF9.fldLocNo} Name: {FF9StateSystem.Common.FF9.mapNameStr}");
+        PlayerWindow.Instance.SetTitle($"Map: {FF9StateSystem.Common.FF9.fldMapNo} ({FF9StateSystem.Common.FF9.mapNameStr}) | Seq: {PersistenSingleton<EventEngine>.Instance.eBin.getVarManually(EBin.MAP_INDEX_SVR)} | Loc: {FF9StateSystem.Common.FF9.fldLocNo}");
 		FPSManager.DelayMainLoop(Time.realtimeSinceStartup - loadStartTime);
 	}
 


### PR DESCRIPTION
Scenes where WS is now disabled, while staying active the rest of the time:
-Arrival at Dali: vivi visible before sleeping
-scene at Madain Sari night w/ Vivi/Zidane/Eiko eavesdropping, bugged if you see too much -Garnet coronation, garnet visible
-Love quiproquo at the docks
-Lindblum meeting after Alexander scene: ATE with kuja at his ship, Zorn & Thorn visible too soon and blending together
-Pandemonium, you're not alone sequence, several glitches

+ improved parts of the camera / widescreen system.
+ added index# in the title, some debug info in memoria.log