### PR TITLE
Turbo Dialog (press F9 to get SPEEEED !)

### DIFF
--- a/Assembly-CSharp/Global/NGUIText.cs
+++ b/Assembly-CSharp/Global/NGUIText.cs
@@ -2726,6 +2726,7 @@ public static class NGUIText
     public const String SpacingY = "SPAY";
     public const String KeyboardButtonIcon = "KCBT";
     public const String JoyStickButtonIcon = "JCBT";
+    public const String NoTurboDialog = "NTUR";
 
     public static readonly String[] RenderOpcodeSymbols;
 

--- a/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
+++ b/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
@@ -131,10 +131,10 @@ public class UIKeyTrigger : MonoBehaviour
         if (!UnityXInput.Input.anyKey && !isLockLazyInput)
             ResetKeyCode();
         AccelerateKeyNavigation();
-        if (handleMenuControlKeyPressCustomInput())
+        if (HandleMenuControlKeyPressCustomInput())
             return;
         HandleBoosterButton();
-        handleDialogControlKeyPressCustomInput();
+        HandleDialogControlKeyPressCustomInput();
     }
 
     private void AccelerateKeyNavigation()
@@ -494,7 +494,7 @@ public class UIKeyTrigger : MonoBehaviour
         }
     }
 
-    private Boolean handleMenuControlKeyPressCustomInput(GameObject activeButton = null)
+    private Boolean HandleMenuControlKeyPressCustomInput(GameObject activeButton = null)
     {
         IsShiftKeyPressed = ShiftKey;
 
@@ -646,7 +646,7 @@ public class UIKeyTrigger : MonoBehaviour
         return false;
     }
 
-    private void handleDialogControlKeyPressCustomInput(GameObject activeButton = null)
+    private void HandleDialogControlKeyPressCustomInput(GameObject activeButton = null)
     {
         if (activeButton == null)
             activeButton = UICamera.selectedObject;
@@ -655,7 +655,7 @@ public class UIKeyTrigger : MonoBehaviour
         foreach (String key in Configuration.Control.DialogProgressButtons)
             if (key.TryEnumParse<Control>(out Control ctrl))
                 dialogConfirmKeys.Add(ctrl);
-        if (dialogConfirmKeys.Any(ctrl => PersistenSingleton<HonoInputManager>.Instance.IsInputDown(ctrl) || keyCommand == ctrl) || shouldTurboDialog(dialogConfirmKeys))
+        if (dialogConfirmKeys.Any(ctrl => PersistenSingleton<HonoInputManager>.Instance.IsInputDown(ctrl) || keyCommand == ctrl) || ShouldTurboDialog(dialogConfirmKeys))
         {
             keyCommand = Control.None;
             PersistenSingleton<UIManager>.Instance.Dialogs.OnKeyConfirm(activeButton);
@@ -795,7 +795,7 @@ public class UIKeyTrigger : MonoBehaviour
         return false;
     }
 
-    private Boolean shouldTurboDialog(List<Control> confirmKeys)
+    private Boolean ShouldTurboDialog(List<Control> confirmKeys)
     {
         if (!Configuration.Cheats.TurboDialog || preventTurboKey || !UIManager.Instance.Dialogs.IsDialogNeedControl() || !UIManager.Instance.Dialogs.CompletlyVisible)
             return false;

--- a/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
+++ b/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
@@ -797,21 +797,10 @@ public class UIKeyTrigger : MonoBehaviour
 
     private Boolean shouldTurboDialog(List<Control> confirmKeys)
     {
-        if (!Configuration.Cheats.TurboDialog || preventTurboKey || TimerUI.Enable || PreventTurboOnFields())
+        if (!Configuration.Cheats.TurboDialog || preventTurboKey || !UIManager.Instance.Dialogs.IsDialogNeedControl() || !UIManager.Instance.Dialogs.CompletlyVisible)
             return false;
 
         return TurboKey || ((HonoInputManager.Instance.IsInput(Control.RightBumper) || ShiftKey) && confirmKeys.Any(HonoInputManager.Instance.IsInput));
-    }
-
-    public Boolean PreventTurboOnFields() // [DV] TODO: Make it compatible with DictionaryPatch
-    {
-        List<Int32> fieldidpreventturbo = new List<Int32> { 656, 657, 658, 659, 2950, 2951, 2952 }; // Kwe Marsh + Chocobo Minigame places
-        foreach (Int32 id in fieldidpreventturbo)
-        {
-            if (FF9StateSystem.Common.FF9.fldMapNo == id)
-                return true;
-        }
-        return false;
     }
 
     private void Start()

--- a/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
+++ b/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
@@ -26,6 +26,8 @@ public class UIKeyTrigger : MonoBehaviour
     private Single fastEventCounter;
     private Boolean triggleEventDialog;
     private Boolean quitConfirm;
+    private Boolean TurboKey;
+    public static Boolean preventTurboKey;
 
     public static Boolean IsShiftKeyPressed { get; private set; }
 
@@ -264,8 +266,9 @@ public class UIKeyTrigger : MonoBehaviour
 
             PersistenSingleton<UIManager>.Instance.Booster.ShowWaringDialog(BoosterType.GilMax);
         }
-        if (Configuration.Mod.TranceSeek && UnityXInput.Input.GetKeyDown(KeyCode.F8) && PersistenSingleton<UIManager>.Instance.IsPause) // TRANCE SEEK - Reset game, back to main menu
+        if (Configuration.Mod.TranceSeek && UnityXInput.Input.GetKeyDown(KeyCode.F8) && PersistenSingleton<UIManager>.Instance.IsPause) // TRANCE SEEK - Hard reset, back to main menu
         {
+            preventTurboKey = false;
             PersistenSingleton<UIManager>.Instance.Dialogs.PauseAllDialog(true);
             PersistenSingleton<UIManager>.Instance.HideAllHUD();
             ButtonGroupState.DisableAllGroup(true);
@@ -278,6 +281,13 @@ public class UIKeyTrigger : MonoBehaviour
             SceneDirector.FadeEventSetColor(FadeMode.Sub, Color.black);
             SceneDirector.Replace("Title", SceneTransition.FadeOutToBlack_FadeIn, true);
             return;
+        }
+        if (UnityXInput.Input.GetKeyDown(KeyCode.F9) && Configuration.Cheats.TurboDialog)
+        {
+            if (TurboKey)
+                TurboKey = false;
+            else
+                TurboKey = true;
         }
     }
 
@@ -645,10 +655,11 @@ public class UIKeyTrigger : MonoBehaviour
         foreach (String key in Configuration.Control.DialogProgressButtons)
             if (key.TryEnumParse<Control>(out Control ctrl))
                 dialogConfirmKeys.Add(ctrl);
-        if (dialogConfirmKeys.Any(ctrl => PersistenSingleton<HonoInputManager>.Instance.IsInputDown(ctrl) || keyCommand == ctrl))
+        if (dialogConfirmKeys.Any(ctrl => PersistenSingleton<HonoInputManager>.Instance.IsInputDown(ctrl) || keyCommand == ctrl) || shouldTurboDialog(dialogConfirmKeys))
         {
             keyCommand = Control.None;
             PersistenSingleton<UIManager>.Instance.Dialogs.OnKeyConfirm(activeButton);
+            preventTurboKey = false;
             if (PersistenSingleton<UIManager>.Instance.Dialogs.IsDialogNeedControl() || !PersistenSingleton<UIManager>.Instance.Dialogs.CompletlyVisible)
                 return;
 
@@ -659,6 +670,7 @@ public class UIKeyTrigger : MonoBehaviour
         {
             keyCommand = Control.None;
             PersistenSingleton<UIManager>.Instance.Dialogs.OnKeyCancel(activeButton);
+            preventTurboKey = false;
         }
         else if (PersistenSingleton<HonoInputManager>.Instance.IsInputDown(Control.Pause) || keyCommand == Control.Pause)
         {
@@ -779,6 +791,25 @@ public class UIKeyTrigger : MonoBehaviour
     {
         if (Application.platform != RuntimePlatform.Android || !UnityXInput.Input.GetKey(KeyCode.Escape))
         {
+        }
+        return false;
+    }
+
+    private Boolean shouldTurboDialog(List<Control> confirmKeys)
+    {
+        if (!Configuration.Cheats.TurboDialog || preventTurboKey || TimerUI.Enable || PreventTurboOnFields())
+            return false;
+
+        return TurboKey || ((HonoInputManager.Instance.IsInput(Control.RightBumper) || ShiftKey) && confirmKeys.Any(HonoInputManager.Instance.IsInput));
+    }
+
+    public Boolean PreventTurboOnFields() // [DV] TODO: Make it compatible with DictionaryPatch
+    {
+        List<Int32> fieldidpreventturbo = new List<Int32> { 656, 657, 658, 659, 2950, 2951, 2952 }; // Kwe Marsh + Chocobo Minigame places
+        foreach (Int32 id in fieldidpreventturbo)
+        {
+            if (FF9StateSystem.Common.FF9.fldMapNo == id)
+                return true;
         }
         return false;
     }

--- a/Assembly-CSharp/Memoria/Assets/Text/Dialogs/DialogBoxConstructor.cs
+++ b/Assembly-CSharp/Memoria/Assets/Text/Dialogs/DialogBoxConstructor.cs
@@ -279,6 +279,12 @@ namespace Memoria.Assets
                     index += 5;
                     return;
                 }
+                if (a == "[" + NGUIText.NoTurboDialog + "]")
+                {
+                    UIKeyTrigger.preventTurboKey = true;  // Disable turbo dialog manually. (for Trance Seek purpose)
+                    index += 5;
+                    return;
+                }
             }
 
             Int32 newIndex = index;
@@ -382,6 +388,7 @@ namespace Memoria.Assets
                 text3 == "[" + NGUIText.JoyStickButtonIcon ||
                 text3 == "[" + NGUIText.KeyboardButtonIcon)
             {
+                UIKeyTrigger.preventTurboKey = true;  // Disable turbo dialog when a special box appear (Gysahl Greens shop from Chocobo Forest, Eiko when she's cooking, ...)
                 newIndex = Array.IndexOf(_chars, ']', index + 4);
                 String text6 = new String(_chars, index + 6, newIndex - index - 6);
                 if (!FF9StateSystem.MobilePlatform ||
@@ -489,6 +496,7 @@ namespace Memoria.Assets
             }
             else if (text3 == "[" + NGUIText.Choose)
             {
+                UIKeyTrigger.preventTurboKey = true; // Disable turbo dialog when a choice appearc
                 Int32 startIndex = Array.IndexOf(_chars, ']', index + 4);
                 OnChoice(startIndex);
             }

--- a/Assembly-CSharp/Memoria/Configuration/Access/Cheats.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Access/Cheats.cs
@@ -18,6 +18,7 @@ namespace Memoria
             public static Boolean MasterSkill => Instance._cheats.MasterSkill;
             public static Boolean LvMax => Instance._cheats.LvMax;
             public static Boolean GilMax => Instance._cheats.GilMax;
+            public static Boolean TurboDialog => Instance._cheats.TurboDialog;
         }
     }
 }

--- a/Assembly-CSharp/Memoria/Configuration/Memoria.ini
+++ b/Assembly-CSharp/Memoria/Configuration/Memoria.ini
@@ -159,7 +159,7 @@ HideSteam = 0
 	; MasterSkill (default 0) F5 - irreversible - Characters learn skills upon equipping
 	; LvMax (default 0) F6 - irreversible - All characters lvl 99
 	; GilMax (default 0) F7 - irreversible - Unlimited gils
-	; TurboDialog (default 0) F9 - Automatically skips basic dialogs
+	; TurboDialog (default 0) F9 - Toggles the automatic skipping of basic dialogs. Alternatively Holding Shift + Confirm or Right Bumper + Confirm also skips dialogs automatically.
 Enabled = 1
 Rotation = 1
 Perspective = 1

--- a/Assembly-CSharp/Memoria/Configuration/Memoria.ini
+++ b/Assembly-CSharp/Memoria/Configuration/Memoria.ini
@@ -159,6 +159,7 @@ HideSteam = 0
 	; MasterSkill (default 0) F5 - irreversible - Characters learn skills upon equipping
 	; LvMax (default 0) F6 - irreversible - All characters lvl 99
 	; GilMax (default 0) F7 - irreversible - Unlimited gils
+	; TurboDialog (default 0) F9 - Automatically skips basic dialogs
 Enabled = 1
 Rotation = 1
 Perspective = 1
@@ -171,6 +172,7 @@ NoRandomEncounter = 1
 MasterSkill = 0
 LvMax = 0
 GilMax = 0
+TurboDialog = 0
 
 [Hacks]
 	; Memoria cheats

--- a/Assembly-CSharp/Memoria/Configuration/Structure/CheatsSection.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Structure/CheatsSection.cs
@@ -21,6 +21,7 @@ namespace Memoria
             public readonly IniValue<Boolean> MasterSkill;
             public readonly IniValue<Boolean> LvMax;
             public readonly IniValue<Boolean> GilMax;
+            public readonly IniValue<Boolean> TurboDialog;
 
             public CheatsSection() : base(nameof(CheatsSection), false)
             {
@@ -37,6 +38,7 @@ namespace Memoria
                 MasterSkill = BindBoolean(nameof(MasterSkill), false);
                 LvMax = BindBoolean(nameof(LvMax), false);
                 GilMax = BindBoolean(nameof(GilMax), false);
+                TurboDialog = BindBoolean(nameof(TurboDialog), false);
             }
         }
     }

--- a/Memoria.Launcher/Ini/Memoria.ini
+++ b/Memoria.Launcher/Ini/Memoria.ini
@@ -159,7 +159,7 @@ HideSteam = 0
 	; MasterSkill (default 0) F5 - irreversible - Characters learn skills upon equipping
 	; LvMax (default 0) F6 - irreversible - All characters lvl 99
 	; GilMax (default 0) F7 - irreversible - Unlimited gils
-	; TurboDialog (default 0) F9 - Automatically skips basic dialogs
+	; TurboDialog (default 0) F9 - Toggles the automatic skipping of basic dialogs. Alternatively Holding Shift + Confirm or Right Bumper + Confirm also skips dialogs automatically.
 Enabled = 1
 Rotation = 1
 Perspective = 1

--- a/Memoria.Launcher/Ini/Memoria.ini
+++ b/Memoria.Launcher/Ini/Memoria.ini
@@ -159,6 +159,7 @@ HideSteam = 0
 	; MasterSkill (default 0) F5 - irreversible - Characters learn skills upon equipping
 	; LvMax (default 0) F6 - irreversible - All characters lvl 99
 	; GilMax (default 0) F7 - irreversible - Unlimited gils
+	; TurboDialog (default 0) F9 - Automatically skips basic dialogs
 Enabled = 1
 Rotation = 1
 Perspective = 1
@@ -171,6 +172,7 @@ NoRandomEncounter = 1
 MasterSkill = 0
 LvMax = 0
 GilMax = 0
+TurboDialog = 0
 
 [Hacks]
 	; Memoria cheats


### PR DESCRIPTION
Add a little option i made few months ago from my precious commit : Turbo Dialog !

You can activate/deactivate with `F9`, all dialogs will skip automatically and it's compatible with speed cheat too (F1).
The Turbo Dialog will pause in specific situations  : 

- When a choice appears in the dialog box.
- When an icon appears in the dialog box.
- When the timer is running.
- In specific fields (like Kwe Marsh, Chocobo Forest, etc...)
- When a special tag is in the dialog box (called `[NTUR]`, for modding purpose).

Exemple : https://www.youtube.com/watch?v=xCU8Q_nc_ws