### PR TITLE
Added battle auto confirm feature

### DIFF
--- a/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
+++ b/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
@@ -425,7 +425,7 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
         Boolean canContinue = false;
         Boolean needContinue = false;
         Int32 maxLoop = 1000;
-        
+
         do
         {
             if (battleSpeed == 1 || battleSpeed == 2)
@@ -477,8 +477,11 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
                     {
                         if (changed)
                         {
-                            BattleHUD.ForceNextTurn = false;
-                            BattleHUD.switchBtlId = btl.btl_id;
+                            if (BattleHUD.ForceNextTurn)
+                            {
+                                BattleHUD.ForceNextTurn = false;
+                                BattleHUD.switchBtlId = btl.btl_id;
+                            }
                             needContinue = false;
                         }
                     }

--- a/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
+++ b/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
@@ -528,8 +528,8 @@ public class UIKeyTrigger : MonoBehaviour
             }
             if (battelAutoConfirm && PersistenSingleton<HonoInputManager>.Instance.IsInput(Control.Confirm))
             {
-                // If confirm is held more than 300ms it will auto confirm at an interval of 100ms
-                const Single delay = 0.3f;
+                // If confirm is held more than 500ms it will auto confirm at an interval of 100ms
+                const Single delay = 0.5f;
                 if (autoConfirmDownTime > 0 && Time.time - autoConfirmDownTime > delay)
                 {
                     autoConfirmDownTime = Time.time - delay + 0.1f;

--- a/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
+++ b/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
@@ -1,5 +1,4 @@
 ﻿using Assets.Scripts.Common;
-using FF9;
 using Memoria;
 using Memoria.Data;
 using Memoria.Prime;
@@ -26,6 +25,7 @@ public class UIKeyTrigger : MonoBehaviour
     private Single fastEventCounter;
     private Boolean triggleEventDialog;
     private Boolean quitConfirm;
+    private Single autoConfirmDownTime = 0;
     private Boolean TurboKey;
     public static Boolean preventTurboKey;
 
@@ -499,6 +499,7 @@ public class UIKeyTrigger : MonoBehaviour
         IsShiftKeyPressed = ShiftKey;
 
         UIScene sceneFromState = PersistenSingleton<UIManager>.Instance.GetSceneFromState(PersistenSingleton<UIManager>.Instance.State);
+        Boolean battelAutoConfirm = Configuration.Control.BattleAutoConfirm && (UIManager.Instance.State == UIManager.UIState.BattleHUD || UIManager.Instance.State == UIManager.UIState.BattleResult);
         if (ButtonGroupState.ActiveButton && ButtonGroupState.ActiveButton != PersistenSingleton<UIManager>.Instance.gameObject)
             activeButton = ButtonGroupState.ActiveButton;
         else if (activeButton == null)
@@ -519,9 +520,26 @@ public class UIKeyTrigger : MonoBehaviour
             }
             if (PersistenSingleton<HonoInputManager>.Instance.IsInputDown(Control.Confirm) || keyCommand == Control.Confirm)
             {
+                if (battelAutoConfirm)
+                    autoConfirmDownTime = Time.time;
                 keyCommand = Control.None;
                 sceneFromState.OnKeyConfirm(activeButton);
                 return true;
+            }
+            if (battelAutoConfirm && PersistenSingleton<HonoInputManager>.Instance.IsInput(Control.Confirm))
+            {
+                // If confirm is held more than 300ms it will auto confirm at an interval of 100ms
+                const Single delay = 0.3f;
+                if (autoConfirmDownTime > 0 && Time.time - autoConfirmDownTime > delay)
+                {
+                    autoConfirmDownTime = Time.time - delay + 0.1f;
+                    sceneFromState.OnKeyConfirm(activeButton);
+                    return true;
+                }
+            }
+            if (battelAutoConfirm && PersistenSingleton<HonoInputManager>.Instance.IsInputUp(Control.Confirm))
+            {
+                autoConfirmDownTime = 0;
             }
             if (PersistenSingleton<HonoInputManager>.Instance.IsInputDown(Control.Pause) || keyCommand == Control.Pause)
             {

--- a/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
+++ b/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
@@ -815,7 +815,7 @@ public class UIKeyTrigger : MonoBehaviour
 
     private Boolean ShouldTurboDialog(List<Control> confirmKeys)
     {
-        if (!Configuration.Cheats.TurboDialog || preventTurboKey || !UIManager.Instance.Dialogs.IsDialogNeedControl() || !UIManager.Instance.Dialogs.CompletlyVisible)
+        if (!Configuration.Cheats.TurboDialog || preventTurboKey || !UIManager.Instance.Dialogs.IsDialogNeedControl())
             return false;
 
         return TurboKey || ((HonoInputManager.Instance.IsInput(Control.RightBumper) || ShiftKey) && confirmKeys.Any(HonoInputManager.Instance.IsInput));

--- a/Assembly-CSharp/Memoria/Configuration/Access/Control.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Access/Control.cs
@@ -22,6 +22,7 @@ namespace Memoria
             public static Boolean DisableMouseInBattles => (DisableMouse & 4) != 0;
             public static String[] DialogProgressButtons => Instance._control.DialogProgressButtons;
             public static Boolean WrapSomeMenus => Instance._control.WrapSomeMenus;
+            public static Boolean BattleAutoConfirm => Instance._control.BattleAutoConfirm;
             public static Boolean PSXScrollingMethod => Instance._control.PSXScrollingMethod;
             /*
             The PSX movement algorithm is different than the remaster's movement algorithm

--- a/Assembly-CSharp/Memoria/Configuration/Memoria.ini
+++ b/Assembly-CSharp/Memoria/Configuration/Memoria.ini
@@ -56,6 +56,7 @@ CameraStabilizer = 85
 	; DisableMouse (default 0) 0 = Can use the mouse to navigate in menus and move on the fields / 7 = Disable the mouse completly / 1 = Disable mouse for field menus and dialogs / 2 = Disable mouse for field movements / 4 = Disable mouse for battle menus
 	; DialogProgressButtons (default "Confirm") A list of buttons that can be used to progress in cutscene dialogs; the PSX version used "Confirm", "Special"
 	; WrapSomeMenus (default 1) 0 = Don't wrap selection in menu that don't natively wrap it / 1 = Wrap selection for easing menu navigation
+	; BattleAutoConfirm (default 1) 0 = Confirm needs to be pressed repeatedly / 1 = Holding Confirm will automatically validate commands during battle and progress the battle result screen
 	; PSXScrollingMethod (default 1) 0 = Use the native Steam scrolling pattern / 1 = Scroll lists with the same behaviour as the PSX version
 	; PSXMovementMethod (default 0) 0 = Use the native Steam move pathing method, which makes movements faster on sloping paths / 1 = Use the PSX move pathing method
 	; AlwaysCaptureGamepad (default 0) 0 = Gamepad inputs are ignored when the game windows doesn't have focus / 1 = Gamepad inputs are always in effect
@@ -63,6 +64,7 @@ Enabled = 1
 DisableMouse = 0
 DialogProgressButtons = "Confirm"
 WrapSomeMenus = 1
+BattleAutoConfirm = 1
 PSXScrollingMethod = 1
 PSXMovementMethod = 0
 AlwaysCaptureGamepad = 0

--- a/Assembly-CSharp/Memoria/Configuration/Structure/ControlSection.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Structure/ControlSection.cs
@@ -24,6 +24,7 @@ namespace Memoria
             public readonly IniValue<Int32> DisableMouse;
             public readonly IniArray<String> DialogProgressButtons;
             public readonly IniValue<Boolean> WrapSomeMenus;
+            public readonly IniValue<Boolean> BattleAutoConfirm;
             public readonly IniValue<Boolean> PSXScrollingMethod;
             public readonly IniValue<Boolean> PSXMovementMethod;
             public readonly IniValue<Boolean> AlwaysCaptureGamepad;
@@ -33,6 +34,7 @@ namespace Memoria
                 DisableMouse = BindInt32(nameof(DisableMouse), 0);
                 DialogProgressButtons = BindStringArray(nameof(DialogProgressButtons), new String[1] { "Confirm" });
                 WrapSomeMenus = BindBoolean(nameof(WrapSomeMenus), true);
+                BattleAutoConfirm = BindBoolean(nameof(WrapSomeMenus), true);
                 PSXScrollingMethod = BindBoolean(nameof(PSXScrollingMethod), true);
                 PSXMovementMethod = BindBoolean(nameof(PSXMovementMethod), false);
                 AlwaysCaptureGamepad = BindBoolean(nameof(AlwaysCaptureGamepad), false);

--- a/Assembly-CSharp/Memoria/Configuration/Structure/ControlSection.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Structure/ControlSection.cs
@@ -34,7 +34,7 @@ namespace Memoria
                 DisableMouse = BindInt32(nameof(DisableMouse), 0);
                 DialogProgressButtons = BindStringArray(nameof(DialogProgressButtons), new String[1] { "Confirm" });
                 WrapSomeMenus = BindBoolean(nameof(WrapSomeMenus), true);
-                BattleAutoConfirm = BindBoolean(nameof(WrapSomeMenus), true);
+                BattleAutoConfirm = BindBoolean(nameof(BattleAutoConfirm), true);
                 PSXScrollingMethod = BindBoolean(nameof(PSXScrollingMethod), true);
                 PSXMovementMethod = BindBoolean(nameof(PSXMovementMethod), false);
                 AlwaysCaptureGamepad = BindBoolean(nameof(AlwaysCaptureGamepad), false);

--- a/Memoria.Launcher/Ini/Memoria.ini
+++ b/Memoria.Launcher/Ini/Memoria.ini
@@ -56,6 +56,7 @@ CameraStabilizer = 85
 	; DisableMouse (default 0) 0 = Can use the mouse to navigate in menus and move on the fields / 7 = Disable the mouse completly / 1 = Disable mouse for field menus and dialogs / 2 = Disable mouse for field movements / 4 = Disable mouse for battle menus
 	; DialogProgressButtons (default "Confirm") A list of buttons that can be used to progress in cutscene dialogs; the PSX version used "Confirm", "Special"
 	; WrapSomeMenus (default 1) 0 = Don't wrap selection in menu that don't natively wrap it / 1 = Wrap selection for easing menu navigation
+	; BattleAutoConfirm (default 1) 0 = Confirm needs to be pressed repeatedly / 1 = Holding Confirm will automatically validate commands during battle and progress the battle result screen
 	; PSXScrollingMethod (default 1) 0 = Use the native Steam scrolling pattern / 1 = Scroll lists with the same behaviour as the PSX version
 	; PSXMovementMethod (default 0) 0 = Use the native Steam move pathing method, which makes movements faster on sloping paths / 1 = Use the PSX move pathing method
 	; AlwaysCaptureGamepad (default 0) 0 = Gamepad inputs are ignored when the game windows doesn't have focus / 1 = Gamepad inputs are always in effect
@@ -63,6 +64,7 @@ Enabled = 1
 DisableMouse = 0
 DialogProgressButtons = "Confirm"
 WrapSomeMenus = 1
+BattleAutoConfirm = 1
 PSXScrollingMethod = 1
 PSXMovementMethod = 0
 AlwaysCaptureGamepad = 0


### PR DESCRIPTION
Holding Confirm will automatically validate commands during battle and progress the battle result screen.

The delay is set to 500ms with an interval of 100ms while held.