### PR TITLE
Turn based fixes

### DIFF
--- a/Assembly-CSharp/FF9/btl_sys.cs
+++ b/Assembly-CSharp/FF9/btl_sys.cs
@@ -319,7 +319,7 @@ namespace FF9
             }
             else
             {
-                if (calc_check && UIManager.Battle.FF9BMenu_IsEnableAtb())
+                if (calc_check && UIManager.Battle.IsNativeEnableAtb())
                     SBattleCalculator.CalcMain(null, null, null, fleeScriptId);
             }
         }

--- a/Assembly-CSharp/Global/Hono/HonoInputManager.cs
+++ b/Assembly-CSharp/Global/Hono/HonoInputManager.cs
@@ -624,7 +624,6 @@ public class HonoInputManager : PersistenSingleton<HonoInputManager>
 
 	public static Boolean ApplicationIsActivated()
 	{
-        if (Configuration.Control.AlwaysCaptureGamepad) return true;
 		IntPtr foregroundWindow = HonoInputManager.GetForegroundWindow();
 		if (foregroundWindow == IntPtr.Zero)
 		{
@@ -680,16 +679,14 @@ public class HonoInputManager : PersistenSingleton<HonoInputManager>
 	{
 		if (!this.isDisablePrimaryKey)
 		{
-			GamePadState state = global::GamePad.GetState(PlayerIndex.One);
+			GamePadState state = GamePad.GetState(PlayerIndex.One);
 			for (Int32 i = 0; i < (Int32)this.KeyName.Length; i++)
 			{
-				Boolean flag = false;
-				if (HonoInputManager.VKKeyCodeMapping.ContainsKey(this.inputKeysPrimary[i]))
+				if (ApplicationIsActivated() && VKKeyCodeMapping.ContainsKey(this.inputKeysPrimary[i]) && GetAsyncKeyState(VKKeyCodeMapping[this.inputKeysPrimary[i]]) != 0)
 				{
-					flag = (HonoInputManager.GetAsyncKeyState(HonoInputManager.VKKeyCodeMapping[this.inputKeysPrimary[i]]) != 0);
+                    this.isInput[i] = true;
 				}
-				Boolean flag2 = this.CheckRawXInput(this.joystickKeysPrimary[i], state);
-				if (HonoInputManager.ApplicationIsActivated() && (flag || flag2))
+                if((Configuration.Control.AlwaysCaptureGamepad || ApplicationIsActivated()) && this.CheckRawXInput(this.joystickKeysPrimary[i], state))
 				{
 					this.isInput[i] = true;
 				}

--- a/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
+++ b/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
@@ -441,6 +441,7 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
 
         do
         {
+            Boolean stopAtb = !UIManager.Battle.TurnBased_IsEnableAtb();
             HonoluluBattleMain.counterATB++;
             for (btl = source; btl != null; btl = btl.next)
             {
@@ -457,7 +458,7 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
                         canContinue = true;
 
                     changed = true;
-                    if (UIManager.Battle.TurnBased_IsEnableAtb())
+                    if (!stopAtb)
                         current.at += (Int16)Math.Max(1, current.at_coef * 4);
                     else
                         needContinue = false;
@@ -516,7 +517,7 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
                             UIManager.Battle.AddPlayerToReady(playerId);
                     }
                 }
-                else if (!FF9StateSystem.Battle.isDebug)
+                else if (!FF9StateSystem.Battle.isDebug && !stopAtb)
                 {
                     if (PersistenSingleton<EventEngine>.Instance.RequestAction(BattleCommandId.EnemyAtk, btl.btl_id, 0, 0, 0))
                         btl.sel_mode = 1;

--- a/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
+++ b/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
@@ -1,13 +1,13 @@
 ﻿using Assets.Scripts.Common;
 using Assets.Sources.Scripts.UI.Common;
 using FF9;
+using Memoria;
+using Memoria.Data;
+using Memoria.Database;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Memoria;
-using Memoria.Data;
-using Memoria.Database;
 using UnityEngine;
 
 #pragma warning disable 169
@@ -455,7 +455,7 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
                         canContinute = true;
 
                     changed = true;
-                    current.at += (Int16)Math.Max(1, current.at_coef * 4 );
+                    current.at += (Int16)Math.Max(1, current.at_coef * 4);
                 }
 
                 if (needContinue)
@@ -475,6 +475,7 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
                     {
                         if (changed)
                         {
+                            BattleHUD.ForceNextTurn = false;
                             needContinue = false;
                         }
                     }

--- a/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
+++ b/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
@@ -421,7 +421,7 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
         Int32 battleSpeed = Configuration.Battle.Speed;
 
         BTL_DATA source = btl;
-        Boolean canContinute = false;
+        Boolean canContinue = false;
         Boolean needContinue = false;
 
         if (battleSpeed == 1 || battleSpeed == 2)
@@ -467,8 +467,8 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
                 Boolean changed = false;
                 if (current.at < maximum.at)
                 {
-                    if (btl.bi.player != 0)
-                        canContinute = true;
+                    if (btl.bi.player != 0 || (battleSpeed == 2 && BattleHUD.ForceNextTurn))
+                        canContinue = true;
 
                     changed = true;
                     current.at += (Int16)Math.Max(1, current.at_coef * 4);
@@ -492,13 +492,14 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
                         if (changed)
                         {
                             BattleHUD.ForceNextTurn = false;
+                            BattleHUD.switchBtlId = btl.btl_id;
                             needContinue = false;
                         }
                     }
-                    else
+                    else if (!btl_stat.CheckStatus(btl, BattleStatusConst.PreventATBConfirm))
                     {
-                        if (!btl_stat.CheckStatus(btl, BattleStatusConst.PreventATBConfirm))
-                            needContinue = false;
+                        if (changed) BattleHUD.ForceNextTurn = false;
+                        needContinue = false;
                     }
                 }
                 else if (battleSpeed != 1 || !btl_stat.CheckStatus(btl, BattleStatusConst.PreventATBConfirm))
@@ -549,7 +550,7 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
                         break;
                 }
             }
-        } while (canContinute && needContinue);
+        } while (canContinue && needContinue);
     }
 
     private void Update()

--- a/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
+++ b/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
@@ -422,7 +422,23 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
 
         BTL_DATA source = btl;
         Boolean canContinute = false;
-        Boolean needContinue = battleSpeed == 1 || battleSpeed == 2;
+        Boolean needContinue = false;
+
+        if (battleSpeed == 1 || battleSpeed == 2)
+        {
+            // Check if someone has some atb, we don't want to advance atb instantly in some cases
+            // This is necessary for some fights starting with a conversation where atb is forced to 0
+            foreach (BattleUnit unit in FF9StateSystem.Battle.FF9Battle.EnumerateBattleUnits())
+            {
+                if (!unit.IsPlayer) continue;
+                if (unit.CurrentAtb > 0)
+                {
+                    needContinue = true;
+                    break;
+                }
+            }
+        }
+
         do
         {
             HonoluluBattleMain.counterATB++;

--- a/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
+++ b/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
@@ -447,20 +447,6 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
                 if (btl.cur.hp == 0)
                     continue;
 
-                if (btl.sel_mode != 0 || btl.sel_menu != 0 || btl.bi.atb == 0)
-                {
-                    // We need to refresh status for any alive characters in the fast or the turn-based mode
-                    if (needContinue)
-                    {
-                        // ============ Warning ============
-                        btl_para.CheckPointData(btl);
-                        btl_stat.CheckStatusLoop(btl, true);
-                        // =================================
-                    }
-
-                    continue;
-                }
-
                 POINTS current = btl.cur;
                 POINTS maximum = btl.max;
 
@@ -471,15 +457,10 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
                         canContinue = true;
 
                     changed = true;
-                    current.at += (Int16)Math.Max(1, current.at_coef * 4);
-                }
-
-                if (needContinue)
-                {
-                    // ============ Warning ============
-                    btl_para.CheckPointData(btl);
-                    btl_stat.CheckStatusLoop(btl, true);
-                    // =================================
+                    if (UIManager.Battle.TurnBased_IsEnableAtb())
+                        current.at += (Int16)Math.Max(1, current.at_coef * 4);
+                    else
+                        needContinue = false;
                 }
 
                 if (current.at < maximum.at)
@@ -545,9 +526,21 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
                     if (Array.IndexOf(FF9StateSystem.Battle.FF9Battle.seq_work_set.AnmOfsList, this.btlIDList[btl_scrp.FindBattleUnit(btl.btl_id).Data.typeNo]) < 0)
                         Debug.LogError("Index out of range");
 
-                    UnityEngine.Random.Range(0, 4);
+                    UnityEngine.Random.Range(0, 4); // Useless?
                     if (FF9StateSystem.Battle.FF9Battle.btl_phase != 4)
-                        break;
+                    {
+                        return;
+                    }
+                }
+            }
+
+            if (canContinue && needContinue)
+            {
+                // Update statuses before looping
+                for (btl = source; btl != null; btl = btl.next)
+                {
+                    btl_para.CheckPointData(btl);
+                    btl_stat.CheckStatusLoop(btl);
                 }
             }
         } while (canContinue && needContinue);

--- a/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
+++ b/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
@@ -521,7 +521,7 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
                             UIManager.Battle.AddPlayerToReady(playerId);
                     }
                 }
-                else if (!FF9StateSystem.Battle.isDebug && advanceAtb)
+                else if (!FF9StateSystem.Battle.isDebug)
                 {
                     if (PersistenSingleton<EventEngine>.Instance.RequestAction(BattleCommandId.EnemyAtk, btl.btl_id, 0, 0, 0))
                         btl.sel_mode = 1;

--- a/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
+++ b/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
@@ -555,7 +555,7 @@ public class UIKeyTrigger : MonoBehaviour
             }
             if (PersistenSingleton<HonoInputManager>.Instance.IsInputDown(Control.LeftTrigger) || keyCommand == Control.LeftTrigger)
             {
-                if (UIManager.Battle.FF9BMenu_IsEnable() && !BattleHUD.ForceNextTurn && FF9StateSystem.Battle.FF9Battle.cur_cmd == null && FF9StateSystem.Battle.FF9Battle.cmd_queue.next == null)
+                if (UIManager.Battle.CanForceNextTurn)
                 {
                     BattleHUD.ForceNextTurn = true;
                     FF9Sfx.FF9SFX_Play(103);

--- a/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
+++ b/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
@@ -1,14 +1,14 @@
 ﻿using Assets.Scripts.Common;
-using System;
-using System.Linq;
-using System.Collections.Generic;
 using Memoria;
 using Memoria.Data;
 using Memoria.Prime;
 using Memoria.Prime.Text;
 using Memoria.Scenes;
-using Memoria.Test;
 using Memoria.Speedrun;
+using Memoria.Test;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 #pragma warning disable 169
@@ -554,6 +554,10 @@ public class UIKeyTrigger : MonoBehaviour
             }
             if (PersistenSingleton<HonoInputManager>.Instance.IsInputDown(Control.LeftTrigger) || keyCommand == Control.LeftTrigger)
             {
+                if (!PersistenSingleton<UIManager>.Instance.IsPause)
+                {
+                    BattleHUD.ForceNextTurn = true;
+                }
                 keyCommand = Control.None;
                 sceneFromState.OnKeyLeftTrigger(activeButton);
                 return true;

--- a/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
+++ b/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
@@ -1,4 +1,5 @@
 ﻿using Assets.Scripts.Common;
+using FF9;
 using Memoria;
 using Memoria.Data;
 using Memoria.Prime;
@@ -554,7 +555,7 @@ public class UIKeyTrigger : MonoBehaviour
             }
             if (PersistenSingleton<HonoInputManager>.Instance.IsInputDown(Control.LeftTrigger) || keyCommand == Control.LeftTrigger)
             {
-                if (PersistenSingleton<UIManager>.Instance.State == UIManager.UIState.BattleHUD && !BattleHUD.ForceNextTurn && FF9StateSystem.Battle.FF9Battle.cur_cmd == null)
+                if (UIManager.Battle.FF9BMenu_IsEnable() && !BattleHUD.ForceNextTurn && FF9StateSystem.Battle.FF9Battle.cur_cmd == null && FF9StateSystem.Battle.FF9Battle.cmd_queue.next == null)
                 {
                     BattleHUD.ForceNextTurn = true;
                     FF9Sfx.FF9SFX_Play(103);

--- a/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
+++ b/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
@@ -554,9 +554,10 @@ public class UIKeyTrigger : MonoBehaviour
             }
             if (PersistenSingleton<HonoInputManager>.Instance.IsInputDown(Control.LeftTrigger) || keyCommand == Control.LeftTrigger)
             {
-                if (!PersistenSingleton<UIManager>.Instance.IsPause)
+                if (PersistenSingleton<UIManager>.Instance.State == UIManager.UIState.BattleHUD && !BattleHUD.ForceNextTurn && FF9StateSystem.Battle.FF9Battle.cur_cmd == null)
                 {
                     BattleHUD.ForceNextTurn = true;
+                    FF9Sfx.FF9SFX_Play(103);
                 }
                 keyCommand = Control.None;
                 sceneFromState.OnKeyLeftTrigger(activeButton);

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
@@ -654,9 +654,9 @@ public partial class BattleHUD : UIScene
         return _commandEnable;
     }
 
-    public Boolean TurnBased_IsEnableAtb()
+    public Boolean FF9BMenu_IsEnableAtb()
     {
-        if (!FF9BMenu_IsEnableAtb())
+        if (!IsNativeEnableAtb())
             return false;
 
         if (Configuration.Battle.Speed != 2 || FF9StateSystem.Battle.FF9Battle.btl_escape_key != 0)
@@ -673,7 +673,7 @@ public partial class BattleHUD : UIScene
         return !(isMenuing || hasQueue || isEnemyActing);
     }
 
-    public Boolean FF9BMenu_IsEnableAtb()
+    public Boolean IsNativeEnableAtb()
     {
         if (!_commandEnable)
             return false;

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
@@ -27,7 +27,8 @@ public partial class BattleHUD : UIScene
         BattleCommandId.DoubleBlackMagic,
         BattleCommandId.DoubleWhiteMagic
     };
-    public static Boolean ForceNextTurn;
+    public static Boolean ForceNextTurn = false;
+    public static Int32 switchBtlId = -1;
 
     public BattleHUD()
     {

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
@@ -665,24 +665,7 @@ public partial class BattleHUD : UIScene
         Boolean isEnemyActing = FF9StateSystem.Battle.FF9Battle.cur_cmd != null && FF9StateSystem.Battle.FF9Battle.cur_cmd.regist?.bi.player == 0;
         Boolean hasQueue = btl_cmd.GetFirstCommandReadyToDequeue(FF9StateSystem.Battle.FF9Battle) != null;
 
-        if (ForceNextTurn)
-        {
-            // Making sure a player needs an ATB
-            foreach (BattleUnit unit in FF9StateSystem.Battle.FF9Battle.EnumerateBattleUnits())
-            {
-                BTL_DATA btl = unit.Data;
-
-                if (btl.sel_mode != 0 || btl.sel_menu != 0 || unit.CurrentHp == 0 || btl.bi.atb == 0 || !unit.IsPlayer)
-                    continue;
-
-                if (unit.CurrentAtb < unit.MaximumAtb)
-                    return true;
-            }
-
-            // No one needs ATB, we wait for anything else to happen instead
-            if (!hasQueue) return true;
-            ForceNextTurn = false;
-        }
+        if (ForceNextTurn && !hasQueue && !isEnemyActing) return true;
 
         return !(isMenuing || hasQueue || isEnemyActing);
     }

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
@@ -654,9 +654,9 @@ public partial class BattleHUD : UIScene
         return _commandEnable;
     }
 
-    public Boolean FF9BMenu_IsEnableAtb()
+    public Boolean TurnBased_IsEnableAtb()
     {
-        if (!IsNativeEnableAtb())
+        if (!FF9BMenu_IsEnableAtb())
             return false;
 
         if (Configuration.Battle.Speed != 2 || FF9StateSystem.Battle.FF9Battle.btl_escape_key != 0)
@@ -667,12 +667,13 @@ public partial class BattleHUD : UIScene
         Boolean isEnemyActing = FF9StateSystem.Battle.FF9Battle.cur_cmd != null && FF9StateSystem.Battle.FF9Battle.cur_cmd.regist?.bi.player == 0;
         Boolean hasQueue = btl_cmd.GetFirstCommandReadyToDequeue(FF9StateSystem.Battle.FF9Battle) != null;
 
-        if (ForceNextTurn && !hasQueue && !isEnemyActing) return true;
+        if (ForceNextTurn && !hasQueue && !isEnemyActing)
+            return true;
 
         return !(isMenuing || hasQueue || isEnemyActing);
     }
 
-    internal Boolean IsNativeEnableAtb()
+    public Boolean FF9BMenu_IsEnableAtb()
     {
         if (!_commandEnable)
             return false;

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
@@ -20,6 +20,8 @@ public partial class BattleHUD : UIScene
     public GameObject PlayerTargetPanel => TargetPanel.GetChild(0);
     public GameObject EnemyTargetPanel => TargetPanel.GetChild(1);
     public Boolean IsDoubleCast => DoubleCastSet.Contains(_currentCommandId);
+    public Boolean CanForceNextTurn => Configuration.Battle.Speed == 2 && UIManager.Battle.FF9BMenu_IsEnable() && !ForceNextTurn
+        && ReadyQueue.Count > 0 && FF9StateSystem.Battle.FF9Battle.cur_cmd == null && btl_cmd.GetFirstCommandReadyToDequeue(FF9StateSystem.Battle.FF9Battle) == null;
     public List<Int32> ReadyQueue { get; }
     public List<Int32> InputFinishList { get; }
     public Int32 CurrentPlayerIndex { get; private set; }

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Scene.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Scene.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using FF9;
+﻿using FF9;
 using Memoria;
 using Memoria.Data;
 using Memoria.Database;
 using Memoria.Scenes;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 public partial class BattleHUD : UIScene
@@ -58,7 +58,7 @@ public partial class BattleHUD : UIScene
     }
 
     public void UpdateSlidingButtonState()
-	{
+    {
         if (!Configuration.Interface.PSXBattleMenu || ButtonGroupState.ActiveGroup != CommandGroupButton)
             return;
         Boolean leftPressed = (ETb.sKey0 & (EventInput.Lleft | EventInput.Pleft)) != 0;
@@ -97,7 +97,7 @@ public partial class BattleHUD : UIScene
             }
         }
         if (_buttonSliding != null)
-		{
+        {
             if (_buttonSliding == _commandPanel.Change && leftPressed)
                 _buttonSlideFactor += 0.3f;
             else if (_buttonSliding == _commandPanel.Defend && rightPressed)
@@ -376,14 +376,20 @@ public partial class BattleHUD : UIScene
                         }
                     }
                     if (Configuration.Battle.Speed == 2)
-                        // We defend if we end up with the same player
-                        return OnKeyConfirm(_commandPanel.Defend.GameObject);
+                    {
+                        // If we end up with the same player
+                        BattleHUD.ForceNextTurn = true;
+                        return true;
+                    }
                 }
                 else if (ReadyQueue.Count == 1)
                 {
                     if (Configuration.Battle.Speed == 2)
-                        // We defend if no other players are ready
-                        return OnKeyConfirm(_commandPanel.Defend.GameObject);
+                    {
+                        // If no other players are ready
+                        BattleHUD.ForceNextTurn = true;
+                        return true;
+                    }
                     else
                         SwitchPlayer(ReadyQueue[0]);
                 }
@@ -568,7 +574,7 @@ public partial class BattleHUD : UIScene
             {
                 foreach (GONavigationButton button in _targetPanel.AllTargets)
                     ButtonGroupState.SetButtonAnimation(button, true);
-                
+
                 ButtonGroupState.ActiveButton = ButtonGroupState.GetCursorStartSelect(TargetGroupButton);
             }
             _cursorType = CursorGroup.Individual;

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Unity.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Unity.cs
@@ -269,6 +269,16 @@ public partial class BattleHUD : UIScene
             }
         }
 
+        if(switchBtlId >= 0)
+        {
+            // Switch to player ready when ForceNextTurn (turn-based)
+            Int32 playerId = 0;
+            while (1 << playerId != switchBtlId)
+                ++playerId;
+            SwitchPlayer(playerId);
+            switchBtlId = -1;
+        }
+
         if (ReadyQueue.Count <= 0 || CurrentPlayerIndex != -1)
             return;
 

--- a/Assembly-CSharp/Global/battle/battle.cs
+++ b/Assembly-CSharp/Global/battle/battle.cs
@@ -223,11 +223,8 @@ public static class battle
             }
 
             btl_para.CheckPointData(next);
-
-            // ============ Warning ============
-            if (Configuration.Battle.Speed == 0 || Configuration.Battle.Speed >= 3 || next.sel_mode != 0 || next.sel_menu != 0 || next.cur.hp == 0 || next.bi.atb == 0)
-                btl_stat.CheckStatusLoop(next, false);
-            // =================================
+            btl_stat.CheckStatusLoop(next);
+            btl_stat.RotateAfterCheckStatusLoop(next);
         }
         if (flag)
         {

--- a/Assembly-CSharp/Global/btl_cmd.cs
+++ b/Assembly-CSharp/Global/btl_cmd.cs
@@ -1,13 +1,13 @@
 ﻿using Assets.Sources.Scripts.UI.Common;
 using FF9;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Memoria;
 using Memoria.Data;
 using Memoria.Scripts;
-using UnityEngine;
 using NCalc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
 
 // ReSharper disable SuspiciousTypeConversion.Global
 // ReSharper disable EmptyConstructor
@@ -582,7 +582,7 @@ public class btl_cmd
                     return;
 
         CMD_DATA cmd = GetFirstCommandReadyToDequeue(btlsys);
-        if (cmd == null || !FF9StateSystem.Battle.isDebug && !UIManager.Battle.IsNativeEnableAtb() && btl_util.IsCommandDeclarable(cmd.cmd_no))
+        if (cmd == null || !FF9StateSystem.Battle.isDebug && !UIManager.Battle.FF9BMenu_IsEnableAtb() && btl_util.IsCommandDeclarable(cmd.cmd_no))
             return;
         if (Configuration.Battle.Speed == 3 && cmd.regist != null && btl_util.IsBtlBusy(cmd.regist, btl_util.BusyMode.ANY_CURRENT))
             return;

--- a/Assembly-CSharp/Global/btl_cmd.cs
+++ b/Assembly-CSharp/Global/btl_cmd.cs
@@ -582,7 +582,7 @@ public class btl_cmd
                     return;
 
         CMD_DATA cmd = GetFirstCommandReadyToDequeue(btlsys);
-        if (cmd == null || !FF9StateSystem.Battle.isDebug && !UIManager.Battle.FF9BMenu_IsEnableAtb() && btl_util.IsCommandDeclarable(cmd.cmd_no))
+        if (cmd == null || !FF9StateSystem.Battle.isDebug && !UIManager.Battle.IsNativeEnableAtb() && btl_util.IsCommandDeclarable(cmd.cmd_no))
             return;
         if (Configuration.Battle.Speed == 3 && cmd.regist != null && btl_util.IsBtlBusy(cmd.regist, btl_util.BusyMode.ANY_CURRENT))
             return;

--- a/Assembly-CSharp/Global/btl_stat.cs
+++ b/Assembly-CSharp/Global/btl_stat.cs
@@ -542,7 +542,7 @@ public static class btl_stat
         if (!unit.IsUnderAnyStatus(BattleStatus.Stop | BattleStatus.Jump))
             btl.bi.atb = 1;
 
-        if (!UIManager.Battle.FF9BMenu_IsEnableAtb() || !UIManager.Battle.TurnBased_IsEnableAtb())
+        if (!UIManager.Battle.FF9BMenu_IsEnableAtb())
             return;
 
         if (btl.bi.atb == 0)

--- a/Assembly-CSharp/Global/btl_stat.cs
+++ b/Assembly-CSharp/Global/btl_stat.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using UnityEngine;
-using FF9;
+﻿using FF9;
 using Memoria;
 using Memoria.Data;
 using NCalc;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
 
 // ReSharper disable ClassNeverInstantiated.Global
 // ReSharper disable EmptyConstructor
@@ -505,13 +505,7 @@ public static class btl_stat
         return (btl.stat.permanent & status) != 0 || (btl.stat.cur & status) != 0;
     }
 
-    public static void CheckStatusLoop(BTL_DATA btl, Boolean ignoreAtb)
-    {
-        CheckStatuses(btl, ignoreAtb);
-        RotateAfterCheckStatusLoop(btl);
-    }
-
-    private static void CheckStatuses(BTL_DATA btl, Boolean ignoreAtb)
+    public static void CheckStatusLoop(BTL_DATA btl)
     {
         FF9StateBattleSystem ff9Battle = FF9StateSystem.Battle.FF9Battle;
         STAT_INFO stat = btl.stat;
@@ -548,7 +542,7 @@ public static class btl_stat
         if (!unit.IsUnderAnyStatus(BattleStatus.Stop | BattleStatus.Jump))
             btl.bi.atb = 1;
 
-        if (!ignoreAtb && !UIManager.Battle.FF9BMenu_IsEnableAtb())
+        if (!UIManager.Battle.FF9BMenu_IsEnableAtb() || !UIManager.Battle.TurnBased_IsEnableAtb())
             return;
 
         if (btl.bi.atb == 0)
@@ -604,7 +598,7 @@ public static class btl_stat
             else
             {
                 stat.cnt.opr[2] -= btl.cur.at_coef;
-            }          
+            }
         }
         if (Configuration.Mod.TranceSeek)
         {
@@ -631,7 +625,7 @@ public static class btl_stat
         ActiveTimeStatus(btl);
     }
 
-    private static void RotateAfterCheckStatusLoop(BTL_DATA btl)
+    public static void RotateAfterCheckStatusLoop(BTL_DATA btl)
     {
         if (CheckStatus(btl, BattleStatus.Confuse)
             && !btl_util.IsBtlUsingCommand(btl)

--- a/Assembly-CSharp/UnityXInput/Input.cs
+++ b/Assembly-CSharp/UnityXInput/Input.cs
@@ -4,6 +4,7 @@
 // MVID: 9E13D328-CC20-4729-BE81-A583B120F83A
 // Compiler-generated code is shown
 
+using Memoria;
 using System;
 using UnityEngine;
 using XInputDotNetPure;
@@ -51,7 +52,7 @@ namespace UnityXInput
 
         private static Single GetXAxis(String axisName)
         {
-            if (!HonoInputManager.ApplicationIsActivated() || !PersistenSingleton<XInputManager>.Instance.CurrentState.IsConnected)
+            if ((!Configuration.Control.AlwaysCaptureGamepad && !HonoInputManager.ApplicationIsActivated()) || !PersistenSingleton<XInputManager>.Instance.CurrentState.IsConnected)
                 return 0.0f;
             if (axisName.Contains("Horizontal"))
             {
@@ -78,7 +79,7 @@ namespace UnityXInput
 
         private static Boolean GetXButton(String keyName)
         {
-            if (!HonoInputManager.ApplicationIsActivated())
+            if (!Configuration.Control.AlwaysCaptureGamepad && !HonoInputManager.ApplicationIsActivated())
                 return false;
             GamePadState currentState = PersistenSingleton<XInputManager>.Instance.CurrentState;
             GamePadState previousState = PersistenSingleton<XInputManager>.Instance.PreviousState;
@@ -141,7 +142,7 @@ namespace UnityXInput
 
         private static Boolean GetXButtonUp(String keyName)
         {
-            if (!HonoInputManager.ApplicationIsActivated())
+            if (!Configuration.Control.AlwaysCaptureGamepad && !HonoInputManager.ApplicationIsActivated())
                 return false;
             GamePadState currentState = PersistenSingleton<XInputManager>.Instance.CurrentState;
             GamePadState previousState = PersistenSingleton<XInputManager>.Instance.PreviousState;
@@ -208,7 +209,7 @@ namespace UnityXInput
 
         private static Boolean GetXButtonDown(String keyName)
         {
-            if (!HonoInputManager.ApplicationIsActivated())
+            if (!Configuration.Control.AlwaysCaptureGamepad && !HonoInputManager.ApplicationIsActivated())
                 return false;
             GamePadState currentState = PersistenSingleton<XInputManager>.Instance.CurrentState;
             GamePadState previousState = PersistenSingleton<XInputManager>.Instance.PreviousState;


### PR DESCRIPTION
So I've restored the ForceNextTurn feature that I previously accidentally removed.

I made some changes to its behavior:
- Can only be triggered in battle when no commands are being performed (including enemies).
- Will advance to the next in line, player or enemy. If it's an enemy it will perform its turn. If it's a player it will switch to it.
- If all players are ready, it will allow an enemy to take its turn.
- When only one person is ready, trying to switch player will force a turn.
- Plays a sound when ForceNextTurn gets activated.

Other changes:
- Fixed Zidane gets a turn prematurely in the Prison Cage fight in Evil Forest
- Fixed AlwaysCaptureGamepad capturing keyboard too (My bad, I thought it didn't)