### PR TITLE
Added an option to always capture the gamepad

### DIFF
--- a/Assembly-CSharp/Global/Hono/HonoInputManager.cs
+++ b/Assembly-CSharp/Global/Hono/HonoInputManager.cs
@@ -624,6 +624,7 @@ public class HonoInputManager : PersistenSingleton<HonoInputManager>
 
 	public static Boolean ApplicationIsActivated()
 	{
+        if (Configuration.Control.AlwaysCaptureGamepad) return true;
 		IntPtr foregroundWindow = HonoInputManager.GetForegroundWindow();
 		if (foregroundWindow == IntPtr.Zero)
 		{

--- a/Assembly-CSharp/Memoria/Configuration/Access/Control.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Access/Control.cs
@@ -30,6 +30,7 @@ namespace Memoria
             If that is true, it results in characters moving faster on steep slopes for the remaster version, and in characters moving either a bit slower or a bit faster on irregular walkmeshes ("irregular" = triangles are not aligned on the same plane)
             */
             public static Boolean PSXMovementMethod => Instance._control.PSXMovementMethod;
+            public static Boolean AlwaysCaptureGamepad => Instance._control.AlwaysCaptureGamepad;
         }
     }
 }

--- a/Assembly-CSharp/Memoria/Configuration/Memoria.ini
+++ b/Assembly-CSharp/Memoria/Configuration/Memoria.ini
@@ -13,10 +13,12 @@ Size = 24
 
 [Audio]
 	; PriorityToOGG (default 0) When enabled, ".ogg" audio files are used instead of the ".akb.bytes" counterpart when both exist; the AKB header is then generated again at each usage
+	; Backend (default 1) Choose the audio backend. 0 = SdLib, legacy backend (not recommended) / 1 = Soloud, new better sounding backend
 MusicVolume = 100
 SoundVolume = 100
 MovieVolume = 100
 PriorityToOGG = 0
+Backend = 1
 
 [Graphics]
 	; BattleFPS (default 30) Controls the fluidity of battle graphics (frame per second)
@@ -56,12 +58,14 @@ CameraStabilizer = 85
 	; WrapSomeMenus (default 1) 0 = Don't wrap selection in menu that don't natively wrap it / 1 = Wrap selection for easing menu navigation
 	; PSXScrollingMethod (default 1) 0 = Use the native Steam scrolling pattern / 1 = Scroll lists with the same behaviour as the PSX version
 	; PSXMovementMethod (default 0) 0 = Use the native Steam move pathing method, which makes movements faster on sloping paths / 1 = Use the PSX move pathing method
+	; AlwaysCaptureGamepad (default 0) 0 = Gamepad inputs are ignored when the game windows doesn't have focus / 1 = Gamepad inputs are always in effect
 Enabled = 1
 DisableMouse = 0
 DialogProgressButtons = "Confirm"
 WrapSomeMenus = 1
 PSXScrollingMethod = 1
 PSXMovementMethod = 0
+AlwaysCaptureGamepad = 0
 
 [AnalogControl]
 	; StickThreshold (default 10) 0->100, threshold under which there is no movement

--- a/Assembly-CSharp/Memoria/Configuration/Structure/ControlSection.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Structure/ControlSection.cs
@@ -26,6 +26,7 @@ namespace Memoria
             public readonly IniValue<Boolean> WrapSomeMenus;
             public readonly IniValue<Boolean> PSXScrollingMethod;
             public readonly IniValue<Boolean> PSXMovementMethod;
+            public readonly IniValue<Boolean> AlwaysCaptureGamepad;
 
             public ControlSection() : base(nameof(ControlSection), true)
             {
@@ -34,6 +35,7 @@ namespace Memoria
                 WrapSomeMenus = BindBoolean(nameof(WrapSomeMenus), true);
                 PSXScrollingMethod = BindBoolean(nameof(PSXScrollingMethod), true);
                 PSXMovementMethod = BindBoolean(nameof(PSXMovementMethod), false);
+                AlwaysCaptureGamepad = BindBoolean(nameof(AlwaysCaptureGamepad), false);
             }
         }
     }

--- a/Memoria.Launcher/Ini/Memoria.ini
+++ b/Memoria.Launcher/Ini/Memoria.ini
@@ -58,12 +58,14 @@ CameraStabilizer = 85
 	; WrapSomeMenus (default 1) 0 = Don't wrap selection in menu that don't natively wrap it / 1 = Wrap selection for easing menu navigation
 	; PSXScrollingMethod (default 1) 0 = Use the native Steam scrolling pattern / 1 = Scroll lists with the same behaviour as the PSX version
 	; PSXMovementMethod (default 0) 0 = Use the native Steam move pathing method, which makes movements faster on sloping paths / 1 = Use the PSX move pathing method
+	; AlwaysCaptureGamepad (default 0) 0 = Gamepad inputs are ignored when the game windows doesn't have focus / 1 = Gamepad inputs are always in effect
 Enabled = 1
 DisableMouse = 0
 DialogProgressButtons = "Confirm"
 WrapSomeMenus = 1
 PSXScrollingMethod = 1
 PSXMovementMethod = 0
+AlwaysCaptureGamepad = 0
 
 [AnalogControl]
 	; StickThreshold (default 10) 0->100, threshold under which there is no movement


### PR DESCRIPTION
When the game window doesn't have focus, the gamepad inputs are ignored. I added an option to disable that behavior (off by default).

There's been a number of times I wanted to control the game, displayed full screen on my main monitor, while working some stuff on my second monitor. Unfortunately that meant I had to give the game focus every time I wanted to move or do an action.

This only affects gamepads, you wouldn't want to accidentally perform actions in the game while typing in another window.