### PR TITLE
[DV features] MP Cost, NCalc options...

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -43,7 +43,8 @@
       <HintPath>..\References\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization">
-      <Private>True</Private> <!-- Don't remove, for Newtonsoft.Json  -->
+      <Private>True</Private>
+      <!-- Don't remove, for Newtonsoft.Json  -->
     </Reference>
     <Reference Include="UnityEngine">
       <HintPath>..\References\UnityEngine.dll</HintPath>
@@ -351,6 +352,7 @@
     <Compile Include="Memoria\Assets\Text\Strings\TextResjsonFormatter.cs" />
     <Compile Include="Memoria\Configuration\Access\Interface.cs" />
     <Compile Include="Memoria\Configuration\Structure\InterfaceSection.cs" />
+    <Compile Include="Memoria\Data\Battle\BattleCommandMenu.cs" />
     <Compile Include="Memoria\Data\Battle\BattleMagicSwordSet.cs" />
     <Compile Include="Memoria\Data\TetraMaster\TripleTriad.cs" />
     <Compile Include="Memoria\Data\TetraMaster\TripleTriadCard.cs" />

--- a/Assembly-CSharp/Global/AbilityUI.cs
+++ b/Assembly-CSharp/Global/AbilityUI.cs
@@ -1157,7 +1157,7 @@ public class AbilityUI : UIScene
     private static Int32 GetMp(AA_DATA aa_data)
     {
         Int32 mpCost = aa_data.MP;
-        if ((aa_data.Type & 4) != 0 && FF9StateSystem.EventState.gEventGlobal[18] != 0)
+        if ((aa_data.Type & 4) != 0 && battle.GARNET_SUMMON_FLAG != 0)
             mpCost <<= 2;
         return mpCost;
     }

--- a/Assembly-CSharp/Global/CMD_DATA.cs
+++ b/Assembly-CSharp/Global/CMD_DATA.cs
@@ -53,6 +53,11 @@ public class CMD_DATA
 		}
 	}
 
+    public Int32 GetCommandMPCost()
+    {
+        return info.CustomMPCost ?? aa?.MP ?? 0;
+    }
+
 	public class SELECT_INFO
 	{
 		public Byte cursor;
@@ -65,17 +70,23 @@ public class CMD_DATA
 		public Byte short_summon;
 		public Byte mon_reflec;
 
-		// Custom fields
-		public command_mode_index mode;
+        // Custom fields
+        public BattleCommandMenu cmdMenu;
+        public command_mode_index mode;
 		public Boolean cmd_motion;
 		// For multi-hit attacks (this counter allows to keep track of the hit number, for having different effects)
 		public Int32 effect_counter;
-		public Boolean IsZeroMP { get; set; }
-		public Int32 CustomMPCost { get; set; }
+		public Int32? CustomMPCost { get; set; }
 		public Boolean ReflectNull { get; set; }
 		public Boolean HasCheckedReflect { get; set; }
 
-		public void Reset()
+        public Boolean IsZeroMP
+        {
+            get => CustomMPCost == 0;
+            set => CustomMPCost = value ? 0 : null;
+        }
+
+        public void Reset()
 		{
 			cursor = 0;
 			stat = 0;
@@ -86,11 +97,12 @@ public class CMD_DATA
 			meteor_miss = 0;
 			short_summon = 0;
 			mon_reflec = 0;
-			mode = command_mode_index.CMD_MODE_INSPECTION;
+            cmdMenu = BattleCommandMenu.None;
+            mode = command_mode_index.CMD_MODE_INSPECTION;
 			cmd_motion = true;
 			effect_counter = 0;
 			IsZeroMP = false;
-			CustomMPCost = -1;
+			CustomMPCost = null;
 			ReflectNull = false;
 			HasCheckedReflect = false;
 		}

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Const.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Const.cs
@@ -200,17 +200,17 @@ public partial class BattleHUD : UIScene
         return false;
     }
 
-    private static BattleCommandId GetCommandFromCommandIndex(ref CommandMenu commandIndex, Int32 playerIndex)
+    private static BattleCommandId GetCommandFromCommandIndex(ref BattleCommandMenu commandIndex, Int32 playerIndex)
     {
         BattleUnit player = FF9StateSystem.Battle.FF9Battle.GetUnit(playerIndex);
         CharacterPresetId presetId = FF9StateSystem.Common.FF9.party.GetCharacter(player.Position).PresetId;
         BattleCommandId result = BattleCommandId.None;
         switch (commandIndex)
         {
-            case CommandMenu.Attack:
+            case BattleCommandMenu.Attack:
                 result = BattleCommandId.Attack;
                 break;
-            case CommandMenu.Defend:
+            case BattleCommandMenu.Defend:
                 result = BattleCommandId.Defend;
                 if (Configuration.Mod.TranceSeek)
                 {
@@ -220,31 +220,31 @@ public partial class BattleHUD : UIScene
                         result = (BattleCommandId)10016;
                 }
                 break;
-            case CommandMenu.Ability1:
+            case BattleCommandMenu.Ability1:
             {
                 CharacterCommandSet commandSet = CharacterCommands.CommandSets[presetId];
                 Boolean underTrance = player.IsUnderAnyStatus(BattleStatus.Trance);
                 result = commandSet.Get(underTrance, 0);
                 break;
             }
-            case CommandMenu.Ability2:
+            case BattleCommandMenu.Ability2:
             {
                 CharacterCommandSet commandSet = CharacterCommands.CommandSets[presetId];
                 Boolean underTrance = player.IsUnderAnyStatus(BattleStatus.Trance);
                 result = commandSet.Get(underTrance, 1);
                 break;
             }
-            case CommandMenu.Item:
+            case BattleCommandMenu.Item:
                 result = BattleCommandId.Item;
                 break;
-            case CommandMenu.Change:
+            case BattleCommandMenu.Change:
                 result = BattleCommandId.Change;
                 break;
         }
         if (player.Data.is_monster_transform && result == player.Data.monster_transform.base_command)
         {
             result = player.Data.monster_transform.new_command;
-            commandIndex = CommandMenu.Ability1;
+            commandIndex = BattleCommandMenu.Ability1;
         }
         return result;
     }

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Nested.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Nested.cs
@@ -25,17 +25,6 @@ public partial class BattleHUD : UIScene
         public Int32 Id;
     }
 
-    private enum CommandMenu
-    {
-        Attack,
-        Defend,
-        Ability1,
-        Ability2,
-        Item,
-        Change,
-        AccessMenu = 7,
-    }
-
     private enum CursorGroup
     {
         Individual,
@@ -126,6 +115,7 @@ public partial class BattleHUD : UIScene
 
     private class CommandDetail
     {
+        public BattleCommandMenu Menu;
         public BattleCommandId CommandId;
         public Int32 SubId;
         public UInt16 TargetId;
@@ -168,7 +158,7 @@ public partial class BattleHUD : UIScene
     private class PlayerMemo
 	{
         public PlayerMemo(PLAYER p, Boolean updateRow)
-		{
+        {
             original = p;
             if (p == null)
                 return;
@@ -198,10 +188,10 @@ public partial class BattleHUD : UIScene
         }
 
         public PLAYER original;
-		public POINTS max;
-		public ELEMENT elem;
-		public ItemDefence defence;
-		public HashSet<SupportAbility> saExtended;
+        public POINTS max;
+        public ELEMENT elem;
+        public ItemDefence defence;
+        public HashSet<SupportAbility> saExtended;
         public CharacterSerialNumber serialNo;
         public Byte row;
         public Byte battleRow;

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
@@ -52,7 +52,7 @@ public partial class BattleHUD : UIScene
         InputFinishList = new List<Int32>();
         _unconsciousStateList = new List<Int32>();
         _firstCommand = new CommandDetail();
-        _commandCursorMemorize = new Dictionary<Int32, CommandMenu>();
+        _commandCursorMemorize = new Dictionary<Int32, BattleCommandMenu>();
         _abilityCursorMemorize = new Dictionary<PairCharCommand, Int32>();
         _matchBattleIdPlayerList = new List<Int32>();
         _matchBattleIdEnemyList = new List<Int32>();
@@ -170,9 +170,10 @@ public partial class BattleHUD : UIScene
     {
         if (Configuration.Interface.ScanDisplay)
         {
+            Single additionalWidth = 0.0f;
             String libraMessage = $"[{NGUIText.Center}]";
             if ((infos & LibraInformation.Name) != 0)
-                libraMessage += pBtl.Name;
+                libraMessage += Singleton<HelpDialog>.Instance.PhraseLabel.PhrasePreOpcodeSymbol(pBtl.Name, ref additionalWidth);
             if ((infos & LibraInformation.Level) != 0)
                 libraMessage += FF9TextTool.BattleLibraText(10) + pBtl.Level.ToString();
             if ((infos & LibraInformation.NameLevel) != 0)
@@ -256,7 +257,7 @@ public partial class BattleHUD : UIScene
             _currentButtonGroup = !_hidingHud ? ButtonGroupState.ActiveGroup : _currentButtonGroup;
             FF9BMenu_EnableMenu(false);
             TutorialUI tutorialUI = PersistenSingleton<UIManager>.Instance.TutorialScene;
-            tutorialUI.libraTitle = pBtl.Name;
+            tutorialUI.libraTitle = Singleton<HelpDialog>.Instance.PhraseLabel.PhrasePreOpcodeSymbol(pBtl.Name, ref additionalWidth);
             tutorialUI.libraMessage = libraMessage;
             tutorialUI.libraPhoto = photo;
             tutorialUI.DisplayMode = TutorialUI.Mode.Libra;
@@ -781,7 +782,7 @@ public partial class BattleHUD : UIScene
         BackButton.SetActive(false);
         _currentSilenceStatus = false;
         _currentMpValue = -1;
-        _currentCommandIndex = CommandMenu.Attack;
+        _currentCommandIndex = BattleCommandMenu.Attack;
         _currentSubMenuIndex = -1;
         CurrentPlayerIndex = -1;
         //currentTranceTrigger = false;

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Scene.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Scene.cs
@@ -75,15 +75,15 @@ public partial class BattleHUD : UIScene
             {
                 Single rowCount = _commandPanel.AccessMenu == null ? 4f : 5f;
                 Single row;
-                if (_currentCommandIndex == CommandMenu.Attack)
+                if (_currentCommandIndex == BattleCommandMenu.Attack)
                     row = 0f;
-                else if (_currentCommandIndex == CommandMenu.Ability1)
+                else if (_currentCommandIndex == BattleCommandMenu.Ability1)
                     row = 1f;
-                else if (_currentCommandIndex == CommandMenu.Ability2)
+                else if (_currentCommandIndex == BattleCommandMenu.Ability2)
                     row = 2f;
-                else if (_currentCommandIndex == CommandMenu.Item)
+                else if (_currentCommandIndex == BattleCommandMenu.Item)
                     row = 3f;
-                else if (_currentCommandIndex == CommandMenu.AccessMenu)
+                else if (_currentCommandIndex == BattleCommandMenu.AccessMenu)
                     row = 4f;
                 else
                     return;
@@ -93,7 +93,7 @@ public partial class BattleHUD : UIScene
                 _buttonSliding.IsActive = true;
                 _commandPanel.GetCommandButton(_buttonSlideInitial).SetActive(false);
                 ButtonGroupState.ActiveButton = _buttonSliding;
-                _currentCommandIndex = (CommandMenu)_buttonSliding.Transform.GetSiblingIndex();
+                _currentCommandIndex = (BattleCommandMenu)_buttonSliding.Transform.GetSiblingIndex();
             }
         }
         if (_buttonSliding != null)
@@ -147,8 +147,8 @@ public partial class BattleHUD : UIScene
         if (ButtonGroupState.ActiveGroup == CommandGroupButton)
         {
             FF9Sfx.FF9SFX_Play(103);
-            _currentCommandIndex = (CommandMenu)go.transform.GetSiblingIndex();
-            CommandMenu menuType = _currentCommandIndex;
+            _currentCommandIndex = (BattleCommandMenu)go.transform.GetSiblingIndex();
+            BattleCommandMenu menuType = _currentCommandIndex;
             _currentCommandId = GetCommandFromCommandIndex(ref menuType, CurrentPlayerIndex);
             ResetSlidingButton();
             TryMemorizeCommand();
@@ -158,17 +158,17 @@ public partial class BattleHUD : UIScene
 
             switch (menuType)
             {
-                case CommandMenu.Attack:
+                case BattleCommandMenu.Attack:
                     SetCommandVisibility(false, false);
                     SetTargetVisibility(true);
                     break;
-                case CommandMenu.Defend:
+                case BattleCommandMenu.Defend:
                     _targetCursor = 0;
                     SendCommand(ProcessCommand(CurrentPlayerIndex, CursorGroup.Individual));
                     SetIdle();
                     break;
-                case CommandMenu.Ability1:
-                case CommandMenu.Ability2:
+                case BattleCommandMenu.Ability1:
+                case BattleCommandMenu.Ability2:
                     CharacterCommand ff9Command = CharacterCommands.Commands[_currentCommandId];
                     if (ff9Command.Type == CharacterCommandType.Normal)
                     {
@@ -191,12 +191,12 @@ public partial class BattleHUD : UIScene
                         SetItemPanelVisibility(true, false);
                     }
                     break;
-                case CommandMenu.Item:
+                case BattleCommandMenu.Item:
                     DisplayItem(false);
                     SetCommandVisibility(false, false);
                     SetItemPanelVisibility(true, false);
                     break;
-                case CommandMenu.Change:
+                case BattleCommandMenu.Change:
                     _targetCursor = 0;
                     if (_isManualTrance)
                     {
@@ -211,7 +211,7 @@ public partial class BattleHUD : UIScene
                         SetIdle();
                     }
                     break;
-                case CommandMenu.AccessMenu:
+                case BattleCommandMenu.AccessMenu:
                     OpenMainMenu(Configuration.Battle.AccessMenus <= 2 ? FF9StateSystem.Battle.FF9Battle.GetUnit(CurrentPlayerIndex)?.Player?.Data : null);
                     break;
             }
@@ -287,18 +287,18 @@ public partial class BattleHUD : UIScene
         {
             if (ButtonGroupState.ActiveGroup == TargetGroupButton)
             {
-                CommandMenu menuType = _currentCommandIndex;
+                BattleCommandMenu menuType = _currentCommandIndex;
                 GetCommandFromCommandIndex(ref menuType, CurrentPlayerIndex);
                 FF9Sfx.FF9SFX_Play(101);
                 SetTargetVisibility(false);
                 ClearModelPointer();
                 switch (menuType)
                 {
-                    case CommandMenu.Attack:
+                    case BattleCommandMenu.Attack:
                         SetCommandVisibility(true, true);
                         break;
-                    case CommandMenu.Ability1:
-                    case CommandMenu.Ability2:
+                    case BattleCommandMenu.Ability1:
+                    case BattleCommandMenu.Ability2:
                         if (_subMenuType == SubMenuType.Ability)
                         {
                             SetAbilityPanelVisibility(true, true);
@@ -311,7 +311,7 @@ public partial class BattleHUD : UIScene
                         }
                         SetCommandVisibility(true, true);
                         break;
-                    case CommandMenu.Item:
+                    case BattleCommandMenu.Item:
                         SetItemPanelVisibility(true, true);
                         break;
                 }
@@ -473,8 +473,8 @@ public partial class BattleHUD : UIScene
         {
             if (ButtonGroupState.ActiveGroup == CommandGroupButton)
             {
-                _currentCommandIndex = (CommandMenu)go.transform.GetSiblingIndex();
-                if (_currentCommandIndex != CommandMenu.Defend && _currentCommandIndex != CommandMenu.Change)
+                _currentCommandIndex = (BattleCommandMenu)go.transform.GetSiblingIndex();
+                if (_currentCommandIndex != BattleCommandMenu.Defend && _currentCommandIndex != BattleCommandMenu.Change)
                     ResetSlidingButton(false);
             }
             else if (ButtonGroupState.ActiveGroup == AbilityGroupButton || ButtonGroupState.ActiveGroup == ItemGroupButton)

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.UI.PanelCommand.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.UI.PanelCommand.cs
@@ -6,6 +6,7 @@ using Memoria.Assets;
 using Memoria.Scenes;
 using UnityEngine;
 using Object = System.Object;
+using Memoria.Data;
 
 public partial class BattleHUD : UIScene
 {
@@ -80,23 +81,23 @@ public partial class BattleHUD : UIScene
                 yield break;
             }
 
-            public GameObject GetCommandButton(CommandMenu menu)
+            public GameObject GetCommandButton(BattleCommandMenu menu)
             {
                 switch (menu)
                 {
-                    case CommandMenu.Attack:
+                    case BattleCommandMenu.Attack:
                         return Attack;
-                    case CommandMenu.Defend:
+                    case BattleCommandMenu.Defend:
                         return Defend;
-                    case CommandMenu.Ability1:
+                    case BattleCommandMenu.Ability1:
                         return Skill1;
-                    case CommandMenu.Ability2:
+                    case BattleCommandMenu.Ability2:
                         return Skill2;
-                    case CommandMenu.Item:
+                    case BattleCommandMenu.Item:
                         return Item;
-                    case CommandMenu.Change:
+                    case BattleCommandMenu.Change:
                         return Change;
-                    case CommandMenu.AccessMenu:
+                    case BattleCommandMenu.AccessMenu:
                         return AccessMenu;
                     default:
                         return Attack;

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Unity.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Unity.cs
@@ -451,9 +451,9 @@ public partial class BattleHUD : UIScene
 
         if (_subMenuType == SubMenuType.Ability)
         {
-            AA_DATA aaData = GetSelectedActiveAbility(CurrentPlayerIndex, _currentCommandId, _currentSubMenuIndex, out _);
+            AA_DATA aaData = GetSelectedActiveAbility(CurrentPlayerIndex, _currentCommandId, _currentSubMenuIndex, out _, out BattleAbilityId abilId);
 
-            if (btl.CurrentMp < GetActionMpCost(aaData, btl))
+            if (btl.CurrentMp < GetActionMpCost(aaData, btl, abilId))
             {
                 FF9Sfx.FF9SFX_Play(101);
                 DisplayAbility();
@@ -602,7 +602,7 @@ public partial class BattleHUD : UIScene
         if (cmd != null && btl_cmd.CheckUsingCommand(cmd))
             return;
         CurrentPlayerIndex = playerIndex;
-        _currentCommandIndex = CommandMenu.Attack;
+        _currentCommandIndex = BattleCommandMenu.Attack;
         
         BattleUnit enemy = GetFirstAliveEnemy();
         if (enemy != null)

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
@@ -11,6 +11,8 @@ using Memoria.Prime;
 using Memoria.Scenes;
 using NCalc;
 using UnityEngine;
+using static SFX;
+using System.Reflection;
 
 public partial class BattleHUD : UIScene
 {
@@ -20,7 +22,7 @@ public partial class BattleHUD : UIScene
     private readonly List<Boolean> _currentEnemyDieState;
     private readonly List<DamageAnimationInfo> _hpInfoVal;
     private readonly List<DamageAnimationInfo> _mpInfoVal;
-    private readonly Dictionary<Int32, CommandMenu> _commandCursorMemorize;
+    private readonly Dictionary<Int32, BattleCommandMenu> _commandCursorMemorize;
     private readonly Dictionary<PairCharCommand, Int32> _abilityCursorMemorize;
     private readonly List<Int32> _matchBattleIdPlayerList;
     private readonly List<Int32> _matchBattleIdEnemyList;
@@ -69,7 +71,7 @@ public partial class BattleHUD : UIScene
     private Boolean _beforePauseCommandEnable;
     private Boolean _isFromPause;
     private Boolean _isNeedToInit;
-    private CommandMenu _currentCommandIndex;
+    private BattleCommandMenu _currentCommandIndex;
     private BattleCommandId _currentCommandId;
     private String _currentButtonGroup;
     private Int32 _currentSubMenuIndex;
@@ -95,7 +97,7 @@ public partial class BattleHUD : UIScene
     private Boolean _oneTime;
     private Single _buttonSlideFactor;
     private Vector2 _buttonSlidePos;
-    private CommandMenu _buttonSlideInitial;
+    private BattleCommandMenu _buttonSlideInitial;
     private GONavigationButton _buttonSliding;
     private Int32 CurrentBattlePlayerIndex => _matchBattleIdPlayerList.IndexOf(CurrentPlayerIndex);
 
@@ -177,9 +179,10 @@ public partial class BattleHUD : UIScene
 
         if (_currentLibraMessageNumber == 1)
         {
+            Single additionalWidth = 0.0f;
             String str = String.Empty;
             if ((_libraEnabledMessage & LibraInformation.Name) != 0)
-                str += _libraBtlData.Name;
+                str += Singleton<HelpDialog>.Instance.PhraseLabel.PhrasePreOpcodeSymbol(_libraBtlData.Name, ref additionalWidth);
             if ((_libraEnabledMessage & LibraInformation.Level) != 0)
                 str += FF9TextTool.BattleLibraText(10) + _libraBtlData.Level.ToString();
             SetBattleMessage(str, 3);
@@ -694,17 +697,18 @@ public partial class BattleHUD : UIScene
         return btl.Data.is_monster_transform && btl.Data.monster_transform.new_command == cmdId;
     }
 
-    private AA_DATA GetSelectedActiveAbility(Int32 playerIndex, BattleCommandId cmdId, Int32 abilityIndex, out Int32 subNo)
+    private AA_DATA GetSelectedActiveAbility(Int32 playerIndex, BattleCommandId cmdId, Int32 abilityIndex, out Int32 subNo, out BattleAbilityId abilId)
     {
         CharacterCommand ff9Command = CharacterCommands.Commands[cmdId];
         if (CommandIsMonsterTransformCommand(playerIndex, cmdId, out BTL_DATA.MONSTER_TRANSFORM transform))
         {
             subNo = ff9Command.ListEntry[abilityIndex];
+            abilId = BattleAbilityId.Void;
             return transform.spell[subNo];
         }
-        BattleAbilityId abilityId = PatchAbility(ff9Command.GetAbilityId(abilityIndex));
-        subNo = (Int32)abilityId;
-        return FF9StateSystem.Battle.FF9Battle.aa_data[abilityId];
+        abilId = PatchAbility(ff9Command.GetAbilityId(abilityIndex));
+        subNo = (Int32)abilId;
+        return FF9StateSystem.Battle.FF9Battle.aa_data[abilId];
     }
 
     private void DisplayAbility()
@@ -773,7 +777,7 @@ public partial class BattleHUD : UIScene
             else
             {
                 BattleAbilityId patchedID = PatchAbility(ff9abil.GetActiveAbilityFromAbilityId(battleAbilityListData.Id));
-                mp = GetActionMpCost(FF9StateSystem.Battle.FF9Battle.aa_data[patchedID], curUnit);
+                mp = GetActionMpCost(FF9StateSystem.Battle.FF9Battle.aa_data[patchedID], curUnit, patchedID);
                 itemListDetailHud.NameLabel.text = FF9TextTool.ActionAbilityName(patchedID);
                 itemListDetailHud.Button.Help.Text = FF9TextTool.ActionAbilityHelpDescription(patchedID);
             }
@@ -958,7 +962,7 @@ public partial class BattleHUD : UIScene
                                 Int32 nextValidTarget = GetFirstAliveEnemyIndex();
                                 if (nextValidTarget != -1)
                                 {
-                                    if (_currentCommandIndex == CommandMenu.Attack && FF9StateSystem.PCPlatform && _enemyCount > 1)
+                                    if (_currentCommandIndex == BattleCommandMenu.Attack && FF9StateSystem.PCPlatform && _enemyCount > 1)
                                     {
                                         if (_currentTargetIndex == nextValidTarget && nextValidTarget + 1 < _targetPanel.AllTargets.Length)
                                             nextValidTarget++;
@@ -1174,11 +1178,16 @@ public partial class BattleHUD : UIScene
         }
     }
 
-    private Int32 GetActionMpCost(AA_DATA aaData, BattleUnit unit)
+    private Int32 GetActionMpCost(AA_DATA aaData, BattleUnit unit, BattleAbilityId abilId = BattleAbilityId.Void)
     {
         Int32 mpCost = aaData.MP;
-        if ((aaData.Type & 4) != 0 && FF9StateSystem.EventState.gEventGlobal[18] != 0)
-            mpCost <<= 2;
+        if (CurrentPlayerIndex >= 0 && unit.Data == FF9StateSystem.Battle.FF9Battle.btl_data[CurrentPlayerIndex]) // The check is a bit hacky to see if the MP cost request is in the context of a command menu
+            BattleAbilityHelper.GetPatchedMPCost(abilId, unit, ref mpCost, ability: aaData, menu: _currentCommandIndex);
+        else
+            BattleAbilityHelper.GetPatchedMPCost(abilId, unit, ref mpCost, ability: aaData);
+
+        if ((aaData.Type & 4) != 0 && battle.GARNET_SUMMON_FLAG != 0)
+            mpCost *= 4;
 
         mpCost = mpCost * unit.Player.Data.mpCostFactor / 100;
 
@@ -1218,7 +1227,8 @@ public partial class BattleHUD : UIScene
             playerIndex = CurrentPlayerIndex;
         AbilityPlayerDetail abilityPlayerDetail = _abilityDetailDict[playerIndex];
         BattleUnit unit = FF9StateSystem.Battle.FF9Battle.GetUnit(playerIndex);
-		AA_DATA patchedAbil = FF9StateSystem.Battle.FF9Battle.aa_data[BattleAbilityHelper.Patch(ff9abil.GetActiveAbilityFromAbilityId(abilId), unit.Player.Data)];
+        BattleAbilityId patchedId = BattleAbilityHelper.Patch(ff9abil.GetActiveAbilityFromAbilityId(abilId), unit.Player.Data);
+        AA_DATA patchedAbil = FF9StateSystem.Battle.FF9Battle.aa_data[patchedId];
 
 		if ((Configuration.Battle.LockEquippedAbilities == 2 || Configuration.Battle.LockEquippedAbilities == 3) && abilityPlayerDetail.Player.Index != CharacterId.Quina && abilityPlayerDetail.HasAp && !abilityPlayerDetail.AbilityEquipList.ContainsKey(abilId) && ff9abil.IsAbilityActive(abilId))
             return AbilityStatus.None;
@@ -1244,7 +1254,7 @@ public partial class BattleHUD : UIScene
                 return AbilityStatus.Disable;
         }
 
-        if (GetActionMpCost(patchedAbil, unit) > unit.CurrentMp)
+        if (GetActionMpCost(patchedAbil, unit, patchedId) > unit.CurrentMp)
             return AbilityStatus.Disable;
 
         return AbilityStatus.Enable;
@@ -1377,7 +1387,7 @@ public partial class BattleHUD : UIScene
 
     private void InitialBattle()
     {
-        _currentCommandIndex = CommandMenu.Attack;
+        _currentCommandIndex = BattleCommandMenu.Attack;
         _currentSubMenuIndex = 0;
         CurrentPlayerIndex = -1;
         _subMenuType = SubMenuType.Normal;
@@ -1435,9 +1445,11 @@ public partial class BattleHUD : UIScene
     {
         CommandDetail commandDetail = new CommandDetail
         {
+            Menu = _currentCommandIndex,
             CommandId = _currentCommandId,
             SubId = 0
         };
+        GetCommandFromCommandIndex(ref commandDetail.Menu, CurrentPlayerIndex);
 
         BattleCommandId cmdId = commandDetail.CommandId;
 
@@ -1526,6 +1538,7 @@ public partial class BattleHUD : UIScene
 
         if (bestRating > 0)
         {
+            commandDetail.Menu = BattleCommandMenu.None;
             commandDetail.CommandId = BattleCommandId.BlackMagic;
             commandDetail.SubId = (Int32)bestAbility;
             caster.Data.cmd[0].info.IsZeroMP = true;
@@ -1537,19 +1550,20 @@ public partial class BattleHUD : UIScene
         BTL_DATA btl = FF9StateSystem.Battle.FF9Battle.btl_data[CurrentPlayerIndex];
         CMD_DATA cmd = btl.cmd[0];
         cmd.regist.sel_mode = 1;
-        btl_cmd.SetCommand(cmd, command.CommandId, command.SubId, command.TargetId, command.TargetType);
+        btl_cmd.SetCommand(cmd, command.CommandId, command.SubId, command.TargetId, command.TargetType, cmdMenu: command.Menu);
         SetPartySwapButtonActive(false);
         InputFinishList.Add(CurrentPlayerIndex);
 
         _partyDetail.SetBlink(CurrentPlayerIndex, false);
     }
 
-    private void SendDoubleCastCommand(CommandDetail first, CommandDetail secondCommand)
+    private void SendDoubleCastCommand(CommandDetail first, CommandDetail second)
     {
-        CMD_DATA cmd = FF9StateSystem.Battle.FF9Battle.btl_data[CurrentPlayerIndex].cmd[3];
-        cmd.regist.sel_mode = 1;
-        btl_cmd.SetCommand(cmd, first.CommandId, first.SubId, first.TargetId, first.TargetType);
-        btl_cmd.SetCommand(FF9StateSystem.Battle.FF9Battle.btl_data[CurrentPlayerIndex].cmd[0], secondCommand.CommandId, secondCommand.SubId, secondCommand.TargetId, secondCommand.TargetType);
+        CMD_DATA cmd1 = FF9StateSystem.Battle.FF9Battle.btl_data[CurrentPlayerIndex].cmd[3];
+        CMD_DATA cmd2 = FF9StateSystem.Battle.FF9Battle.btl_data[CurrentPlayerIndex].cmd[0]; // The second command sent/performed is the main one (it resets the ATB correctly amongst other things)
+        cmd1.regist.sel_mode = 1;
+        btl_cmd.SetCommand(cmd1, first.CommandId, first.SubId, first.TargetId, first.TargetType, cmdMenu: first.Menu);
+        btl_cmd.SetCommand(cmd2, second.CommandId, second.SubId, second.TargetId, second.TargetType, cmdMenu: second.Menu);
         SetPartySwapButtonActive(false);
         InputFinishList.Add(CurrentPlayerIndex);
 
@@ -1600,7 +1614,7 @@ public partial class BattleHUD : UIScene
 
     private void TryMemorizeCommand()
     {
-        if (Configuration.Interface.PSXBattleMenu && (_currentCommandIndex == CommandMenu.Defend || _currentCommandIndex == CommandMenu.Change))
+        if (Configuration.Interface.PSXBattleMenu && (_currentCommandIndex == BattleCommandMenu.Defend || _currentCommandIndex == BattleCommandMenu.Change))
             return;
         _commandCursorMemorize[CurrentPlayerIndex] = _currentCommandIndex;
     }
@@ -1610,7 +1624,7 @@ public partial class BattleHUD : UIScene
         if (!forceCursorMemo && (Int64)FF9StateSystem.Settings.cfg.cursor == 0L)
             return;
 
-        CommandMenu memorizedCommand;
+        BattleCommandMenu memorizedCommand;
         if (_commandCursorMemorize.TryGetValue(CurrentPlayerIndex, out memorizedCommand))
             commandObject = _commandPanel.GetCommandButton(memorizedCommand);
     }
@@ -1679,9 +1693,9 @@ public partial class BattleHUD : UIScene
             _defaultTargetDead = false;
             _targetDead = false;
             _bestTargetIndex = -1;
-            if (_currentCommandIndex == CommandMenu.Ability1 || _currentCommandIndex == CommandMenu.Ability2 || CommandIsMonsterTransformCommand(CurrentPlayerIndex, _currentCommandId, out _))
+            if (_currentCommandIndex == BattleCommandMenu.Ability1 || _currentCommandIndex == BattleCommandMenu.Ability2 || CommandIsMonsterTransformCommand(CurrentPlayerIndex, _currentCommandId, out _))
             {
-                AA_DATA aaData = GetSelectedActiveAbility(CurrentPlayerIndex, _currentCommandId, _currentSubMenuIndex, out Int32 subNo);
+                AA_DATA aaData = GetSelectedActiveAbility(CurrentPlayerIndex, _currentCommandId, _currentSubMenuIndex, out Int32 subNo, out _);
                 targetType = aaData.Info.Target;
                 _defaultTargetAlly = aaData.Info.DefaultAlly;
                 _defaultTargetDead = aaData.Info.DefaultOnDead;
@@ -1699,7 +1713,7 @@ public partial class BattleHUD : UIScene
 
                 SelectBestTarget(targetType, testCommand);
             }
-            else if (_currentCommandIndex == CommandMenu.Item)
+            else if (_currentCommandIndex == BattleCommandMenu.Item)
             {
                 RegularItem itemId = _itemIdList[_currentSubMenuIndex];
                 ITEM_DATA itemData = ff9item.GetItemEffect(itemId);
@@ -1720,7 +1734,7 @@ public partial class BattleHUD : UIScene
 
                 SelectBestTarget(targetType, testCommand);
             }
-            else if (_currentCommandIndex == CommandMenu.Attack && CurrentPlayerIndex > -1)
+            else if (_currentCommandIndex == BattleCommandMenu.Attack && CurrentPlayerIndex > -1)
             {
                 BattleUnit btl = FF9StateSystem.Battle.FF9Battle.GetUnit(CurrentPlayerIndex);
                 if (btl.IsHealingRod || btl.HasSupportAbility(SupportAbility1.Healer)) // Todo: should be coded as a SA feature instead of being hard-coded
@@ -1942,7 +1956,7 @@ public partial class BattleHUD : UIScene
                 if (targetIndex > -1)
                 {
                     targetIndex += HonoluluBattleMain.EnemyStartIndex;
-                    if (_currentCommandIndex == CommandMenu.Attack && FF9StateSystem.PCPlatform)
+                    if (_currentCommandIndex == BattleCommandMenu.Attack && FF9StateSystem.PCPlatform)
                         ValidateDefaultTarget(ref targetIndex);
                     GONavigationButton targetEnemy = _targetPanel.AllTargets[targetIndex];
                     ButtonGroupState.SetCursorStartSelect(targetEnemy, TargetGroupButton);
@@ -1978,7 +1992,7 @@ public partial class BattleHUD : UIScene
                     targetIndex = GetFirstAliveEnemyIndex();
                     if (targetIndex != -1)
                     {
-                        if (_currentCommandIndex == CommandMenu.Attack && FF9StateSystem.PCPlatform)
+                        if (_currentCommandIndex == BattleCommandMenu.Attack && FF9StateSystem.PCPlatform)
                             ValidateDefaultTarget(ref targetIndex);
                         GONavigationButton currentEnemy = _targetPanel.AllTargets[targetIndex];
                         ButtonGroupState.SetCursorStartSelect(currentEnemy, TargetGroupButton);

--- a/Assembly-CSharp/Memoria/Battle/Calculator/BattleCommand.cs
+++ b/Assembly-CSharp/Memoria/Battle/Calculator/BattleCommand.cs
@@ -116,6 +116,8 @@ namespace Memoria
             set => Data.info.short_summon = (Byte)(value ? 1 : 0);
         }
         public Boolean IsZeroMP => Data.info.IsZeroMP;
+        public Int32 CommandMPCost => Data.GetCommandMPCost(); // This takes AA features into account but not increased summon cost early on or player MP cost factor
+        public BattleCommandMenu CommandMenu => Data.info.cmdMenu;
 
         public Boolean IsDevided => IsManyTarget && (Int32)Data.aa.Info.Target > 2 && (Int32)Data.aa.Info.Target < 6;
 

--- a/Assembly-CSharp/Memoria/Battle/Calculator/SBattleCalculator.cs
+++ b/Assembly-CSharp/Memoria/Battle/Calculator/SBattleCalculator.cs
@@ -1,10 +1,9 @@
-using System;
-using System.Reflection;
-using System.Collections.Generic;
 using FF9;
 using Memoria.Data;
 using Memoria.Prime;
 using Memoria.Scripts;
+using System;
+using System.Reflection;
 using UnityEngine;
 // ReSharper disable PossibleNullReferenceException
 
@@ -115,6 +114,7 @@ namespace Memoria
             BTL_DATA target = v.Target.Data;
             BTL_DATA caster = v.Caster.Data;
             CMD_DATA cmd = v.Command.Data;
+            v.Context.AddedStatuses |= v.Target.AddededCheckPointStatuses;
             foreach (SupportingAbilityFeature saFeature in ff9abil.GetEnabledSA(caster))
                 saFeature.TriggerOnAbility(v, "BattleScriptEnd", false);
             foreach (SupportingAbilityFeature saFeature in ff9abil.GetEnabledSA(target))
@@ -294,6 +294,7 @@ namespace Memoria
                     target.cur.mp = target.max.mp;
                 }
             }
+            v.Context.AddedStatuses |= v.Target.AddededCheckPointStatuses;
             foreach (SupportingAbilityFeature saFeature in ff9abil.GetEnabledSA(caster))
                 saFeature.TriggerOnAbility(v, "EffectDone", false);
             foreach (SupportingAbilityFeature saFeature in ff9abil.GetEnabledSA(target))

--- a/Assembly-CSharp/Memoria/Data/Battle/BattleAbilityHelper.cs
+++ b/Assembly-CSharp/Memoria/Data/Battle/BattleAbilityHelper.cs
@@ -1,93 +1,233 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
+﻿using FF9;
+using Memoria.Database;
 using Memoria.Prime;
 using NCalc;
-using FF9;
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace Memoria.Data
 {
     public static class BattleAbilityHelper
     {
-        private static Dictionary<BattleAbilityId, String> AbilityPatch = new Dictionary<BattleAbilityId, String>();
-        private static Dictionary<BattleAbilityId, String> AbilityPriority = new Dictionary<BattleAbilityId, String>();
-        private static Dictionary<BattleAbilityId, String> AbilityPowerPatch = new Dictionary<BattleAbilityId, String>();
-        private static Dictionary<BattleAbilityId, String> AbilityHitRatePatch = new Dictionary<BattleAbilityId, String>();
-        private static Dictionary<BattleAbilityId, String> AbilityElementPatch = new Dictionary<BattleAbilityId, String>();
-        private static Dictionary<BattleAbilityId, String> AbilityStatusPatch = new Dictionary<BattleAbilityId, String>();
-        private static Dictionary<BattleAbilityId, String> AbilityTargetPatch = new Dictionary<BattleAbilityId, String>();
-        private static Dictionary<BattleAbilityId, String> AbilitySpecialEffectPatch = new Dictionary<BattleAbilityId, String>();
-        private static Dictionary<BattleAbilityId, String> AbilityGilCost = new Dictionary<BattleAbilityId, String>();
-        private static Dictionary<BattleAbilityId, String> AbilityItemRequirement = new Dictionary<BattleAbilityId, String>();
-
-        public static void ParseAbilityFeature(BattleAbilityId id, String input)
+        public static void ParseAbilityFeature(String input)
         {
+            ParseAbilityFeature(BattleAbilityId.Void, input);
+        }
+
+        public static void ParseAbilityFeature(BattleAbilityId abilId, String input)
+        {
+            FeatureSet set;
+            if (abilId == BattleAbilityId.Void)
+            {
+                // A feature that relies on their "Condition" to discriminate whether they apply or not
+                set = new FeatureSet();
+                FlexibleFeatures.Add(set);
+            }
+            else
+            {
+                // A feature linked to a particular Ability ID
+                if (!AbilityFeatures.TryGetValue(abilId, out set))
+                {
+                    set = new FeatureSet();
+                    AbilityFeatures.Add(abilId, set);
+                }
+            }
             foreach (Match formula in new Regex(@"\[code=(.*?)\](.*?)\[/code\]").Matches(input))
             {
-                if (String.Compare(formula.Groups[1].Value, "Patch") == 0)
-                    AbilityPatch[id] = formula.Groups[2].Value;
-                else if (String.Compare(formula.Groups[1].Value, "Priority") == 0)
-                    AbilityPriority[id] = formula.Groups[2].Value;
-                else if (String.Compare(formula.Groups[1].Value, "Power") == 0)
-                    AbilityPowerPatch[id] = formula.Groups[2].Value;
-                else if (String.Compare(formula.Groups[1].Value, "HitRate") == 0)
-                    AbilityHitRatePatch[id] = formula.Groups[2].Value;
-                else if (String.Compare(formula.Groups[1].Value, "Element") == 0)
-                    AbilityElementPatch[id] = formula.Groups[2].Value;
-                else if (String.Compare(formula.Groups[1].Value, "Status") == 0)
-                    AbilityStatusPatch[id] = formula.Groups[2].Value;
-                else if (String.Compare(formula.Groups[1].Value, "Target") == 0)
-                    AbilityTargetPatch[id] = formula.Groups[2].Value;
-                else if (String.Compare(formula.Groups[1].Value, "SpecialEffect") == 0)
-                    AbilitySpecialEffectPatch[id] = formula.Groups[2].Value;
-                else if (String.Compare(formula.Groups[1].Value, "GilCost") == 0)
-                    AbilityGilCost[id] = formula.Groups[2].Value;
-                else if (String.Compare(formula.Groups[1].Value, "ItemRequirement") == 0)
-                    AbilityItemRequirement[id] = formula.Groups[2].Value;
+                if (String.Equals(formula.Groups[1].Value, "Condition"))
+                    set.Condition = formula.Groups[2].Value;
+                else if (String.Equals(formula.Groups[1].Value, "Patch"))
+                {
+                    set.AbilityPatch = formula.Groups[2].Value;
+                    if (abilId == BattleAbilityId.Void)
+                        Log.Warning($"[{nameof(BattleAbilityHelper)}] \"AbilityPatch\" cannot be used as a Global AA feature");
+                }
+                else if (String.Equals(formula.Groups[1].Value, "Priority"))
+                    set.AbilityPriority = formula.Groups[2].Value;
+                else if (String.Equals(formula.Groups[1].Value, "Power"))
+                    set.AbilityPowerPatch = formula.Groups[2].Value;
+                else if (String.Equals(formula.Groups[1].Value, "HitRate"))
+                    set.AbilityHitRatePatch = formula.Groups[2].Value;
+                else if (String.Equals(formula.Groups[1].Value, "Element"))
+                    set.AbilityElementPatch = formula.Groups[2].Value;
+                else if (String.Equals(formula.Groups[1].Value, "Status"))
+                    set.AbilityStatusPatch = formula.Groups[2].Value;
+                else if (String.Equals(formula.Groups[1].Value, "Target"))
+                    set.AbilityTargetPatch = formula.Groups[2].Value;
+                else if (String.Equals(formula.Groups[1].Value, "SpecialEffect"))
+                    set.AbilitySpecialEffectPatch = formula.Groups[2].Value;
+                else if (String.Equals(formula.Groups[1].Value, "GilCost"))
+                    set.AbilityGilCost = formula.Groups[2].Value;
+                else if (String.Equals(formula.Groups[1].Value, "MPCost"))
+                    set.AbilityMPCost = formula.Groups[2].Value;
+                else if (String.Equals(formula.Groups[1].Value, "ItemRequirement"))
+                    set.AbilityItemRequirement = formula.Groups[2].Value;
             }
         }
 
-        public static void ClearAbilityFeature(BattleAbilityId id)
+        public static void ClearAbilityFeature(BattleAbilityId abilId)
 		{
-            AbilityPatch.Remove(id);
-            AbilityPriority.Remove(id);
-            AbilityPowerPatch.Remove(id);
-            AbilityHitRatePatch.Remove(id);
-            AbilityElementPatch.Remove(id);
-            AbilityStatusPatch.Remove(id);
-            AbilityTargetPatch.Remove(id);
-            AbilitySpecialEffectPatch.Remove(id);
-            AbilityGilCost.Remove(id);
-            AbilityItemRequirement.Remove(id);
+            AbilityFeatures.Remove(abilId);
+        }
+
+        public static void ClearFlexibleAbilityFeature()
+        {
+            FlexibleFeatures.Clear();
         }
 
         public static Boolean ApplySpecialCommandCondition(CMD_DATA cmd)
         {
-            BattleAbilityId abilId = btl_util.GetCommandMainActionIndex(cmd);
-            if (abilId == BattleAbilityId.Void)
-                return true;
             try
             {
-                String featureStr;
-                if (AbilityPowerPatch.TryGetValue(abilId, out featureStr))
+                BattleAbilityId abilId = btl_util.GetCommandMainActionIndex(cmd);
+                Int64 gilCost = 0;
+                foreach (FeatureSet feat in GetApplicableFeatures(abilId, new BattleUnit(cmd.regist), cmd: cmd))
                 {
-                    Expression e = new Expression(featureStr);
+                    feat.ApplyBasicModifiers(cmd);
+                    if (!feat.ApplyCommandCondition(cmd, ref gilCost))
+                        return false;
+                }
+                PARTY_DATA ff9party = FF9StateSystem.Common.FF9.party;
+                if (gilCost > ff9party.gil)
+                {
+                    UIManager.Battle.SetBattleFollowMessage(BattleMesages.NotEnoughGil);
+                    return false;
+                }
+                ff9party.gil -= (UInt32)gilCost;
+            }
+            catch (Exception err)
+            {
+                Log.Error(err);
+            }
+            return true;
+        }
+
+        public static Boolean GetPatchedMPCost(BattleAbilityId abilId, BattleUnit potentialCaster, ref Int32 mpCost, AA_DATA ability = null, CMD_DATA cmd = null, BattleCommandMenu menu = BattleCommandMenu.None)
+        {
+            Boolean changeMPCost = false;
+            try
+            {
+                foreach (FeatureSet feat in GetApplicableFeatures(abilId, potentialCaster, ability: ability, cmd: cmd, menu: menu))
+                    if (feat.ApplyMPCost(abilId, potentialCaster, ref mpCost, ability: ability, cmd: cmd, menu: menu))
+                        changeMPCost = true;
+            }
+            catch (Exception err)
+            {
+                Log.Error(err);
+            }
+            return changeMPCost;
+        }
+
+        public static void SetCustomPriority(CMD_DATA cmd)
+        {
+            try
+            {
+                BattleAbilityId abilId = btl_util.GetCommandMainActionIndex(cmd);
+                foreach (FeatureSet feat in GetApplicableFeatures(abilId, new BattleUnit(cmd.regist), cmd: cmd))
+                    feat.ApplyPriority(cmd);
+            }
+            catch (Exception err)
+            {
+                Log.Error(err);
+            }
+        }
+
+        public static BattleAbilityId Patch(BattleAbilityId abilId, PLAYER character)
+        {
+            try
+            {
+                // Flexible features are not taken into account, and there cannot be any condition tied to a patch
+                // Using a NCalc formula that conditionally returns -1 can be used instead of a condition
+                if (abilId != BattleAbilityId.Void && AbilityFeatures.TryGetValue(abilId, out FeatureSet abilSet))
+                    return abilSet.ApplyPatch(abilId, character);
+            }
+            catch (Exception err)
+            {
+                Log.Error(err);
+            }
+            return abilId;
+        }
+
+        private static IEnumerable<FeatureSet> GetApplicableFeatures(BattleAbilityId abilId, BattleUnit caster, AA_DATA ability = null, CMD_DATA cmd = null, BattleCommandMenu menu = BattleCommandMenu.None)
+        {
+            foreach (FeatureSet flexiSet in FlexibleFeatures)
+                if (flexiSet.CheckCondition(abilId, caster, ability, cmd, menu))
+                    yield return flexiSet;
+            if (abilId != BattleAbilityId.Void && AbilityFeatures.TryGetValue(abilId, out FeatureSet abilSet) && abilSet.CheckCondition(abilId, caster, ability, cmd, menu))
+                yield return abilSet;
+            yield break;
+        }
+
+        private class FeatureSet
+        {
+            public String Condition = null;
+            public String AbilityPatch = null;
+            public String AbilityPriority = null;
+            public String AbilityPowerPatch = null;
+            public String AbilityHitRatePatch = null;
+            public String AbilityElementPatch = null;
+            public String AbilityStatusPatch = null;
+            public String AbilityTargetPatch = null;
+            public String AbilitySpecialEffectPatch = null;
+            public String AbilityGilCost = null;
+            public String AbilityMPCost = null;
+            public String AbilityItemRequirement = null;
+
+            public Boolean CheckCondition(BattleAbilityId abilId, BattleUnit caster, AA_DATA ability = null, CMD_DATA cmd = null, BattleCommandMenu menu = BattleCommandMenu.None)
+            {
+                if (String.IsNullOrEmpty(Condition))
+                    return true;
+                if (cmd == null && ability == null && abilId == BattleAbilityId.Void)
+                    return false;
+                Expression c = new Expression(Condition);
+                NCalcUtility.InitializeExpressionUnit(ref c, caster, "Caster");
+                if (cmd != null)
+                {
+                    NCalcUtility.InitializeExpressionCommand(ref c, new BattleCommand(cmd));
+                    c.Parameters["CommandId"] = (Int32)cmd.cmd_no;
+                    c.Parameters["CommandMenu"] = (Int32)cmd.info.cmdMenu;
+                }
+                else
+                {
+                    if (ability != null)
+                        NCalcUtility.InitializeExpressionRawAbility(ref c, ability, abilId);
+                    else
+                        NCalcUtility.InitializeExpressionRawAbility(ref c, FF9BattleDB.CharacterActions[abilId], abilId);
+                    if (menu == BattleCommandMenu.Ability1 && caster.IsPlayer)
+                        c.Parameters["CommandId"] = (Int32)CharacterCommands.CommandSets[caster.Player.PresetId].Get(caster.IsUnderAnyStatus(BattleStatus.Trance), 0);
+                    else if (menu == BattleCommandMenu.Ability2 && caster.IsPlayer)
+                        c.Parameters["CommandId"] = (Int32)CharacterCommands.CommandSets[caster.Player.PresetId].Get(caster.IsUnderAnyStatus(BattleStatus.Trance), 1);
+                    else
+                        c.Parameters["CommandId"] = (Int32)BattleCommandId.None;
+                    c.Parameters["CommandMenu"] = (Int32)menu;
+                }
+                c.EvaluateFunction += NCalcUtility.commonNCalcFunctions;
+                c.EvaluateParameter += NCalcUtility.commonNCalcParameters;
+                return NCalcUtility.EvaluateNCalcCondition(c.Evaluate());
+            }
+
+            public void ApplyBasicModifiers(CMD_DATA cmd)
+            {
+                if (!String.IsNullOrEmpty(AbilityPowerPatch))
+                {
+                    Expression e = new Expression(AbilityPowerPatch);
                     InitCommandExpression(ref e, cmd);
                     Int64 power = NCalcUtility.ConvertNCalcResult(e.Evaluate(), -1);
                     if (power >= 0)
                         cmd.Power = (Byte)power;
                 }
-                if (AbilityHitRatePatch.TryGetValue(abilId, out featureStr))
+                if (!String.IsNullOrEmpty(AbilityHitRatePatch))
                 {
-                    Expression e = new Expression(featureStr);
+                    Expression e = new Expression(AbilityHitRatePatch);
                     InitCommandExpression(ref e, cmd);
                     Int64 hitRate = NCalcUtility.ConvertNCalcResult(e.Evaluate(), -1);
                     if (hitRate >= 0)
                         cmd.HitRate = (Byte)hitRate;
                 }
-                if (AbilityElementPatch.TryGetValue(abilId, out featureStr))
+                if (!String.IsNullOrEmpty(AbilityElementPatch))
                 {
-                    Expression e = new Expression(featureStr);
+                    Expression e = new Expression(AbilityElementPatch);
                     InitCommandExpression(ref e, cmd);
                     Int64 element = NCalcUtility.ConvertNCalcResult(e.Evaluate(), -1);
                     if (element >= 0)
@@ -96,25 +236,25 @@ namespace Memoria.Data
                         cmd.ElementForBonus = cmd.Element;
                     }
                 }
-                if (AbilityStatusPatch.TryGetValue(abilId, out featureStr))
+                if (!String.IsNullOrEmpty(AbilityStatusPatch))
                 {
-                    Expression e = new Expression(featureStr);
+                    Expression e = new Expression(AbilityStatusPatch);
                     InitCommandExpression(ref e, cmd);
                     Int64 status = NCalcUtility.ConvertNCalcResult(e.Evaluate(), -1);
                     if (status >= 0)
                         cmd.AbilityStatus = (BattleStatus)status;
                 }
-                if (AbilityTargetPatch.TryGetValue(abilId, out featureStr))
+                if (!String.IsNullOrEmpty(AbilityTargetPatch))
                 {
-                    Expression e = new Expression(featureStr);
+                    Expression e = new Expression(AbilityTargetPatch);
                     InitCommandExpression(ref e, cmd);
                     Int64 target = NCalcUtility.ConvertNCalcResult(e.Evaluate(), -1);
                     if (target >= 0)
                         cmd.tar_id = (UInt16)target;
                 }
-                if (AbilitySpecialEffectPatch.TryGetValue(abilId, out featureStr))
+                if (!String.IsNullOrEmpty(AbilitySpecialEffectPatch))
                 {
-                    Expression e = new Expression(featureStr);
+                    Expression e = new Expression(AbilitySpecialEffectPatch);
                     InitCommandExpression(ref e, cmd);
                     Int64 vfx = NCalcUtility.ConvertNCalcResult(e.Evaluate(), -1);
                     if (vfx >= 0)
@@ -124,9 +264,13 @@ namespace Memoria.Data
                             cmd.info.meteor_miss = 1;
                     }
                 }
-                if (AbilityItemRequirement.TryGetValue(abilId, out featureStr))
+            }
+
+            public Boolean ApplyCommandCondition(CMD_DATA cmd, ref Int64 totalGilCost)
+            {
+                if (!String.IsNullOrEmpty(AbilityItemRequirement))
                 {
-                    String[] featureSplit = featureStr.Split(';');
+                    String[] featureSplit = AbilityItemRequirement.Split(';');
                     Int64 itemType = -1;
                     Int64 itemCount = 1;
                     for (Int32 i = 0; i < featureSplit.Length; i++)
@@ -155,89 +299,105 @@ namespace Memoria.Data
                         return false;
                     }
                 }
-                if (AbilityGilCost.TryGetValue(abilId, out featureStr))
+                if (!String.IsNullOrEmpty(AbilityGilCost))
                 {
-                    PARTY_DATA partyState = FF9StateSystem.Common.FF9.party;
-                    Expression e = new Expression(featureStr);
+                    Expression e = new Expression(AbilityGilCost);
                     InitCommandExpression(ref e, cmd);
-                    Int64 gilCost = NCalcUtility.ConvertNCalcResult(e.Evaluate(), -1);
-                    if (gilCost >= 0)
+                    Int64 gilCost = NCalcUtility.ConvertNCalcResult(e.Evaluate(), Int64.MinValue);
+                    if (gilCost != Int64.MinValue)
+                        totalGilCost += gilCost;
+                }
+                return true;
+            }
+
+            public Boolean ApplyMPCost(BattleAbilityId abilId, BattleUnit potentialCaster, ref Int32 mpCost, AA_DATA ability = null, CMD_DATA cmd = null, BattleCommandMenu menu = BattleCommandMenu.None)
+            {
+                if (ability == null && cmd == null)
+                {
+                    if (abilId == BattleAbilityId.Void)
+                        return false;
+                    if (!FF9BattleDB.CharacterActions.TryGetValue(abilId, out ability))
+                        return false;
+                }
+                if (ability == null && cmd != null)
+                    ability = cmd.aa;
+                if (!String.IsNullOrEmpty(AbilityMPCost))
+                {
+                    Expression e = new Expression(AbilityMPCost);
+                    NCalcUtility.InitializeExpressionUnit(ref e, potentialCaster, "Caster");
+                    NCalcUtility.InitializeExpressionRawAbility(ref e, ability, abilId);
+                    if (cmd != null)
                     {
-                        if (gilCost > partyState.gil)
-                        {
-                            UIManager.Battle.SetBattleFollowMessage(BattleMesages.NotEnoughGil);
-                            return false;
-                        }
-                        partyState.gil -= (UInt32)gilCost;
+                        e.Parameters["CommandId"] = (Int32)cmd.cmd_no;
+                        e.Parameters["CommandMenu"] = (Int32)cmd.info.cmdMenu;
+                    }
+                    else
+                    {
+                        if (menu == BattleCommandMenu.Ability1 && potentialCaster.IsPlayer)
+                            e.Parameters["CommandId"] = (Int32)CharacterCommands.CommandSets[potentialCaster.Player.PresetId].Get(potentialCaster.IsUnderAnyStatus(BattleStatus.Trance), 0);
+                        else if (menu == BattleCommandMenu.Ability2 && potentialCaster.IsPlayer)
+                            e.Parameters["CommandId"] = (Int32)CharacterCommands.CommandSets[potentialCaster.Player.PresetId].Get(potentialCaster.IsUnderAnyStatus(BattleStatus.Trance), 1);
+                        else
+                            e.Parameters["CommandId"] = (Int32)BattleCommandId.None;
+                        e.Parameters["CommandMenu"] = (Int32)menu;
+                    }
+                    e.Parameters["MPCost"] = (Int32)mpCost;
+                    e.EvaluateFunction += NCalcUtility.commonNCalcFunctions;
+                    e.EvaluateParameter += NCalcUtility.commonNCalcParameters;
+                    Int64 mp = NCalcUtility.ConvertNCalcResult(e.Evaluate(), Int64.MinValue);
+                    if (mp != Int64.MinValue)
+                    {
+                        mpCost = (Int32)mp;
+                        return true;
                     }
                 }
+                return false;
             }
-            catch (Exception err)
-            {
-                Log.Error(err);
-            }
-            return true;
-        }
 
-        public static void SetCustomPriority(CMD_DATA cmd)
-        {
-            BattleAbilityId abilId = btl_util.GetCommandMainActionIndex(cmd);
-            if (abilId == BattleAbilityId.Void)
-                return;
-            String featureStr;
-            if (AbilityPriority.TryGetValue(abilId, out featureStr))
+            public void ApplyPriority(CMD_DATA cmd)
             {
-                try
+                if (!String.IsNullOrEmpty(AbilityPriority))
                 {
-                    Expression e = new Expression(featureStr);
+                    Expression e = new Expression(AbilityPriority);
                     InitCommandExpression(ref e, cmd);
                     Int64 priority = NCalcUtility.ConvertNCalcResult(e.Evaluate(), -1);
                     if (priority >= 0)
                         cmd.info.priority = (Byte)priority;
                 }
-                catch (Exception err)
-                {
-                    Log.Error(err);
-                }
             }
-        }
 
-        private static void InitCommandExpression(ref Expression e, CMD_DATA cmd)
-        {
-            BattleUnit caster = new BattleUnit(cmd.regist);
-            //BattleUnit target = btl_scrp.FindBattleUnitUnlimited((UInt16)Comn.firstBitSet(cmd.tar_id));
-            NCalcUtility.InitializeExpressionUnit(ref e, caster, "Caster");
-            //NCalcUtility.InitializeExpressionUnit(ref e, target, "Target");
-            NCalcUtility.InitializeExpressionCommand(ref e, new BattleCommand(cmd));
-            e.Parameters["IsSingleTarget"] = Comn.countBits(cmd.tar_id) == 1;
-            e.Parameters["IsSelfTarget"] = caster.Id == cmd.tar_id;
-            e.Parameters["AreCasterAndTargetEnemies"] = (caster.IsPlayer && (cmd.tar_id & 0xF0) == cmd.tar_id) || (!caster.IsPlayer && (cmd.tar_id & 0xF) == cmd.tar_id);
-            e.Parameters["AreCasterAndTargetAllies"] = (caster.IsPlayer && (cmd.tar_id & 0xF) == cmd.tar_id) || (!caster.IsPlayer && (cmd.tar_id & 0x0F) == cmd.tar_id);
-            e.EvaluateFunction += NCalcUtility.commonNCalcFunctions;
-            e.EvaluateParameter += NCalcUtility.commonNCalcParameters;
-        }
-
-        public static BattleAbilityId Patch(BattleAbilityId id, PLAYER character)
-        {
-            String patchStr;
-            if (AbilityPatch.TryGetValue(id, out patchStr))
+            public BattleAbilityId ApplyPatch(BattleAbilityId abilId, PLAYER character)
             {
-                try
+                if (!String.IsNullOrEmpty(AbilityPatch))
                 {
-                    Expression e = new Expression(patchStr);
+                    Expression e = new Expression(AbilityPatch);
                     e.EvaluateFunction += NCalcUtility.commonNCalcFunctions;
                     e.EvaluateParameter += NCalcUtility.commonNCalcParameters;
                     NCalcUtility.InitializeExpressionPlayer(ref e, character);
                     Int64 val = NCalcUtility.ConvertNCalcResult(e.Evaluate(), -1);
-                    if (val >= 0)
+                    if (val >= 0 && FF9BattleDB.CharacterActions.ContainsKey((BattleAbilityId)val))
                         return (BattleAbilityId)val;
                 }
-                catch (Exception err)
-				{
-                    Log.Error(err);
-				}
+                return abilId;
             }
-            return id;
+
+            private static void InitCommandExpression(ref Expression e, CMD_DATA cmd)
+            {
+                BattleUnit caster = new BattleUnit(cmd.regist);
+                //BattleUnit target = btl_scrp.FindBattleUnitUnlimited((UInt16)Comn.firstBitSet(cmd.tar_id));
+                NCalcUtility.InitializeExpressionUnit(ref e, caster, "Caster");
+                //NCalcUtility.InitializeExpressionUnit(ref e, target, "Target");
+                NCalcUtility.InitializeExpressionCommand(ref e, new BattleCommand(cmd));
+                e.Parameters["IsSingleTarget"] = Comn.countBits(cmd.tar_id) == 1;
+                e.Parameters["IsSelfTarget"] = caster.Id == cmd.tar_id;
+                e.Parameters["AreCasterAndTargetEnemies"] = (caster.IsPlayer && (cmd.tar_id & 0xF0) == cmd.tar_id) || (!caster.IsPlayer && (cmd.tar_id & 0xF) == cmd.tar_id);
+                e.Parameters["AreCasterAndTargetAllies"] = (caster.IsPlayer && (cmd.tar_id & 0xF) == cmd.tar_id) || (!caster.IsPlayer && (cmd.tar_id & 0x0F) == cmd.tar_id);
+                e.EvaluateFunction += NCalcUtility.commonNCalcFunctions;
+                e.EvaluateParameter += NCalcUtility.commonNCalcParameters;
+            }
         }
+
+        private static Dictionary<BattleAbilityId, FeatureSet> AbilityFeatures = new Dictionary<BattleAbilityId, FeatureSet>();
+        private static List<FeatureSet> FlexibleFeatures = new List<FeatureSet>();
     }
 }

--- a/Assembly-CSharp/Memoria/Data/Battle/BattleCommandMenu.cs
+++ b/Assembly-CSharp/Memoria/Data/Battle/BattleCommandMenu.cs
@@ -1,0 +1,15 @@
+﻿namespace Memoria.Data
+{
+    public enum BattleCommandMenu
+    {
+        // Only concerns commands that really emanate from a player's input (so no counter-attacks, no Berserk/Confuse attacks...)
+        None = -1,
+        Attack = 0,
+        Defend,
+        Ability1,
+        Ability2,
+        Item,
+        Change,
+        AccessMenu = 7,
+    }
+}

--- a/Assembly-CSharp/Memoria/Data/Characters/CharacterAbilityGems.cs
+++ b/Assembly-CSharp/Memoria/Data/Characters/CharacterAbilityGems.cs
@@ -116,23 +116,23 @@ namespace Memoria.Data
                         NCalcUtility.InitializeExpressionPlayer(ref e, play);
                         e.EvaluateFunction += NCalcUtility.commonNCalcFunctions;
                         e.EvaluateParameter += NCalcUtility.commonNCalcParameters;
-                        if (String.Compare(formula.Key, "MaxHP") == 0) play.max.hp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.max.hp);
-                        else if (String.Compare(formula.Key, "MaxMP") == 0) play.max.mp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.max.mp);
-                        else if (String.Compare(formula.Key, "Speed") == 0) play.basis.dex = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.basis.dex);
-                        else if (String.Compare(formula.Key, "Strength") == 0) play.basis.str = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.basis.str);
-                        else if (String.Compare(formula.Key, "Magic") == 0) play.basis.mgc = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.basis.mgc);
-                        else if (String.Compare(formula.Key, "Spirit") == 0) play.basis.wpr = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.basis.wpr);
-                        else if (String.Compare(formula.Key, "Defence") == 0) play.defence.PhysicalDefence = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.defence.PhysicalDefence);
-                        else if (String.Compare(formula.Key, "Evade") == 0) play.defence.PhysicalEvade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.defence.PhysicalEvade);
-                        else if (String.Compare(formula.Key, "MagicDefence") == 0) play.defence.MagicalDefence = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.defence.MagicalDefence);
-                        else if (String.Compare(formula.Key, "MagicEvade") == 0) play.defence.MagicalEvade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.defence.MagicalEvade);
-                        else if (String.Compare(formula.Key, "PlayerCategory") == 0) play.category = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.category);
-                        else if (String.Compare(formula.Key, "MPCostFactor") == 0) play.mpCostFactor = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.mpCostFactor);
-                        else if (String.Compare(formula.Key, "MaxHPLimit") == 0) play.maxHpLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.maxHpLimit);
-                        else if (String.Compare(formula.Key, "MaxMPLimit") == 0) play.maxMpLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.maxMpLimit);
-                        else if (String.Compare(formula.Key, "MaxDamageLimit") == 0) play.maxDamageLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.maxDamageLimit);
-                        else if (String.Compare(formula.Key, "MaxMPDamageLimit") == 0) play.maxMpDamageLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.maxMpDamageLimit);
-                        else if (String.Compare(formula.Key, "PlayerPermanentStatus") == 0) play.SetPermanentStatus((BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)play.permanent_status));
+                        if (String.Equals(formula.Key, "MaxHP")) play.max.hp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.max.hp);
+                        else if (String.Equals(formula.Key, "MaxMP")) play.max.mp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.max.mp);
+                        else if (String.Equals(formula.Key, "Speed")) play.basis.dex = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.basis.dex);
+                        else if (String.Equals(formula.Key, "Strength")) play.basis.str = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.basis.str);
+                        else if (String.Equals(formula.Key, "Magic")) play.basis.mgc = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.basis.mgc);
+                        else if (String.Equals(formula.Key, "Spirit")) play.basis.wpr = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.basis.wpr);
+                        else if (String.Equals(formula.Key, "Defence")) play.defence.PhysicalDefence = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.defence.PhysicalDefence);
+                        else if (String.Equals(formula.Key, "Evade")) play.defence.PhysicalEvade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.defence.PhysicalEvade);
+                        else if (String.Equals(formula.Key, "MagicDefence")) play.defence.MagicalDefence = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.defence.MagicalDefence);
+                        else if (String.Equals(formula.Key, "MagicEvade")) play.defence.MagicalEvade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.defence.MagicalEvade);
+                        else if (String.Equals(formula.Key, "PlayerCategory")) play.category = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.category);
+                        else if (String.Equals(formula.Key, "MPCostFactor")) play.mpCostFactor = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.mpCostFactor);
+                        else if (String.Equals(formula.Key, "MaxHPLimit")) play.maxHpLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.maxHpLimit);
+                        else if (String.Equals(formula.Key, "MaxMPLimit")) play.maxMpLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.maxMpLimit);
+                        else if (String.Equals(formula.Key, "MaxDamageLimit")) play.maxDamageLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.maxDamageLimit);
+                        else if (String.Equals(formula.Key, "MaxMPDamageLimit")) play.maxMpDamageLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.maxMpDamageLimit);
+                        else if (String.Equals(formula.Key, "PlayerPermanentStatus")) play.SetPermanentStatus((BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)play.permanent_status));
                     }
                 }
             }
@@ -161,8 +161,8 @@ namespace Memoria.Data
                         Expression e = new Expression(formula.Value);
                         e.EvaluateFunction += NCalcUtility.commonNCalcFunctions;
                         e.EvaluateParameter += NCalcUtility.commonNCalcParameters;
-                        if (String.Compare(formula.Key, "BackAttack") == 0) backAttackChance = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), backAttackChance);
-                        else if (String.Compare(formula.Key, "Preemptive") == 0) preemptiveChance = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), preemptiveChance);
+                        if (String.Equals(formula.Key, "BackAttack")) backAttackChance = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), backAttackChance);
+                        else if (String.Equals(formula.Key, "Preemptive")) preemptiveChance = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), preemptiveChance);
                     }
                     preemptivePriority += BattleStartEffect[i].PreemptivePriorityDelta;
                 }
@@ -180,7 +180,7 @@ namespace Memoria.Data
             {
                 for (Int32 i = 0; i < BattleResultEffect.Count; i++)
                 {
-                    if (String.Compare(BattleResultEffect[i].When, when) == 0)
+                    if (String.Equals(BattleResultEffect[i].When, when))
                     {
                         if (BattleResultEffect[i].Condition.Length > 0)
                         {
@@ -208,14 +208,14 @@ namespace Memoria.Data
                             e.Parameters["Status"] = (UInt32)play.status;
                             e.EvaluateFunction += NCalcUtility.commonNCalcFunctions;
                             e.EvaluateParameter += NCalcUtility.commonNCalcParameters;
-                            if (String.Compare(formula.Key, "FleeGil") == 0) fleeGil = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), fleeGil);
-                            else if (String.Compare(formula.Key, "HP") == 0) play.cur.hp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.cur.hp);
-                            else if (String.Compare(formula.Key, "MP") == 0) play.cur.mp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.cur.mp);
-                            else if (String.Compare(formula.Key, "Status") == 0) play.status = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)play.status);
-                            else if (String.Compare(formula.Key, "BonusAP") == 0) bonus.ap = (UInt16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), bonus.ap);
-                            else if (String.Compare(formula.Key, "BonusCard") == 0) bonus.card = (TetraMasterCardId)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Int32)bonus.card);
-                            else if (String.Compare(formula.Key, "BonusExp") == 0) bonus.exp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), bonus.exp);
-                            else if (String.Compare(formula.Key, "BonusGil") == 0) bonus.gil = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), bonus.gil);
+                            if (String.Equals(formula.Key, "FleeGil")) fleeGil = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), fleeGil);
+                            else if (String.Equals(formula.Key, "HP")) play.cur.hp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.cur.hp);
+                            else if (String.Equals(formula.Key, "MP")) play.cur.mp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.cur.mp);
+                            else if (String.Equals(formula.Key, "Status")) play.status = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)play.status);
+                            else if (String.Equals(formula.Key, "BonusAP")) bonus.ap = (UInt16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), bonus.ap);
+                            else if (String.Equals(formula.Key, "BonusCard")) bonus.card = (TetraMasterCardId)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Int32)bonus.card);
+                            else if (String.Equals(formula.Key, "BonusExp")) bonus.exp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), bonus.exp);
+                            else if (String.Equals(formula.Key, "BonusGil")) bonus.gil = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), bonus.gil);
                             else
                             {
                                 for (Int32 j = 0; j < BattleResultUI.ItemMax; j++)
@@ -314,7 +314,7 @@ namespace Memoria.Data
                 Boolean canMove = asTarget ? !calc.Target.IsUnderAnyStatus(BattleStatusConst.NoReaction) : !calc.Caster.IsUnderAnyStatus(BattleStatusConst.NoReaction);
                 for (Int32 i = 0; i < AbilityEffect.Count; i++)
                 {
-                    if (AbilityEffect[i].AsTarget == asTarget && (canMove || AbilityEffect[i].EvenImmobilized) && String.Compare(AbilityEffect[i].When, when) == 0)
+                    if (AbilityEffect[i].AsTarget == asTarget && (canMove || AbilityEffect[i].EvenImmobilized) && String.Equals(AbilityEffect[i].When, when))
                     {
                         BattleCaster caster = calc.Caster;
                         BattleTarget target = calc.Target;
@@ -335,126 +335,152 @@ namespace Memoria.Data
                         BattleStatus tCurStat = target.CurrentStatus, tAutoStat = target.PermanentStatus, tResistStat = target.ResistStatus;
                         foreach (KeyValuePair<String, String> formula in AbilityEffect[i].Effect)
                         {
-                            Expression e = new Expression(formula.Value);
+                            String[] formulaSplit = formula.Value.Split(';');
+                            if (formulaSplit.Length == 0)
+                                continue;
+                            Expression e = new Expression(formulaSplit[0]);
                             NCalcUtility.InitializeExpressionUnit(ref e, caster, "Caster");
                             NCalcUtility.InitializeExpressionUnit(ref e, target, "Target");
                             NCalcUtility.InitializeExpressionAbilityContext(ref e, calc);
                             e.EvaluateFunction += NCalcUtility.commonNCalcFunctions;
                             e.EvaluateParameter += NCalcUtility.commonNCalcParameters;
-                            if (String.Compare(formula.Key, "CasterHP") == 0) caster.CurrentHp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.CurrentHp);
-                            else if (String.Compare(formula.Key, "CasterMP") == 0) caster.CurrentMp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.CurrentMp);
-                            else if (String.Compare(formula.Key, "CasterMaxHP") == 0) caster.MaximumHp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.MaximumHp);
-                            else if (String.Compare(formula.Key, "CasterMaxMP") == 0) caster.MaximumMp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.MaximumMp);
-                            else if (String.Compare(formula.Key, "CasterATB") == 0) caster.CurrentAtb = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.CurrentAtb);
-                            else if (String.Compare(formula.Key, "CasterTrance") == 0) caster.Trance = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.Trance);
-                            else if (String.Compare(formula.Key, "CasterCurrentStatus") == 0) cCurStat = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)cCurStat);
-                            else if (String.Compare(formula.Key, "CasterPermanentStatus") == 0) cAutoStat = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)cAutoStat);
-                            else if (String.Compare(formula.Key, "CasterResistStatus") == 0) cResistStat = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)cResistStat);
-                            else if (String.Compare(formula.Key, "CasterHalfElement") == 0) caster.HalfElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)caster.HalfElement);
-                            else if (String.Compare(formula.Key, "CasterGuardElement") == 0) caster.GuardElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)caster.GuardElement);
-                            else if (String.Compare(formula.Key, "CasterAbsorbElement") == 0) caster.AbsorbElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)caster.AbsorbElement);
-                            else if (String.Compare(formula.Key, "CasterWeakElement") == 0) caster.WeakElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)caster.WeakElement);
-                            else if (String.Compare(formula.Key, "CasterBonusElement") == 0) caster.BonusElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)caster.BonusElement);
-                            else if (String.Compare(formula.Key, "CasterSpeed") == 0) caster.Dexterity = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.Dexterity);
-                            else if (String.Compare(formula.Key, "CasterStrength") == 0) caster.Strength = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.Strength);
-                            else if (String.Compare(formula.Key, "CasterMagic") == 0) caster.Magic = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.Magic);
-                            else if (String.Compare(formula.Key, "CasterSpirit") == 0) caster.Will = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.Will);
-                            else if (String.Compare(formula.Key, "CasterDefence") == 0) caster.PhysicalDefence = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.PhysicalDefence);
-                            else if (String.Compare(formula.Key, "CasterEvade") == 0) caster.PhysicalEvade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.PhysicalEvade);
-                            else if (String.Compare(formula.Key, "CasterMagicDefence") == 0) caster.MagicDefence = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.MagicDefence);
-                            else if (String.Compare(formula.Key, "CasterMagicEvade") == 0) caster.MagicEvade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.MagicEvade);
-                            else if (String.Compare(formula.Key, "CasterRow") == 0) caster.Row = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.Row);
-                            else if (String.Compare(formula.Key, "CasterSummonCount") == 0) caster.SummonCount = (UInt16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.SummonCount);
-                            else if (String.Compare(formula.Key, "CasterIsStrengthModified") == 0) caster.StatModifier[0] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), caster.StatModifier[0]);
-                            else if (String.Compare(formula.Key, "CasterIsMagicModified") == 0) caster.StatModifier[1] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), caster.StatModifier[1]);
-                            else if (String.Compare(formula.Key, "CasterIsDefenceModified") == 0) caster.StatModifier[2] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), caster.StatModifier[2]);
-                            else if (String.Compare(formula.Key, "CasterIsEvadeModified") == 0) caster.StatModifier[3] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), caster.StatModifier[3]);
-                            else if (String.Compare(formula.Key, "CasterIsMagicDefenceModified") == 0) caster.StatModifier[4] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), caster.StatModifier[4]);
-                            else if (String.Compare(formula.Key, "CasterIsMagicEvadeModified") == 0) caster.StatModifier[5] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), caster.StatModifier[5]);
-                            else if (String.Compare(formula.Key, "CasterCriticalRateBonus") == 0) caster.CriticalRateBonus = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.CriticalRateBonus);
-                            else if (String.Compare(formula.Key, "CasterCriticalRateWeakening") == 0) caster.CriticalRateWeakening = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.CriticalRateWeakening);
-                            else if (String.Compare(formula.Key, "CasterMaxDamageLimit") == 0) caster.MaxDamageLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.MaxDamageLimit);
-                            else if (String.Compare(formula.Key, "CasterMaxMPDamageLimit") == 0) caster.MaxMpDamageLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.MaxMpDamageLimit);
-                            else if (String.Compare(formula.Key, "CasterBonusExp") == 0 && !caster.IsPlayer) caster.Enemy.Data.bonus_exp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.Enemy.Data.bonus_exp);
-                            else if (String.Compare(formula.Key, "CasterBonusGil") == 0 && !caster.IsPlayer) caster.Enemy.Data.bonus_gil = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.Enemy.Data.bonus_gil);
-                            else if (String.Compare(formula.Key, "CasterBonusCard") == 0 && !caster.IsPlayer) caster.Enemy.Data.bonus_card = (TetraMasterCardId)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Int32)caster.Enemy.Data.bonus_card);
-                            else if (String.Compare(formula.Key, "TargetHP") == 0) target.CurrentHp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.CurrentHp);
-                            else if (String.Compare(formula.Key, "TargetMP") == 0) target.CurrentMp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.CurrentMp);
-                            else if (String.Compare(formula.Key, "TargetMaxHP") == 0) target.MaximumHp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.MaximumHp);
-                            else if (String.Compare(formula.Key, "TargetMaxMP") == 0) target.MaximumMp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.MaximumMp);
-                            else if (String.Compare(formula.Key, "TargetATB") == 0) target.CurrentAtb = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.CurrentAtb);
-                            else if (String.Compare(formula.Key, "TargetTrance") == 0) target.Trance = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.Trance);
-                            else if (String.Compare(formula.Key, "TargetCurrentStatus") == 0) tCurStat = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)tCurStat);
-                            else if (String.Compare(formula.Key, "TargetPermanentStatus") == 0) tAutoStat = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)tAutoStat);
-                            else if (String.Compare(formula.Key, "TargetResistStatus") == 0) tResistStat = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)tResistStat);
-                            else if (String.Compare(formula.Key, "TargetHalfElement") == 0) target.HalfElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)target.HalfElement);
-                            else if (String.Compare(formula.Key, "TargetGuardElement") == 0) target.GuardElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)target.GuardElement);
-                            else if (String.Compare(formula.Key, "TargetAbsorbElement") == 0) target.AbsorbElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)target.AbsorbElement);
-                            else if (String.Compare(formula.Key, "TargetWeakElement") == 0) target.WeakElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)target.WeakElement);
-                            else if (String.Compare(formula.Key, "TargetBonusElement") == 0) target.BonusElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)target.BonusElement);
-                            else if (String.Compare(formula.Key, "TargetSpeed") == 0) target.Dexterity = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.Dexterity);
-                            else if (String.Compare(formula.Key, "TargetStrength") == 0) target.Strength = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.Strength);
-                            else if (String.Compare(formula.Key, "TargetMagic") == 0) target.Magic = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.Magic);
-                            else if (String.Compare(formula.Key, "TargetSpirit") == 0) target.Will = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.Will);
-                            else if (String.Compare(formula.Key, "TargetDefence") == 0) target.PhysicalDefence = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.PhysicalDefence);
-                            else if (String.Compare(formula.Key, "TargetEvade") == 0) target.PhysicalEvade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.PhysicalEvade);
-                            else if (String.Compare(formula.Key, "TargetMagicDefence") == 0) target.MagicDefence = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.MagicDefence);
-                            else if (String.Compare(formula.Key, "TargetMagicEvade") == 0) target.MagicEvade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.MagicEvade);
-                            else if (String.Compare(formula.Key, "TargetRow") == 0) target.Row = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.Row);
-                            else if (String.Compare(formula.Key, "TargetSummonCount") == 0) target.SummonCount = (UInt16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.SummonCount);
-                            else if (String.Compare(formula.Key, "TargetIsStrengthModified") == 0) target.StatModifier[0] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), target.StatModifier[0]);
-                            else if (String.Compare(formula.Key, "TargetIsMagicModified") == 0) target.StatModifier[1] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), target.StatModifier[1]);
-                            else if (String.Compare(formula.Key, "TargetIsDefenceModified") == 0) target.StatModifier[2] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), target.StatModifier[2]);
-                            else if (String.Compare(formula.Key, "TargetIsEvadeModified") == 0) target.StatModifier[3] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), target.StatModifier[3]);
-                            else if (String.Compare(formula.Key, "TargetIsMagicDefenceModified") == 0) target.StatModifier[4] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), target.StatModifier[4]);
-                            else if (String.Compare(formula.Key, "TargetIsMagicEvadeModified") == 0) target.StatModifier[5] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), target.StatModifier[5]);
-                            else if (String.Compare(formula.Key, "TargetCriticalRateBonus") == 0) target.CriticalRateBonus = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.CriticalRateBonus);
-                            else if (String.Compare(formula.Key, "TargetCriticalRateWeakening") == 0) target.CriticalRateWeakening = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.CriticalRateWeakening);
-                            else if (String.Compare(formula.Key, "TargetMaxDamageLimit") == 0) target.MaxDamageLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.MaxDamageLimit);
-                            else if (String.Compare(formula.Key, "TargetMaxMPDamageLimit") == 0) target.MaxMpDamageLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.MaxMpDamageLimit);
-                            else if (String.Compare(formula.Key, "TargetBonusExp") == 0 && !target.IsPlayer) target.Enemy.Data.bonus_exp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.Enemy.Data.bonus_exp);
-                            else if (String.Compare(formula.Key, "TargetBonusGil") == 0 && !target.IsPlayer) target.Enemy.Data.bonus_gil = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.Enemy.Data.bonus_gil);
-                            else if (String.Compare(formula.Key, "TargetBonusCard") == 0 && !target.IsPlayer) target.Enemy.Data.bonus_card = (TetraMasterCardId)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Int32)target.Enemy.Data.bonus_card);
-                            else if (String.Compare(formula.Key, "EffectCasterFlags") == 0) caster.Flags = (CalcFlag)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)caster.Flags);
-                            else if (String.Compare(formula.Key, "CasterHPDamage") == 0) caster.HpDamage = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.HpDamage);
-                            else if (String.Compare(formula.Key, "CasterMPDamage") == 0) caster.MpDamage = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.MpDamage);
-                            else if (String.Compare(formula.Key, "EffectTargetFlags") == 0) target.Flags = (CalcFlag)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)target.Flags);
-                            else if (String.Compare(formula.Key, "HPDamage") == 0) target.HpDamage = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.HpDamage);
-                            else if (String.Compare(formula.Key, "MPDamage") == 0) target.MpDamage = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.MpDamage);
-                            else if (String.Compare(formula.Key, "FigureInfo") == 0) target.Data.fig_info = (UInt16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.Data.fig_info);
-                            else if (String.Compare(formula.Key, "Power") == 0) command.Power = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), command.Power);
-                            else if (String.Compare(formula.Key, "AbilityStatus") == 0) command.AbilityStatus = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)command.AbilityStatus);
-                            else if (String.Compare(formula.Key, "AbilityElement") == 0) command.Element = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)command.Element);
-                            else if (String.Compare(formula.Key, "AbilityElementForBonus") == 0) command.Element = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)command.Element);
-                            else if (String.Compare(formula.Key, "IsShortRanged") == 0) command.IsShortRange = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), command.IsShortRange);
-                            else if (String.Compare(formula.Key, "IsDrain") == 0) context.IsDrain = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), context.IsDrain);
-                            else if (String.Compare(formula.Key, "AbilityCategory") == 0) command.AbilityCategory = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), command.AbilityCategory);
-                            else if (String.Compare(formula.Key, "AbilityFlags") == 0) command.AbilityType = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), command.AbilityType);
-                            else if (String.Compare(formula.Key, "Attack") == 0) context.Attack = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), context.Attack);
-                            else if (String.Compare(formula.Key, "AttackPower") == 0) context.AttackPower = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), context.AttackPower);
-                            else if (String.Compare(formula.Key, "DefencePower") == 0) context.DefensePower = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), context.DefensePower);
-                            else if (String.Compare(formula.Key, "StatusRate") == 0) context.StatusRate = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), context.StatusRate);
-                            else if (String.Compare(formula.Key, "HitRate") == 0) context.HitRate = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), context.HitRate);
-                            else if (String.Compare(formula.Key, "Evade") == 0) context.Evade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), context.Evade);
-                            else if (String.Compare(formula.Key, "EffectFlags") == 0) context.Flags = (BattleCalcFlags)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt16)context.Flags);
-                            else if (String.Compare(formula.Key, "DamageModifierCount") == 0) context.DamageModifierCount = (SByte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), context.DamageModifierCount);
-                            else if (String.Compare(formula.Key, "TranceIncrease") == 0) context.TranceIncrease = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), context.TranceIncrease);
-                            else if (String.Compare(formula.Key, "ItemSteal") == 0) context.ItemSteal = (RegularItem)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Int32)context.ItemSteal);
-                            else if (String.Compare(formula.Key, "Gil") == 0) GameState.Gil = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), GameState.Gil);
-                            else if (String.Compare(formula.Key, "BattleBonusAP") == 0) battle.btl_bonus.ap = (UInt16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), battle.btl_bonus.ap);
-                            else if (String.Compare(formula.Key, "Counter") == 0)
+                            if (String.Equals(formula.Key, "CasterHP")) caster.CurrentHp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.CurrentHp);
+                            else if (String.Equals(formula.Key, "CasterMP")) caster.CurrentMp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.CurrentMp);
+                            else if (String.Equals(formula.Key, "CasterMaxHP")) caster.MaximumHp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.MaximumHp);
+                            else if (String.Equals(formula.Key, "CasterMaxMP")) caster.MaximumMp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.MaximumMp);
+                            else if (String.Equals(formula.Key, "CasterATB")) caster.CurrentAtb = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.CurrentAtb);
+                            else if (String.Equals(formula.Key, "CasterTrance")) caster.Trance = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.Trance);
+                            else if (String.Equals(formula.Key, "CasterCurrentStatus")) cCurStat = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)cCurStat);
+                            else if (String.Equals(formula.Key, "CasterPermanentStatus")) cAutoStat = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)cAutoStat);
+                            else if (String.Equals(formula.Key, "CasterResistStatus")) cResistStat = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)cResistStat);
+                            else if (String.Equals(formula.Key, "CasterHalfElement")) caster.HalfElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)caster.HalfElement);
+                            else if (String.Equals(formula.Key, "CasterGuardElement")) caster.GuardElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)caster.GuardElement);
+                            else if (String.Equals(formula.Key, "CasterAbsorbElement")) caster.AbsorbElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)caster.AbsorbElement);
+                            else if (String.Equals(formula.Key, "CasterWeakElement")) caster.WeakElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)caster.WeakElement);
+                            else if (String.Equals(formula.Key, "CasterBonusElement")) caster.BonusElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)caster.BonusElement);
+                            else if (String.Equals(formula.Key, "CasterSpeed")) caster.Dexterity = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.Dexterity);
+                            else if (String.Equals(formula.Key, "CasterStrength")) caster.Strength = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.Strength);
+                            else if (String.Equals(formula.Key, "CasterMagic")) caster.Magic = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.Magic);
+                            else if (String.Equals(formula.Key, "CasterSpirit")) caster.Will = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.Will);
+                            else if (String.Equals(formula.Key, "CasterDefence")) caster.PhysicalDefence = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.PhysicalDefence);
+                            else if (String.Equals(formula.Key, "CasterEvade")) caster.PhysicalEvade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.PhysicalEvade);
+                            else if (String.Equals(formula.Key, "CasterMagicDefence")) caster.MagicDefence = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.MagicDefence);
+                            else if (String.Equals(formula.Key, "CasterMagicEvade")) caster.MagicEvade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.MagicEvade);
+                            else if (String.Equals(formula.Key, "CasterRow")) caster.Row = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.Row);
+                            else if (String.Equals(formula.Key, "CasterSummonCount")) caster.SummonCount = (UInt16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.SummonCount);
+                            else if (String.Equals(formula.Key, "CasterIsStrengthModified")) caster.StatModifier[0] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), caster.StatModifier[0]);
+                            else if (String.Equals(formula.Key, "CasterIsMagicModified")) caster.StatModifier[1] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), caster.StatModifier[1]);
+                            else if (String.Equals(formula.Key, "CasterIsDefenceModified")) caster.StatModifier[2] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), caster.StatModifier[2]);
+                            else if (String.Equals(formula.Key, "CasterIsEvadeModified")) caster.StatModifier[3] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), caster.StatModifier[3]);
+                            else if (String.Equals(formula.Key, "CasterIsMagicDefenceModified")) caster.StatModifier[4] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), caster.StatModifier[4]);
+                            else if (String.Equals(formula.Key, "CasterIsMagicEvadeModified")) caster.StatModifier[5] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), caster.StatModifier[5]);
+                            else if (String.Equals(formula.Key, "CasterCriticalRateBonus")) caster.CriticalRateBonus = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.CriticalRateBonus);
+                            else if (String.Equals(formula.Key, "CasterCriticalRateWeakening")) caster.CriticalRateWeakening = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.CriticalRateWeakening);
+                            else if (String.Equals(formula.Key, "CasterMaxDamageLimit")) caster.MaxDamageLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.MaxDamageLimit);
+                            else if (String.Equals(formula.Key, "CasterMaxMPDamageLimit")) caster.MaxMpDamageLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.MaxMpDamageLimit);
+                            else if (String.Equals(formula.Key, "CasterBonusExp") && !caster.IsPlayer) caster.Enemy.Data.bonus_exp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.Enemy.Data.bonus_exp);
+                            else if (String.Equals(formula.Key, "CasterBonusGil") && !caster.IsPlayer) caster.Enemy.Data.bonus_gil = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.Enemy.Data.bonus_gil);
+                            else if (String.Equals(formula.Key, "CasterBonusCard") && !caster.IsPlayer) caster.Enemy.Data.bonus_card = (TetraMasterCardId)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Int32)caster.Enemy.Data.bonus_card);
+                            else if (String.Equals(formula.Key, "TargetHP")) target.CurrentHp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.CurrentHp);
+                            else if (String.Equals(formula.Key, "TargetMP")) target.CurrentMp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.CurrentMp);
+                            else if (String.Equals(formula.Key, "TargetMaxHP")) target.MaximumHp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.MaximumHp);
+                            else if (String.Equals(formula.Key, "TargetMaxMP")) target.MaximumMp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.MaximumMp);
+                            else if (String.Equals(formula.Key, "TargetATB")) target.CurrentAtb = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.CurrentAtb);
+                            else if (String.Equals(formula.Key, "TargetTrance")) target.Trance = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.Trance);
+                            else if (String.Equals(formula.Key, "TargetCurrentStatus")) tCurStat = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)tCurStat);
+                            else if (String.Equals(formula.Key, "TargetPermanentStatus")) tAutoStat = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)tAutoStat);
+                            else if (String.Equals(formula.Key, "TargetResistStatus")) tResistStat = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)tResistStat);
+                            else if (String.Equals(formula.Key, "TargetHalfElement")) target.HalfElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)target.HalfElement);
+                            else if (String.Equals(formula.Key, "TargetGuardElement")) target.GuardElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)target.GuardElement);
+                            else if (String.Equals(formula.Key, "TargetAbsorbElement")) target.AbsorbElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)target.AbsorbElement);
+                            else if (String.Equals(formula.Key, "TargetWeakElement")) target.WeakElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)target.WeakElement);
+                            else if (String.Equals(formula.Key, "TargetBonusElement")) target.BonusElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)target.BonusElement);
+                            else if (String.Equals(formula.Key, "TargetSpeed")) target.Dexterity = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.Dexterity);
+                            else if (String.Equals(formula.Key, "TargetStrength")) target.Strength = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.Strength);
+                            else if (String.Equals(formula.Key, "TargetMagic")) target.Magic = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.Magic);
+                            else if (String.Equals(formula.Key, "TargetSpirit")) target.Will = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.Will);
+                            else if (String.Equals(formula.Key, "TargetDefence")) target.PhysicalDefence = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.PhysicalDefence);
+                            else if (String.Equals(formula.Key, "TargetEvade")) target.PhysicalEvade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.PhysicalEvade);
+                            else if (String.Equals(formula.Key, "TargetMagicDefence")) target.MagicDefence = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.MagicDefence);
+                            else if (String.Equals(formula.Key, "TargetMagicEvade")) target.MagicEvade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.MagicEvade);
+                            else if (String.Equals(formula.Key, "TargetRow")) target.Row = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.Row);
+                            else if (String.Equals(formula.Key, "TargetSummonCount")) target.SummonCount = (UInt16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.SummonCount);
+                            else if (String.Equals(formula.Key, "TargetIsStrengthModified")) target.StatModifier[0] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), target.StatModifier[0]);
+                            else if (String.Equals(formula.Key, "TargetIsMagicModified")) target.StatModifier[1] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), target.StatModifier[1]);
+                            else if (String.Equals(formula.Key, "TargetIsDefenceModified")) target.StatModifier[2] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), target.StatModifier[2]);
+                            else if (String.Equals(formula.Key, "TargetIsEvadeModified")) target.StatModifier[3] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), target.StatModifier[3]);
+                            else if (String.Equals(formula.Key, "TargetIsMagicDefenceModified")) target.StatModifier[4] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), target.StatModifier[4]);
+                            else if (String.Equals(formula.Key, "TargetIsMagicEvadeModified")) target.StatModifier[5] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), target.StatModifier[5]);
+                            else if (String.Equals(formula.Key, "TargetCriticalRateBonus")) target.CriticalRateBonus = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.CriticalRateBonus);
+                            else if (String.Equals(formula.Key, "TargetCriticalRateWeakening")) target.CriticalRateWeakening = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.CriticalRateWeakening);
+                            else if (String.Equals(formula.Key, "TargetMaxDamageLimit")) target.MaxDamageLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.MaxDamageLimit);
+                            else if (String.Equals(formula.Key, "TargetMaxMPDamageLimit")) target.MaxMpDamageLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.MaxMpDamageLimit);
+                            else if (String.Equals(formula.Key, "TargetBonusExp") && !target.IsPlayer) target.Enemy.Data.bonus_exp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.Enemy.Data.bonus_exp);
+                            else if (String.Equals(formula.Key, "TargetBonusGil") && !target.IsPlayer) target.Enemy.Data.bonus_gil = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.Enemy.Data.bonus_gil);
+                            else if (String.Equals(formula.Key, "TargetBonusCard") && !target.IsPlayer) target.Enemy.Data.bonus_card = (TetraMasterCardId)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Int32)target.Enemy.Data.bonus_card);
+                            else if (String.Equals(formula.Key, "EffectCasterFlags")) caster.Flags = (CalcFlag)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)caster.Flags);
+                            else if (String.Equals(formula.Key, "CasterHPDamage")) caster.HpDamage = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.HpDamage);
+                            else if (String.Equals(formula.Key, "CasterMPDamage")) caster.MpDamage = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), caster.MpDamage);
+                            else if (String.Equals(formula.Key, "EffectTargetFlags")) target.Flags = (CalcFlag)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)target.Flags);
+                            else if (String.Equals(formula.Key, "HPDamage")) target.HpDamage = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.HpDamage);
+                            else if (String.Equals(formula.Key, "MPDamage")) target.MpDamage = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.MpDamage);
+                            else if (String.Equals(formula.Key, "FigureInfo")) target.Data.fig_info = (UInt16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), target.Data.fig_info);
+                            else if (String.Equals(formula.Key, "Power")) command.Power = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), command.Power);
+                            else if (String.Equals(formula.Key, "AbilityStatus")) command.AbilityStatus = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)command.AbilityStatus);
+                            else if (String.Equals(formula.Key, "AbilityElement")) command.Element = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)command.Element);
+                            else if (String.Equals(formula.Key, "AbilityElementForBonus")) command.Element = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)command.Element);
+                            else if (String.Equals(formula.Key, "IsShortRanged")) command.IsShortRange = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), command.IsShortRange);
+                            else if (String.Equals(formula.Key, "IsDrain")) context.IsDrain = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), context.IsDrain);
+                            else if (String.Equals(formula.Key, "AbilityCategory")) command.AbilityCategory = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), command.AbilityCategory);
+                            else if (String.Equals(formula.Key, "AbilityFlags")) command.AbilityType = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), command.AbilityType);
+                            else if (String.Equals(formula.Key, "Attack")) context.Attack = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), context.Attack);
+                            else if (String.Equals(formula.Key, "AttackPower")) context.AttackPower = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), context.AttackPower);
+                            else if (String.Equals(formula.Key, "DefencePower")) context.DefensePower = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), context.DefensePower);
+                            else if (String.Equals(formula.Key, "StatusRate")) context.StatusRate = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), context.StatusRate);
+                            else if (String.Equals(formula.Key, "HitRate")) context.HitRate = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), context.HitRate);
+                            else if (String.Equals(formula.Key, "Evade")) context.Evade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), context.Evade);
+                            else if (String.Equals(formula.Key, "EffectFlags")) context.Flags = (BattleCalcFlags)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt16)context.Flags);
+                            else if (String.Equals(formula.Key, "DamageModifierCount")) context.DamageModifierCount = (SByte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), context.DamageModifierCount);
+                            else if (String.Equals(formula.Key, "TranceIncrease")) context.TranceIncrease = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), context.TranceIncrease);
+                            else if (String.Equals(formula.Key, "ItemSteal")) context.ItemSteal = (RegularItem)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Int32)context.ItemSteal);
+                            else if (String.Equals(formula.Key, "Gil")) GameState.Gil = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), GameState.Gil);
+                            else if (String.Equals(formula.Key, "BattleBonusAP")) battle.btl_bonus.ap = (UInt16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), battle.btl_bonus.ap);
+                            else if (String.Equals(formula.Key, "Counter"))
                             {
+                                List<Expression> allArgs = new List<Expression>(formulaSplit.Length);
+                                allArgs.Add(e);
+                                for (Int32 argi = 1; argi < formulaSplit.Length; argi++)
+                                {
+                                    Expression arge = new Expression(formulaSplit[argi]);
+                                    NCalcUtility.InitializeExpressionUnit(ref arge, caster, "Caster");
+                                    NCalcUtility.InitializeExpressionUnit(ref arge, target, "Target");
+                                    NCalcUtility.InitializeExpressionAbilityContext(ref arge, calc);
+                                    arge.EvaluateFunction += NCalcUtility.commonNCalcFunctions;
+                                    arge.EvaluateParameter += NCalcUtility.commonNCalcParameters;
+                                    allArgs.Add(arge);
+                                }
                                 Int32 attackId = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Int32)BattleAbilityId.Attack);
-                                if (attackId == (Int32)BattleAbilityId.Void && !EnableAsEnemy && !EnableAsMonsterTransform)
+                                BattleCommandId counterCmd = EnableAsEnemy || EnableAsMonsterTransform ? BattleCommandId.EnemyCounter : BattleCommandId.Counter;
+                                if (allArgs.Count > 1)
+                                    counterCmd = (BattleCommandId)NCalcUtility.ConvertNCalcResult(allArgs[1].Evaluate(), (Int32)BattleCommandId.Counter);
+                                if (attackId == (Int32)BattleAbilityId.Void && counterCmd != BattleCommandId.EnemyCounter && counterCmd != BattleCommandId.MagicCounter)
                                     continue;
                                 BTL_DATA counterer = asTarget ? target.Data : caster.Data;
                                 UInt16 countered = asTarget ? caster.Id : target.Id;
-                                if (EnableAsEnemy || EnableAsMonsterTransform)
-                                    btl_cmd.SetCounter(counterer, BattleCommandId.EnemyCounter, attackId, countered);
-                                else
-                                    btl_cmd.SetCounter(counterer, BattleCommandId.Counter, attackId, countered);
+                                if (allArgs.Count > 2)
+                                    countered = (UInt16)NCalcUtility.ConvertNCalcResult(allArgs[2].Evaluate(), 0);
+                                if (allArgs.Count > 3)
+                                {
+                                    UInt16 countererId = (UInt16)NCalcUtility.ConvertNCalcResult(allArgs[3].Evaluate(), 0);
+                                    if (countererId == 0)
+                                        continue;
+                                    counterer = btl_scrp.FindBattleUnit((UInt16)Comn.firstBitSet(countererId))?.Data ?? null;
+                                    if (counterer == null)
+                                        continue;
+                                }
+                                btl_cmd.SetCounter(counterer, counterCmd, attackId, countered);
                             }
-                            else if (String.Compare(formula.Key, "ReturnMagic") == 0)
+                            else if (String.Equals(formula.Key, "ReturnMagic"))
                             {
                                 //NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Int32)BattleAbilityId.Attack);
                                 if (asTarget)
@@ -462,7 +488,7 @@ namespace Memoria.Data
                                 else
                                     btl_abil.TryReturnMagic(caster, target, command);
                             }
-                            else if (String.Compare(formula.Key, "AutoItem") == 0)
+                            else if (String.Equals(formula.Key, "AutoItem"))
                             {
                                 BTL_DATA counterer = asTarget ? target.Data : caster.Data;
                                 if (counterer.is_monster_transform && counterer.monster_transform.disable_commands.Contains(BattleCommandId.Item))
@@ -553,58 +579,58 @@ namespace Memoria.Data
                             e.Parameters["AreCasterAndTargetAllies"] = caster != null && (caster.IsPlayer && (command.Data.tar_id & 0xF) == command.Data.tar_id || !caster.IsPlayer && (command.Data.tar_id & 0x0F) == command.Data.tar_id);
                             e.EvaluateFunction += NCalcUtility.commonNCalcFunctions;
                             e.EvaluateParameter += NCalcUtility.commonNCalcParameters;
-                            if (String.Compare(formula.Key, "Power") == 0) command.Power = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), command.Power);
-                            else if (String.Compare(formula.Key, "AbilityStatus") == 0) command.AbilityStatus = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)command.AbilityStatus);
-                            else if (String.Compare(formula.Key, "AbilityElement") == 0) command.Element = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)command.Element);
-                            else if (String.Compare(formula.Key, "AbilityElementForBonus") == 0) command.Element = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)command.Element);
-                            else if (String.Compare(formula.Key, "IsShortRanged") == 0) command.IsShortRange = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), command.IsShortRange);
-                            else if (String.Compare(formula.Key, "AbilityCategory") == 0) command.AbilityCategory = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), command.AbilityCategory);
-                            else if (String.Compare(formula.Key, "AbilityFlags") == 0) command.AbilityType = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), command.AbilityType);
-                            else if (String.Compare(formula.Key, "IsReflectNull") == 0) command.IsReflectNull = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), command.IsReflectNull);
-                            else if (String.Compare(formula.Key, "IsMeteorMiss") == 0) command.Data.info.meteor_miss = (Byte)(NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), command.IsReflectNull) ? 1 : 0);
-                            else if (String.Compare(formula.Key, "IsShortSummon") == 0) command.IsShortSummon = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), command.IsShortSummon);
-                            else if (String.Compare(formula.Key, "TryCover") == 0) tryCover |= NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), false) ? abilityUser.Id : (UInt16)0;
-                            else if (String.Compare(formula.Key, "ScriptId") == 0) command.ScriptId = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), command.ScriptId);
-                            else if (String.Compare(formula.Key, "HitRate") == 0) command.HitRate = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), command.HitRate);
-                            else if (String.Compare(formula.Key, "CommandTargetId") == 0) command.Data.tar_id = (UInt16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), command.Data.tar_id);
-                            else if (String.Compare(formula.Key, "HP") == 0) abilityUser.CurrentHp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.CurrentHp);
-                            else if (String.Compare(formula.Key, "MP") == 0) abilityUser.CurrentMp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.CurrentMp);
-                            else if (String.Compare(formula.Key, "MaxHP") == 0) abilityUser.MaximumHp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.MaximumHp);
-                            else if (String.Compare(formula.Key, "MaxMP") == 0) abilityUser.MaximumMp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.MaximumMp);
-                            else if (String.Compare(formula.Key, "ATB") == 0) abilityUser.CurrentAtb = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.CurrentAtb);
-                            else if (String.Compare(formula.Key, "Trance") == 0) abilityUser.Trance = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.Trance);
-                            else if (String.Compare(formula.Key, "CurrentStatus") == 0) uCurStat = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)uCurStat);
-                            else if (String.Compare(formula.Key, "PermanentStatus") == 0) uAutoStat = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)uAutoStat);
-                            else if (String.Compare(formula.Key, "ResistStatus") == 0) uResistStat = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)uResistStat);
-                            else if (String.Compare(formula.Key, "HalfElement") == 0) abilityUser.HalfElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)abilityUser.HalfElement);
-                            else if (String.Compare(formula.Key, "GuardElement") == 0) abilityUser.GuardElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)abilityUser.GuardElement);
-                            else if (String.Compare(formula.Key, "AbsorbElement") == 0) abilityUser.AbsorbElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)abilityUser.AbsorbElement);
-                            else if (String.Compare(formula.Key, "WeakElement") == 0) abilityUser.WeakElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)abilityUser.WeakElement);
-                            else if (String.Compare(formula.Key, "BonusElement") == 0) abilityUser.BonusElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)abilityUser.BonusElement);
-                            else if (String.Compare(formula.Key, "Speed") == 0) abilityUser.Dexterity = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.Dexterity);
-                            else if (String.Compare(formula.Key, "Strength") == 0) abilityUser.Strength = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.Strength);
-                            else if (String.Compare(formula.Key, "Magic") == 0) abilityUser.Magic = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.Magic);
-                            else if (String.Compare(formula.Key, "Spirit") == 0) abilityUser.Will = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.Will);
-                            else if (String.Compare(formula.Key, "Defence") == 0) abilityUser.PhysicalDefence = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.PhysicalDefence);
-                            else if (String.Compare(formula.Key, "Evade") == 0) abilityUser.PhysicalEvade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.PhysicalEvade);
-                            else if (String.Compare(formula.Key, "MagicDefence") == 0) abilityUser.MagicDefence = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.MagicDefence);
-                            else if (String.Compare(formula.Key, "MagicEvade") == 0) abilityUser.MagicEvade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.MagicEvade);
-                            else if (String.Compare(formula.Key, "Row") == 0) abilityUser.Row = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.Row);
-                            else if (String.Compare(formula.Key, "IsStrengthModified") == 0) abilityUser.StatModifier[0] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), abilityUser.StatModifier[0]);
-                            else if (String.Compare(formula.Key, "IsMagicModified") == 0) abilityUser.StatModifier[1] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), abilityUser.StatModifier[1]);
-                            else if (String.Compare(formula.Key, "IsDefenceModified") == 0) abilityUser.StatModifier[2] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), abilityUser.StatModifier[2]);
-                            else if (String.Compare(formula.Key, "IsEvadeModified") == 0) abilityUser.StatModifier[3] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), abilityUser.StatModifier[3]);
-                            else if (String.Compare(formula.Key, "IsMagicDefenceModified") == 0) abilityUser.StatModifier[4] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), abilityUser.StatModifier[4]);
-                            else if (String.Compare(formula.Key, "IsMagicEvadeModified") == 0) abilityUser.StatModifier[5] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), abilityUser.StatModifier[5]);
-                            else if (String.Compare(formula.Key, "CriticalRateBonus") == 0) abilityUser.CriticalRateBonus = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.CriticalRateBonus);
-                            else if (String.Compare(formula.Key, "CriticalRateWeakening") == 0) abilityUser.CriticalRateWeakening = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.CriticalRateWeakening);
-                            else if (String.Compare(formula.Key, "MaxDamageLimit") == 0) abilityUser.MaxDamageLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.MaxDamageLimit);
-                            else if (String.Compare(formula.Key, "MaxMPDamageLimit") == 0) abilityUser.MaxMpDamageLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.MaxMpDamageLimit);
-                            else if (String.Compare(formula.Key, "BonusExp") == 0 && !abilityUser.IsPlayer) abilityUser.Enemy.Data.bonus_exp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.Enemy.Data.bonus_exp);
-                            else if (String.Compare(formula.Key, "BonusGil") == 0 && !abilityUser.IsPlayer) abilityUser.Enemy.Data.bonus_gil = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.Enemy.Data.bonus_gil);
-                            else if (String.Compare(formula.Key, "BonusCard") == 0 && !abilityUser.IsPlayer) abilityUser.Enemy.Data.bonus_card = (TetraMasterCardId)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Int32)abilityUser.Enemy.Data.bonus_card);
-                            else if (String.Compare(formula.Key, "BattleBonusAP") == 0) battle.btl_bonus.ap = (UInt16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), battle.btl_bonus.ap);
-                            else if (String.Compare(formula.Key, "Counter") == 0)
+                            if (String.Equals(formula.Key, "Power")) command.Power = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), command.Power);
+                            else if (String.Equals(formula.Key, "AbilityStatus")) command.AbilityStatus = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)command.AbilityStatus);
+                            else if (String.Equals(formula.Key, "AbilityElement")) command.Element = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)command.Element);
+                            else if (String.Equals(formula.Key, "AbilityElementForBonus")) command.Element = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)command.Element);
+                            else if (String.Equals(formula.Key, "IsShortRanged")) command.IsShortRange = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), command.IsShortRange);
+                            else if (String.Equals(formula.Key, "AbilityCategory")) command.AbilityCategory = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), command.AbilityCategory);
+                            else if (String.Equals(formula.Key, "AbilityFlags")) command.AbilityType = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), command.AbilityType);
+                            else if (String.Equals(formula.Key, "IsReflectNull")) command.IsReflectNull = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), command.IsReflectNull);
+                            else if (String.Equals(formula.Key, "IsMeteorMiss")) command.Data.info.meteor_miss = (Byte)(NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), command.IsReflectNull) ? 1 : 0);
+                            else if (String.Equals(formula.Key, "IsShortSummon")) command.IsShortSummon = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), command.IsShortSummon);
+                            else if (String.Equals(formula.Key, "TryCover")) tryCover |= NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), false) ? abilityUser.Id : (UInt16)0;
+                            else if (String.Equals(formula.Key, "ScriptId")) command.ScriptId = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), command.ScriptId);
+                            else if (String.Equals(formula.Key, "HitRate")) command.HitRate = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), command.HitRate);
+                            else if (String.Equals(formula.Key, "CommandTargetId")) command.Data.tar_id = (UInt16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), command.Data.tar_id);
+                            else if (String.Equals(formula.Key, "HP")) abilityUser.CurrentHp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.CurrentHp);
+                            else if (String.Equals(formula.Key, "MP")) abilityUser.CurrentMp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.CurrentMp);
+                            else if (String.Equals(formula.Key, "MaxHP")) abilityUser.MaximumHp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.MaximumHp);
+                            else if (String.Equals(formula.Key, "MaxMP")) abilityUser.MaximumMp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.MaximumMp);
+                            else if (String.Equals(formula.Key, "ATB")) abilityUser.CurrentAtb = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.CurrentAtb);
+                            else if (String.Equals(formula.Key, "Trance")) abilityUser.Trance = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.Trance);
+                            else if (String.Equals(formula.Key, "CurrentStatus")) uCurStat = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)uCurStat);
+                            else if (String.Equals(formula.Key, "PermanentStatus")) uAutoStat = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)uAutoStat);
+                            else if (String.Equals(formula.Key, "ResistStatus")) uResistStat = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)uResistStat);
+                            else if (String.Equals(formula.Key, "HalfElement")) abilityUser.HalfElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)abilityUser.HalfElement);
+                            else if (String.Equals(formula.Key, "GuardElement")) abilityUser.GuardElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)abilityUser.GuardElement);
+                            else if (String.Equals(formula.Key, "AbsorbElement")) abilityUser.AbsorbElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)abilityUser.AbsorbElement);
+                            else if (String.Equals(formula.Key, "WeakElement")) abilityUser.WeakElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)abilityUser.WeakElement);
+                            else if (String.Equals(formula.Key, "BonusElement")) abilityUser.BonusElement = (EffectElement)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Byte)abilityUser.BonusElement);
+                            else if (String.Equals(formula.Key, "Speed")) abilityUser.Dexterity = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.Dexterity);
+                            else if (String.Equals(formula.Key, "Strength")) abilityUser.Strength = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.Strength);
+                            else if (String.Equals(formula.Key, "Magic")) abilityUser.Magic = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.Magic);
+                            else if (String.Equals(formula.Key, "Spirit")) abilityUser.Will = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.Will);
+                            else if (String.Equals(formula.Key, "Defence")) abilityUser.PhysicalDefence = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.PhysicalDefence);
+                            else if (String.Equals(formula.Key, "Evade")) abilityUser.PhysicalEvade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.PhysicalEvade);
+                            else if (String.Equals(formula.Key, "MagicDefence")) abilityUser.MagicDefence = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.MagicDefence);
+                            else if (String.Equals(formula.Key, "MagicEvade")) abilityUser.MagicEvade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.MagicEvade);
+                            else if (String.Equals(formula.Key, "Row")) abilityUser.Row = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.Row);
+                            else if (String.Equals(formula.Key, "IsStrengthModified")) abilityUser.StatModifier[0] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), abilityUser.StatModifier[0]);
+                            else if (String.Equals(formula.Key, "IsMagicModified")) abilityUser.StatModifier[1] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), abilityUser.StatModifier[1]);
+                            else if (String.Equals(formula.Key, "IsDefenceModified")) abilityUser.StatModifier[2] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), abilityUser.StatModifier[2]);
+                            else if (String.Equals(formula.Key, "IsEvadeModified")) abilityUser.StatModifier[3] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), abilityUser.StatModifier[3]);
+                            else if (String.Equals(formula.Key, "IsMagicDefenceModified")) abilityUser.StatModifier[4] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), abilityUser.StatModifier[4]);
+                            else if (String.Equals(formula.Key, "IsMagicEvadeModified")) abilityUser.StatModifier[5] = NCalcUtility.EvaluateNCalcCondition(e.Evaluate(), abilityUser.StatModifier[5]);
+                            else if (String.Equals(formula.Key, "CriticalRateBonus")) abilityUser.CriticalRateBonus = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.CriticalRateBonus);
+                            else if (String.Equals(formula.Key, "CriticalRateWeakening")) abilityUser.CriticalRateWeakening = (Int16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.CriticalRateWeakening);
+                            else if (String.Equals(formula.Key, "MaxDamageLimit")) abilityUser.MaxDamageLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.MaxDamageLimit);
+                            else if (String.Equals(formula.Key, "MaxMPDamageLimit")) abilityUser.MaxMpDamageLimit = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.MaxMpDamageLimit);
+                            else if (String.Equals(formula.Key, "BonusExp") && !abilityUser.IsPlayer) abilityUser.Enemy.Data.bonus_exp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.Enemy.Data.bonus_exp);
+                            else if (String.Equals(formula.Key, "BonusGil") && !abilityUser.IsPlayer) abilityUser.Enemy.Data.bonus_gil = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), abilityUser.Enemy.Data.bonus_gil);
+                            else if (String.Equals(formula.Key, "BonusCard") && !abilityUser.IsPlayer) abilityUser.Enemy.Data.bonus_card = (TetraMasterCardId)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Int32)abilityUser.Enemy.Data.bonus_card);
+                            else if (String.Equals(formula.Key, "BattleBonusAP")) battle.btl_bonus.ap = (UInt16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), battle.btl_bonus.ap);
+                            else if (String.Equals(formula.Key, "Counter"))
                             {
                                 Int32 attackId = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Int32)BattleAbilityId.Attack);
                                 if (attackId == (Int32)BattleAbilityId.Void && !EnableAsEnemy && !EnableAsMonsterTransform)
@@ -649,19 +675,19 @@ namespace Memoria.Data
                 else
                     endPos = codeMatches[i + 1].Groups[1].Captures[0].Index;
                 String saArgs = featureCode.Substring(startPos, endPos - startPos);
-                if (String.Compare(saCode, "Permanent") == 0)
+                if (String.Equals(saCode, "Permanent"))
                 {
                     SupportingAbilityEffectPermanent newEffect = new SupportingAbilityEffectPermanent();
                     foreach (Match formula in new Regex(@"\[code=(.*?)\](.*?)\[/code\]").Matches(saArgs))
                     {
-                        if (String.Compare(formula.Groups[1].Value, "Condition") == 0)
+                        if (String.Equals(formula.Groups[1].Value, "Condition"))
                             newEffect.Condition = formula.Groups[2].Value;
                         else
                             newEffect.Formula[formula.Groups[1].Value] = formula.Groups[2].Value;
                     }
                     PermanentEffect.Add(newEffect);
                 }
-                else if (String.Compare(saCode, "BattleStart") == 0)
+                else if (String.Equals(saCode, "BattleStart"))
                 {
                     SupportingAbilityEffectBattleStartType newEffect = new SupportingAbilityEffectBattleStartType();
                     Match priorityDelta = new Regex(@"\bPreemptivePriority\s+([\+-]?\d+)").Match(saArgs);
@@ -669,14 +695,14 @@ namespace Memoria.Data
                         Int32.TryParse(priorityDelta.Groups[1].Value, out newEffect.PreemptivePriorityDelta);
                     foreach (Match formula in new Regex(@"\[code=(.*?)\](.*?)\[/code\]").Matches(saArgs))
                     {
-                        if (String.Compare(formula.Groups[1].Value, "Condition") == 0)
+                        if (String.Equals(formula.Groups[1].Value, "Condition"))
                             newEffect.Condition = formula.Groups[2].Value;
                         else
                             newEffect.Formula[formula.Groups[1].Value] = formula.Groups[2].Value;
                     }
                     BattleStartEffect.Add(newEffect);
                 }
-                else if (String.Compare(saCode, "BattleResult") == 0)
+                else if (String.Equals(saCode, "BattleResult"))
                 {
                     SupportingAbilityEffectBattleResult newEffect = new SupportingAbilityEffectBattleResult();
                     Match when = new Regex(@"\bWhen(\w+)\b").Match(saArgs);
@@ -684,20 +710,20 @@ namespace Memoria.Data
                         newEffect.When = when.Groups[1].Value;
                     foreach (Match formula in new Regex(@"\[code=(.*?)\](.*?)\[/code\]").Matches(saArgs))
                     {
-                        if (String.Compare(formula.Groups[1].Value, "Condition") == 0)
+                        if (String.Equals(formula.Groups[1].Value, "Condition"))
                             newEffect.Condition = formula.Groups[2].Value;
                         else
                             newEffect.Formula[formula.Groups[1].Value] = formula.Groups[2].Value;
                     }
                     BattleResultEffect.Add(newEffect);
                 }
-                else if (String.Compare(saCode, "StatusInit") == 0)
+                else if (String.Equals(saCode, "StatusInit"))
                 {
                     SupportingAbilityEffectBattleInitStatus newEffect = new SupportingAbilityEffectBattleInitStatus();
                     foreach (Match formula in new Regex(@"\[code=(.*?)\](.*?)\[/code\]").Matches(saArgs))
                     {
                         String codeName = formula.Groups[1].Value;
-                        if (String.Compare(codeName, "Condition") == 0)
+                        if (String.Equals(codeName, "Condition"))
                         {
                             newEffect.Condition = formula.Groups[2].Value;
                         }
@@ -714,7 +740,7 @@ namespace Memoria.Data
                     }
                     foreach (Match statusMatch in new Regex(@"\b((Auto|Initial|Resist)Status|InitialATB)\s+(\w+|\d+)\b").Matches(saArgs))
                     {
-                        if (String.Compare(statusMatch.Groups[1].Value, "InitialATB") == 0)
+                        if (String.Equals(statusMatch.Groups[1].Value, "InitialATB"))
                         {
                             Int32.TryParse(statusMatch.Groups[3].Value, out newEffect.InitialATB);
                         }
@@ -722,18 +748,18 @@ namespace Memoria.Data
                         {
                             if (statusMatch.Groups[3].Value.TryEnumParse(out BattleStatus status))
                             {
-                                if (String.Compare(statusMatch.Groups[2].Value, "Auto") == 0)
+                                if (String.Equals(statusMatch.Groups[2].Value, "Auto"))
                                     newEffect.PermanentStatus |= status;
-                                else if (String.Compare(statusMatch.Groups[2].Value, "Initial") == 0)
+                                else if (String.Equals(statusMatch.Groups[2].Value, "Initial"))
                                     newEffect.InitialStatus |= status;
-                                else if (String.Compare(statusMatch.Groups[2].Value, "Resist") == 0)
+                                else if (String.Equals(statusMatch.Groups[2].Value, "Resist"))
                                     newEffect.ResistStatus |= status;
                             }
                         }
                     }
                     StatusEffect.Add(newEffect);
                 }
-                else if (String.Compare(saCode, "Ability") == 0)
+                else if (String.Equals(saCode, "Ability"))
                 {
                     SupportingAbilityEffectAbilityUse newEffect = new SupportingAbilityEffectAbilityUse();
                     Match when = new Regex(@"\bWhen(\w+)\b").Match(saArgs);
@@ -741,7 +767,7 @@ namespace Memoria.Data
                         newEffect.When = when.Groups[1].Value;
                     foreach (Match effect in new Regex(@"\[code=(.*?)\](.*?)\[/code\]").Matches(saArgs))
                     {
-                        if (String.Compare(effect.Groups[1].Value, "Condition") == 0)
+                        if (String.Equals(effect.Groups[1].Value, "Condition"))
                             newEffect.Condition = effect.Groups[2].Value;
                         else
                             newEffect.Effect[effect.Groups[1].Value] = effect.Groups[2].Value;
@@ -756,12 +782,12 @@ namespace Memoria.Data
                                 newEffect.DisableSA.Add((SupportAbility)saValue);
                     AbilityEffect.Add(newEffect);
                 }
-                else if (String.Compare(saCode, "Command") == 0)
+                else if (String.Equals(saCode, "Command"))
                 {
                     SupportingAbilityEffectCommandStart newEffect = new SupportingAbilityEffectCommandStart();
                     foreach (Match effect in new Regex(@"\[code=(.*?)\](.*?)\[/code\]").Matches(saArgs))
                     {
-                        if (String.Compare(effect.Groups[1].Value, "Condition") == 0)
+                        if (String.Equals(effect.Groups[1].Value, "Condition"))
                             newEffect.Condition = effect.Groups[2].Value;
                         else
                             newEffect.Effect[effect.Groups[1].Value] = effect.Groups[2].Value;
@@ -769,11 +795,11 @@ namespace Memoria.Data
                     if (new Regex(@"\bEvenImmobilized\b").Match(saArgs).Success) newEffect.EvenImmobilized = true;
                     CommandEffect.Add(newEffect);
                 }
-                else if (String.Compare(saCode, "EnemyFeature") == 0)
+                else if (String.Equals(saCode, "EnemyFeature"))
 				{
                     EnableAsEnemy = true;
                 }
-                else if (String.Compare(saCode, "MorphFeature") == 0)
+                else if (String.Equals(saCode, "MorphFeature"))
                 {
                     EnableAsMonsterTransform = true;
                 }

--- a/Assembly-CSharp/Memoria/Data/ff9abil.cs
+++ b/Assembly-CSharp/Memoria/Data/ff9abil.cs
@@ -421,13 +421,13 @@ namespace FF9
             for (Int32 i = 0; i < abilMatches.Count; i++)
 			{
                 Int32 abilIndex;
-                if (String.Compare(abilMatches[i].Groups[2].Value, "Global") == 0)
+                if (String.Equals(abilMatches[i].Groups[2].Value, "Global"))
                     abilIndex = -1;
-                else if (String.Compare(abilMatches[i].Groups[2].Value, "GlobalLast") == 0)
+                else if (String.Equals(abilMatches[i].Groups[2].Value, "GlobalLast"))
                     abilIndex = -2;
-                else if (String.Compare(abilMatches[i].Groups[2].Value, "GlobalEnemy") == 0)
+                else if (String.Equals(abilMatches[i].Groups[2].Value, "GlobalEnemy"))
                     abilIndex = -3;
-                else if (String.Compare(abilMatches[i].Groups[2].Value, "GlobalEnemyLast") == 0)
+                else if (String.Equals(abilMatches[i].Groups[2].Value, "GlobalEnemyLast"))
                     abilIndex = -4;
                 else if (!Int32.TryParse(abilMatches[i].Groups[2].Value, out abilIndex))
                     continue;
@@ -443,11 +443,20 @@ namespace FF9
                         entries[(SupportAbility)abilIndex] = new SupportingAbilityFeature();
                     entries[(SupportAbility)abilIndex].ParseFeatures((SupportAbility)abilIndex, input.Substring(startPos, endPos - startPos));
                 }
-                else if (abilIndex >= 0)
+                else
 				{
-                    if (!cumulate)
-                        BattleAbilityHelper.ClearAbilityFeature((BattleAbilityId)abilIndex);
-                    BattleAbilityHelper.ParseAbilityFeature((BattleAbilityId)abilIndex, input.Substring(startPos, endPos - startPos));
+                    if (abilIndex > 0)
+                    {
+                        if (!cumulate)
+                            BattleAbilityHelper.ClearAbilityFeature((BattleAbilityId)abilIndex);
+                        BattleAbilityHelper.ParseAbilityFeature((BattleAbilityId)abilIndex, input.Substring(startPos, endPos - startPos));
+                    }
+                    else if (abilIndex == -1)
+                    {
+                        if (!cumulate)
+                            BattleAbilityHelper.ClearFlexibleAbilityFeature();
+                        BattleAbilityHelper.ParseAbilityFeature(input.Substring(startPos, endPos - startPos));
+                    }
                 }
             }
 		}

--- a/Assembly-CSharp/NCalc/NCalcUtility.cs
+++ b/Assembly-CSharp/NCalc/NCalcUtility.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Reflection;
-using System.Collections.Generic;
-using System.Linq;
-using FF9;
+﻿using FF9;
 using Memoria;
 using Memoria.Data;
 using Memoria.Prime.Text;
-using static SFX;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 
 // NCalc source code embedded in Assembly-CSharp.dll for avoiding a DLL dependency
 // Original author of NCalc: sebastienros, https://archive.codeplex.com/?p=ncalc
@@ -14,7 +13,7 @@ using static SFX;
 
 namespace NCalc
 {
-	public static class NCalcUtility
+    public static class NCalcUtility
     {
         public static readonly Type[] UsableEnumTypes = new Type[]
         {
@@ -92,7 +91,7 @@ namespace NCalc
             else if (name == "GetItemCount" && args.Parameters.Length == 1)
                 args.Result = GameState.ItemCount((RegularItem)NCalcUtility.ConvertNCalcResult(args.Parameters[0].Evaluate(), (Int32)RegularItem.NoItem));
             else if (name == "GetItemProperty" && args.Parameters.Length == 2)
-                args.Result = ff9item.GetItemProperty((RegularItem)NCalcUtility.ConvertNCalcResult(args.Parameters[0].Evaluate(), (Int32)RegularItem.NoItem), NCalcUtility.EvaluateNCalcString(args.Parameters[1].Evaluate(), ""));
+                args.Result = ff9item.GetItemProperty((RegularItem)NCalcUtility.ConvertNCalcResult(args.Parameters[0].Evaluate(), (Int32)RegularItem.NoItem), NCalcUtility.EvaluateNCalcString(args.Parameters[1].Evaluate(), "Invalid"));
             else if (name == "GetPartyMemberLevel" && args.Parameters.Length == 1)
                 args.Result = GameState.PartyLevel((Int32)NCalcUtility.ConvertNCalcResult(args.Parameters[0].Evaluate(), -1));
             else if (name == "GetPartyMemberIndex" && args.Parameters.Length == 1)

--- a/Assembly-CSharp/NCalc/NCalcUtility.cs
+++ b/Assembly-CSharp/NCalc/NCalcUtility.cs
@@ -145,6 +145,17 @@ namespace NCalc
                 BattleUnit killer = killed?.GetKiller();
                 args.Result = killer != null && killer.Id == killerId;
             }
+            else if (name == "BattleUnitFilter" && args.Parameters.Length >= 1)
+            {
+                UInt16 filterId = 0;
+                foreach (BattleUnit btlUnit in FF9StateSystem.Battle.FF9Battle.EnumerateBattleUnits())
+                {
+                    NCalcUtility.InitializeExpressionUnit(ref args.Parameters[0], btlUnit, "Candidate");
+                    if (NCalcUtility.EvaluateNCalcCondition(args.Parameters[0].Evaluate(), false))
+                        filterId |= btlUnit.Id;
+                }
+                args.Result = filterId;
+            }
             else if (name == "BattleFilter" && args.Parameters.Length >= 1)
             {
                 UInt16 btlId = (UInt16)NCalcUtility.ConvertNCalcResult(args.Parameters[0].Evaluate(), 0);
@@ -321,6 +332,7 @@ namespace NCalc
         {
             ENEMY enemy = unit.IsPlayer ? null : unit.Enemy.Data;
             expr.Parameters[prefix + "Name"] = unit.Name;
+            expr.Parameters[prefix + "BattleId"] = (Int32)unit.Id;
             expr.Parameters[prefix + "MaxHP"] = unit.MaximumHp;
             expr.Parameters[prefix + "MaxMP"] = unit.MaximumMp;
             expr.Parameters[prefix + "MaxATB"] = (Int32)unit.MaximumAtb;
@@ -406,6 +418,7 @@ namespace NCalc
                 return;
             }
             expr.Parameters[prefix + "Name"] = String.Empty;
+            expr.Parameters[prefix + "BattleId"] = 0;
             expr.Parameters[prefix + "MaxHP"] = 0;
             expr.Parameters[prefix + "MaxMP"] = 0;
             expr.Parameters[prefix + "MaxATB"] = 0;


### PR DESCRIPTION
This PR's original purpose is to allow the possibility to change MP Cost of either the first ability menu or the second ability menu. In order to add flexibility, it improves the [AA features](https://github.com/Albeoris/Memoria/wiki/Active-ability-features) (action ability features that can be set in ``AbilityFeatures.txt``) and a couple of other things:
- Add ``[code=MPCost]`` to the possible ability features, so you can change the MP cost of specific abilities in specific situations.
- AA features can now be conditional, except for the feature ``Patch``.
- Add multiple NCalc options and property accesses.
- Add a way to use ``>AA Global+`` to apply AA features to non-specific abilities but use in the situation determined by ``[code=Condition]`` instead, similar to ``>SA Global+`` for SA features not tied to a specific supporting ability.
For example, the following lines decrease the MP Cost of the abilities in the 1st command menu if the character has Extension equipped:
```
>AA Global+
[code=Condition] CommandMenu == BattleCommandMenu_Ability1 && MPCost > 0 && CasterAccessoryId == RegularItem_Extension [/code]
[code=MPCost] MPCost / 2 [/code]
```

Also, since it is based on a part of DV's PR #393, the following changes that were in the related files are done:
- Fix the name of enemies with Scan when there name use tags (eg. Epitaph summons).
- Add NCalc properties ``MPCost`` and ``CommandMenu`` but also ``BattleGroupIndex`` and ``GetItemProperty``.

**Edit:** ``GetItemProperty`` is a bit more flexible now. Here's an example of what can be done with it:
```
>AA Global+
[code=Condition] CasterHasSA(29) && GetItemProperty( CasterWeaponId, 'HasActiveAbility ' + AbilityId ) [/code]
[code=MPCost] 0 [/code]
```
With this feature, the supporting ability 29 (Power Up by default) gets an additional effect of removing the MP cost of the abilities taught by the claws that are currently equipped.