### PR TITLE
Fix text shadow issue #397

### DIFF
--- a/Assembly-CSharp/Memoria/Assets/Text/Dialogs/DialogBoxRenderer.cs
+++ b/Assembly-CSharp/Memoria/Assets/Text/Dialogs/DialogBoxRenderer.cs
@@ -1,5 +1,5 @@
-using System;
 using Assets.Sources.Scripts.UI.Common;
+using System;
 using UnityEngine;
 
 namespace Memoria.Assets
@@ -247,7 +247,7 @@ namespace Memoria.Assets
             else if (tag == NGUIText.Shadow)
             {
                 closingBracket = Array.IndexOf(text, ']', index + 4);
-                highShadow = !highShadow;
+                highShadow = !highShadow; // The tag seems to be used as a toogle (see issue #397)
             }
             else if (tag == NGUIText.NoShadow)
             {

--- a/Assembly-CSharp/Memoria/Assets/Text/Dialogs/DialogBoxRenderer.cs
+++ b/Assembly-CSharp/Memoria/Assets/Text/Dialogs/DialogBoxRenderer.cs
@@ -247,7 +247,7 @@ namespace Memoria.Assets
             else if (tag == NGUIText.Shadow)
             {
                 closingBracket = Array.IndexOf(text, ']', index + 4);
-                highShadow = !highShadow; // The tag seems to be used as a toogle (see issue #397)
+                highShadow = !highShadow; // The tag seems to be used as a toggle (see issue #397)
             }
             else if (tag == NGUIText.NoShadow)
             {

--- a/Assembly-CSharp/Memoria/Assets/Text/Dialogs/DialogBoxRenderer.cs
+++ b/Assembly-CSharp/Memoria/Assets/Text/Dialogs/DialogBoxRenderer.cs
@@ -247,7 +247,7 @@ namespace Memoria.Assets
             else if (tag == NGUIText.Shadow)
             {
                 closingBracket = Array.IndexOf(text, ']', index + 4);
-                highShadow = true;
+                highShadow = !highShadow;
             }
             else if (tag == NGUIText.NoShadow)
             {


### PR DESCRIPTION
The [HSHD] tag seems to be used to toggle the high shadow on and off rather than just toggle it on.
I haven't seen the [NSHD] tag used to toggle the shadow off.

> [STRT=173,3][TAIL=LOLF]Short Guard
> “You need a [C8B040][HSHD]Gate Pass[C8C8C8][HSHD] to
>  reach the South Gate summit.”

> [STRT=142,4][TAIL=UPRF][WDTH=0,120,18,-1][DGGR]
> “You have to call me [DGGR]
>  until we reach [68C0D8][HSHD]Treno[C8C8C8][HSHD].
>  Don’t salute me, either.”

With the fix:
![image](https://github.com/Albeoris/Memoria/assets/2388532/7cdfb77e-eb83-412a-9a24-9dd031f75de5)
![image](https://github.com/Albeoris/Memoria/assets/2388532/e68c699c-93c4-4d7d-9e1a-1c5e2a166cb2)
