### PR TITLE
Prefer `Int64` over `long` to avoid errors in unsafe context

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,8 +29,8 @@ dotnet_style_qualification_for_method = false
 dotnet_style_qualification_for_property = false
 
 # Language keywords vs BCL types preferences
-dotnet_style_predefined_type_for_locals_parameters_members = true
-dotnet_style_predefined_type_for_member_access = true
+dotnet_style_predefined_type_for_locals_parameters_members = false # Int32 value = 1;
+dotnet_style_predefined_type_for_member_access = false # Int32.Parse
 
 # Parentheses preferences
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity


### PR DESCRIPTION
Hi guys! I know how much you like to use C# keywords like `long`, `string`, `float` instead of the library types `Int64`, `String` and `Single`, but I suggest returning the style code to its previous form.

The main motivation for using type names is to protect against errors in `unsafe` code. Since the game actively uses binary data to store resources, and unsafe context, it is necessary to very clearly understand the difference between `Int32` and `Int64` and avoid errors associated with porting C++ code, where `long` takes 4 bytes, unlike C#, where it is stored in 8 bytes.

If you really don’t want to see `for (Int32 i = 0; i < count; i++)` you can always use `var`: `for (var i = 0; i < count; i++)`. Otherwise this shouldn't be a problem and will be consistent with the code style in the rest of the codebase.