### PR TITLE
In-game option for auto text

### DIFF
--- a/Assembly-CSharp/Global/Config/ConfigUI.cs
+++ b/Assembly-CSharp/Global/Config/ConfigUI.cs
@@ -67,7 +67,8 @@ public class ConfigUI : UIScene
         MusicVolume,
         MovieVolume,
         VoiceVolume,
-        ATBMode
+        ATBMode,
+        AutoText
     }
 
     public enum ATBMode
@@ -1269,6 +1270,9 @@ public class ConfigUI : UIScene
                     int mode = Configuration.Battle.ATBMode >= 3 ? 3 : Configuration.Battle.ATBMode;
                     current.Value = mode / 3f;
                     break;
+                case Configurator.AutoText:
+                    current.Value = Configuration.VoiceActing.AutoDismissDialogAfterCompletion ? 0 : 1;
+                    break;
                 default:
                     current.Value = 0f;
                     break;
@@ -1451,6 +1455,10 @@ public class ConfigUI : UIScene
                         Configuration.Battle.ATBMode = mode >= 3 ? 5 : mode;
                         Configuration.Battle.SaveBattleSpeed();
                         break;
+                    case Configurator.AutoText:
+                        Configuration.VoiceActing.AutoDismissDialogAfterCompletion = configField.Value == 0;
+                        Configuration.VoiceActing.SaveAutoText();
+                        break;
                     default:
                         configField.Value = 0f;
                         break;
@@ -1509,6 +1517,34 @@ public class ConfigUI : UIScene
             }
         }
     }*/
+
+    private GameObject CreateChoice(GameObject template, Configurator id, String choice1, String choice2, int siblingIndex)
+    {
+        try
+        {
+            GameObject go = Instantiate(template);
+            go.transform.parent = template.transform.parent;
+            go.transform.localPosition = template.transform.localPosition;
+            go.transform.localScale = template.transform.localScale;
+            go.transform.SetSiblingIndex(siblingIndex);
+            go.name = $"{id} Panel - Choice";
+            go.GetComponent<ScrollItemKeyNavigation>().ID = (int)id;
+            if (siblingIndex <= fieldMessageConfigIndex)
+                fieldMessageConfigIndex++;
+
+            var locs = go.GetComponentsInChildren<UILocalize>();
+            locs[0].key = id.ToString();
+            if (!String.IsNullOrEmpty(choice1)) locs[1].key = choice1;
+            if (!String.IsNullOrEmpty(choice2)) locs[2].key = choice2;
+
+            return go;
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"[ConfigUI] Couldn't create silder\n{ex.Message}\n{ex.StackTrace}");
+        }
+        return null;
+    }
 
     private GameObject CreateSlider(GameObject template, Configurator id, int siblingIndex)
     {
@@ -1572,15 +1608,20 @@ public class ConfigUI : UIScene
         FadingComponent = ScreenFadeGameObject.GetComponent<HonoFading>();
         ConfigFieldList = new List<ConfigField>();
 
-        // Adding the volume sliders
-        GameObject template = SliderMenuTemplate;
-        CreateVolumeSlider(template, Configurator.SoundVolume, 0);
-        CreateVolumeSlider(template, Configurator.MusicVolume, 1);
-        CreateVolumeSlider(template, Configurator.MovieVolume, 2);
-        if (Configuration.VoiceActing.Enabled)
-            CreateVolumeSlider(template, Configurator.VoiceVolume, 3);
+        // Adding the volume sliders and auto-text
+        GameObject sliderTemplate = SliderMenuTemplate;
+        GameObject choiceTemplate = ConfigList.GetChild(1).GetChild(0).GetChild(0);
 
-        CreateATBModeSlider(template, Configurator.ATBMode, 9);
+        CreateVolumeSlider(sliderTemplate, Configurator.SoundVolume, 0);
+        CreateVolumeSlider(sliderTemplate, Configurator.MusicVolume, 1);
+        CreateVolumeSlider(sliderTemplate, Configurator.MovieVolume, 2);
+        if (Configuration.VoiceActing.Enabled)
+        {
+            CreateVolumeSlider(sliderTemplate, Configurator.VoiceVolume, 3);
+            CreateChoice(choiceTemplate, Configurator.AutoText, null, null, 4);
+        }
+
+        CreateATBModeSlider(sliderTemplate, Configurator.ATBMode, 9);
 
         foreach (Transform trans in ConfigList.GetChild(1).GetChild(0).transform)
         {

--- a/Assembly-CSharp/Memoria/Configuration/Access/VoiceActing.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Access/VoiceActing.cs
@@ -21,9 +21,15 @@ namespace Memoria
             public static void SaveVolume()
             {
                 // We need to make sure VoiceActing is enabled otherwise the volume won't apply
-                // This can happen if a mod enable the VoiceActing
+                // This happens if a mod forces VoiceActing enabled
                 SaveValue(Instance._voiceActing.Name, Instance._voiceActing.Enabled);
                 SaveValue(Instance._voiceActing.Name, Instance._voiceActing.Volume);
+            }
+
+            public static void SaveAutoText()
+            {
+                Instance._voiceActing.AutoDismissDialogAfterCompletion.Value = AutoDismissDialogAfterCompletion;
+                SaveValue(Instance._voiceActing.Name, Instance._voiceActing.AutoDismissDialogAfterCompletion);
             }
         }
     }

--- a/Assembly-CSharp/Memoria/Configuration/Access/VoiceActing.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Access/VoiceActing.cs
@@ -12,17 +12,11 @@ namespace Memoria
             public static Boolean LogVoiceActing => Instance._voiceActing.LogVoiceActing;
             public static Boolean StopVoiceWhenDialogDismissed = Instance._voiceActing.StopVoiceWhenDialogDismissed;
             public static Boolean AutoDismissDialogAfterCompletion = Instance._voiceActing.AutoDismissDialogAfterCompletion;
-            public static Int32 Volume
-            {
-                get => Instance._voiceActing.Volume;
-                set => Instance._voiceActing.Volume.Value = value;
-            }
+            public static Int32 Volume = Instance._voiceActing.Volume.Value;
 
             public static void SaveVolume()
             {
-                // We need to make sure VoiceActing is enabled otherwise the volume won't apply
-                // This happens if a mod forces VoiceActing enabled
-                SaveValue(Instance._voiceActing.Name, Instance._voiceActing.Enabled);
+                Instance._voiceActing.Volume.Value = Volume;
                 SaveValue(Instance._voiceActing.Name, Instance._voiceActing.Volume);
             }
 

--- a/Memoria.Patcher/StreamingAssets/Data/Text/LocalizationPatch.txt
+++ b/Memoria.Patcher/StreamingAssets/Data/Text/LocalizationPatch.txt
@@ -6,3 +6,4 @@ ATBModeNormal,ATB: Normal,ATB: Normal,ATBモード: 通常,ATB: Normal,ATB : Nor
 ATBModeFast,ATB: Fast,ATB: Fast,ATBモード: 高速,ATB: Rápido,ATB : Rapide,ATB: Schneller,ATB: Veloce
 ATBModeTurnBased,ATB: Turn-Based,ATB: Turn-Based,ATBモード: ターン制,ATB: Por Turnos,ATB : Par Tour,ATB: Turn,ATB: A Turni
 ATBModeDynamic,ATB: Dynamic,ATB: Dynamic,ATBモード: 動的,ATB: Dinámico,ATB: Dynamique,ATB: Dynamischer,ATB: Dinamica
+AutoText,Auto Text,Auto Text,自動テキスト,Texto Automático,Texte Automatique,Autotext,Testo Automatico

--- a/Memoria.Prime/Ini/IniReader.cs
+++ b/Memoria.Prime/Ini/IniReader.cs
@@ -134,9 +134,11 @@ namespace Memoria.Prime.Ini
                             vs.Value = ModFolders;
                         }
                     }
+                ResetDisabledSections();
             }
             finally
             {
+                ResetDisabledSections();
                 FlushSection();
                 _sections = null;
                 _values = null;
@@ -271,11 +273,17 @@ namespace Memoria.Prime.Ini
         {
             if (_currentSection != null && _currentSectionBinding != null)
             {
-                if (!_currentSection.Enabled.Value)
-                    _currentSection.Reset();
-
                 _currentSectionBinding.UpdateSection(_currentSection);
                 _sectionsRead[_currentSection.Name] = _currentSection;
+            }
+        }
+
+        private void ResetDisabledSections()
+        {
+            foreach (var section in _sectionsRead.Values)
+            {
+                if (!section.Enabled.Value)
+                    section.Reset();
             }
         }
     }


### PR DESCRIPTION
- Added an in-game option for auto text. Only displayed when voice acting is enabled.
- Fixed a bug where an ini section, disabled in the main ini file but forced enabled by a mod, would be reset to default. Now if a mod enables a section, the values in the main ini are kept (if not overwritten by mod).

![image](https://github.com/Albeoris/Memoria/assets/2388532/2f7d3ecf-8145-451c-9671-5721790e8535)
