### PR TITLE
Fixed background music not paused properly

### DIFF
--- a/Assembly-CSharp/Global/AllSoundDispatchPlayer.cs
+++ b/Assembly-CSharp/Global/AllSoundDispatchPlayer.cs
@@ -119,8 +119,7 @@ public class AllSoundDispatchPlayer : SoundPlayer
 					this.CreateSound(soundProfile);
 					soundProfile.SoundVolume = 1f;
 					ISdLibAPIProxy.Instance.SdSoundSystem_SoundCtrl_SetVolume(soundProfile.SoundID, SoundLib.MusicPlayer.Volume, 0);
-					ISdLibAPIProxy.Instance.SdSoundSystem_SoundCtrl_SetPause(soundProfile.SoundID, 1, 0);
-					Int16 fldMapNo = FF9StateSystem.Common.FF9.fldMapNo;
+                    Int16 fldMapNo = FF9StateSystem.Common.FF9.fldMapNo;
 					if (fldMapNo == 503 && PersistenSingleton<EventEngine>.Instance.eBin.getVarManually(EBin.SC_COUNTER_SVR) == 2970 && PersistenSingleton<EventEngine>.Instance.eBin.getVarManually(EBin.MAP_INDEX_SVR) == 11 && ObjNo == 35)
 					{
 						// What is this for ? - SamsamTS
@@ -129,7 +128,8 @@ public class AllSoundDispatchPlayer : SoundPlayer
 						ISdLibAPIProxy.Instance.SdSoundSystem_SoundCtrl_SetVolume(soundProfile.SoundID, 0f, 0);
 					}
 					ISdLibAPIProxy.Instance.SdSoundSystem_SoundCtrl_Start(soundProfile.SoundID, 0);
-					this.currentMusicID = ObjNo;
+                    ISdLibAPIProxy.Instance.SdSoundSystem_SoundCtrl_SetPause(soundProfile.SoundID, 1, 0);
+                    this.currentMusicID = ObjNo;
 					this.StopAndClearSuspendBGM(ObjNo, true);
 				});
 			}

--- a/Assembly-CSharp/Global/Sound/SoLoud/SdLibAPIWithSoloud.cs
+++ b/Assembly-CSharp/Global/Sound/SoLoud/SdLibAPIWithSoloud.cs
@@ -33,6 +33,7 @@ namespace Global.Sound.SoLoud
             }
             public Int32 bankID;
             public Single volume = 1f;
+            public Boolean manuallyPaused = false;
         }
 
         private Dictionary<Int32, StreamInfo> streams = new Dictionary<Int32, StreamInfo>();
@@ -192,7 +193,8 @@ namespace Global.Sound.SoLoud
             {
                 soloud.seek((uint)soundID, offsetTimeMSec / 1000d);
             }
-            soloud.setPause((uint)soundID, 0);
+            if (!sounds[soundID].manuallyPaused) // SdLib doesn't resume paused sounds, we replicate the behavior
+                soloud.setPause((uint)soundID, 0);
 
             return 1;
         }
@@ -217,6 +219,8 @@ namespace Global.Sound.SoLoud
         {
             SoundLib.Log($"SoundCtrl_SetPause({soundID}, {pauseOn}, {transTimeMSec})");
             if (!sounds.ContainsKey(soundID)) return;
+
+            sounds[soundID].manuallyPaused = pauseOn > 0;
 
             uint h = (uint)soundID;
             double t = transTimeMSec / 1000d;


### PR DESCRIPTION
With SdLib calling start on a paused sound doesn't resume the sound, SoLoud does. This would cause some sounds to play prematurely.

An example of this is during the FMV for the start of the play "I Want To Be Your Canary", the song for the stage play starts playing at the beginning of the FMV.