### PR TITLE
System interactions

### DIFF
--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
@@ -61,7 +61,7 @@ public partial class BattleHUD : UIScene
         _oneTime = true;
     }
 
-    public void SetBattleFollowMessage(BattleMesages pMes, params Object[] args)
+    public void SetBattleFollowMessage(BattleMesages pMes, Object arg = null, CMD_DATA msgCmd = null)
     {
         Int32 pMesNo = (Int32)pMes;
         String fmtMessage = FF9TextTool.BattleFollowText(pMesNo + 7);
@@ -71,15 +71,14 @@ public partial class BattleHUD : UIScene
         Byte priority = (Byte)Char.GetNumericValue(fmtMessage[0]);
         String parsedMessage = fmtMessage.Substring(1);
 
-        if (args.Length > 0)
+        if (arg != null)
         {
-            String str3 = args[0].ToString();
-            Int32 result;
-            parsedMessage = !Int32.TryParse(str3, out result) ? parsedMessage.Replace("%", str3) : parsedMessage.Replace("&", str3);
+            String argStr = arg.ToString();
+            parsedMessage = !Int32.TryParse(argStr, out _) ? parsedMessage.Replace("%", argStr) : parsedMessage.Replace("&", argStr);
         }
 
         VoicePlayer.PlayBattleVoice(pMesNo + 7, fmtMessage, true);
-        SetBattleMessage(parsedMessage, priority);
+        SetBattleMessage(parsedMessage, priority, msgCmd);
     }
 
     public void SetBattleFollowMessage(Byte priority, String formatMessage, params Object[] args)
@@ -322,7 +321,7 @@ public partial class BattleHUD : UIScene
         DisplayBattleMessage(asMessage);
     }
 
-    public void SetBattleMessage(String str, Byte strPriority)
+    public void SetBattleMessage(String str, Byte strPriority, CMD_DATA cmd = null)
     {
         Message asMessage = new Message()
         {
@@ -330,7 +329,7 @@ public partial class BattleHUD : UIScene
             priority = strPriority,
             counter = 0f,
             isRect = false,
-            titleCmd = null
+            titleCmd = cmd
         };
         _messageQueue[str] = asMessage;
 

--- a/Assembly-CSharp/Global/btl_cmd.cs
+++ b/Assembly-CSharp/Global/btl_cmd.cs
@@ -545,7 +545,6 @@ public class btl_cmd
                 || Configuration.Battle.Speed >= 4 && btl_util.IsBtlUsingCommandMotion(cmd.regist)
                 || Configuration.Battle.Speed >= 5 && cmd.regist.bi.cover != 0
                 || (Configuration.Mod.TranceSeek && btl_stat.CheckStatus(cmd.regist, BattleStatus.EasyKill) && btl_stat.CheckStatus(cmd.regist, BattleStatus.Sleep))) // [DV] Prevent command cancel for boss.
-
             {
                 if (Configuration.Battle.Speed == 4)
                 {
@@ -1060,10 +1059,10 @@ public class btl_cmd
                 cmd.tar_id = caster.Id;
                 break;
             case BattleCommandId.MagicCounter:
-                UIManager.Battle.SetBattleFollowMessage(BattleMesages.ReturnMagic);
+                UIManager.Battle.SetBattleFollowMessage(BattleMesages.ReturnMagic, msgCmd: cmd);
                 break;
             case BattleCommandId.AutoPotion:
-                UIManager.Battle.SetBattleFollowMessage(BattleMesages.AutoPotion);
+                UIManager.Battle.SetBattleFollowMessage(BattleMesages.AutoPotion, msgCmd: cmd);
                 break;
             case BattleCommandId.SummonGarnet:
             case BattleCommandId.SummonEiko:
@@ -1074,7 +1073,7 @@ public class btl_cmd
                 return DecideMagicSword(caster, cmd.aa.MP);
             case BattleCommandId.Counter:
                 if (btl_util.GetCommandMainActionIndex(cmd) == BattleAbilityId.Attack)
-                    UIManager.Battle.SetBattleFollowMessage(BattleMesages.CounterAttack);
+                    UIManager.Battle.SetBattleFollowMessage(BattleMesages.CounterAttack, msgCmd: cmd);
                 break;
             case BattleCommandId.SysEscape:
                 if (btlsys.btl_phase == 4)

--- a/Assembly-CSharp/Global/btl_cmd.cs
+++ b/Assembly-CSharp/Global/btl_cmd.cs
@@ -1606,7 +1606,7 @@ public class btl_cmd
         }
     }
 
-    public static void ExecVfxCommand(BTL_DATA target, CMD_DATA cmd = null)
+    public static void ExecVfxCommand(BTL_DATA target, CMD_DATA cmd = null, BattleActionThread sfxThread = null)
     {
         if (cmd == null)
             cmd = btl_util.getCurCmdPtr();
@@ -1638,7 +1638,7 @@ public class btl_cmd
                         KillAllCommand(btlsys);
                     }
                 }
-                SBattleCalculator.CalcMain(caster, target, cmd);
+                SBattleCalculator.CalcMain(caster, target, cmd, sfxThread);
                 return;
             case BattleCommandId.SysTrans:
             {
@@ -1664,7 +1664,7 @@ public class btl_cmd
             case BattleCommandId.Item:
             case BattleCommandId.AutoPotion:
             default:
-                SBattleCalculator.CalcMain(caster, target, cmd);
+                SBattleCalculator.CalcMain(caster, target, cmd, sfxThread);
                 return;
         }
     }

--- a/Assembly-CSharp/Memoria/Battle/Calculator/BattleCalculator.cs
+++ b/Assembly-CSharp/Memoria/Battle/Calculator/BattleCalculator.cs
@@ -18,7 +18,7 @@ namespace Memoria
 
         public static void SetBattleFollowFormatMessage(BattleMesages message, params Object[] args)
         {
-            UIManager.Battle.SetBattleFollowMessage(message, args);
+            UIManager.Battle.SetBattleFollowMessage(message, args != null && args.Length > 0 ? args[0] : null);
         }
 
         public static void SetBattleFollowFormatMessage(Byte priority, String formatMessage, params Object[] args)

--- a/Assembly-CSharp/Memoria/Battle/Calculator/CalcContext.cs
+++ b/Assembly-CSharp/Memoria/Battle/Calculator/CalcContext.cs
@@ -20,9 +20,13 @@ namespace Memoria
         public HashSet<SupportAbility> DisabledSA = new HashSet<SupportAbility>(); // The support abilities that are disabled by successfully applied SA features
         public Boolean IsDrain = false; // Keep the Caster.Hp/MpDamage at the same value of Target.Hp/MpDamage even when modified by external effects
         public EatResult EatResult = 0;
+
+        // Current sfxthread at the moment of the effect point (from UnifiedBattleSequencer, in SFXRework mode only)
+        // This field may be removed and replaced by another system in the future
+        public BattleActionThread sfxThread = null; // Warning: can be null
+
         public Int32 PowerDifference => AttackPower - DefensePower;
         public Boolean IsAbsorb => (Flags & BattleCalcFlags.Absorb) != 0;
-
         public Int32 EnsureAttack => Attack < 1 ? (Attack = 1) : Attack;
         public Int32 EnsurePowerDifference => PowerDifference < 1 ? 1 : PowerDifference;
     }

--- a/Assembly-CSharp/Memoria/Battle/Calculator/SBattleCalculator.cs
+++ b/Assembly-CSharp/Memoria/Battle/Calculator/SBattleCalculator.cs
@@ -11,6 +11,7 @@ namespace Memoria
 {
     public static class SBattleCalculator
     {
+        // Note: no optional parameters in these methods, at least yet, for retro-compatibility purpose
         public static void CalcMain(BattleUnit caster, BattleUnit target, BattleCommand command)
         {
             CalcMain(caster.Data, target.Data, command, command.ScriptId);
@@ -18,10 +19,20 @@ namespace Memoria
 
         public static void CalcMain(BTL_DATA caster, BTL_DATA target, CMD_DATA cmd)
         {
-            CalcMain(caster, target, new BattleCommand(cmd), cmd.ScriptId);
+            CalcMain(caster, target, new BattleCommand(cmd), cmd.ScriptId, null);
+        }
+
+        public static void CalcMain(BTL_DATA caster, BTL_DATA target, CMD_DATA cmd, BattleActionThread sfxThread)
+        {
+            CalcMain(caster, target, new BattleCommand(cmd), cmd.ScriptId, sfxThread);
         }
 
         public static void CalcMain(BTL_DATA caster, BTL_DATA target, BattleCommand command, Int32 scriptId)
+        {
+            CalcMain(caster, target, command, scriptId, null);
+        }
+
+        public static void CalcMain(BTL_DATA caster, BTL_DATA target, BattleCommand command, Int32 scriptId, BattleActionThread sfxThread)
         {
             try
             {
@@ -41,6 +52,7 @@ namespace Memoria
                 }
                 command.ScriptId = scriptId;
                 BattleCalculator v = new BattleCalculator(caster, target, command);
+                v.Context.sfxThread = sfxThread;
                 BattleScriptFactory factory = FindScriptFactory(scriptId);
                 foreach (SupportingAbilityFeature saFeature in ff9abil.GetEnabledSA(v.Caster))
                     saFeature.TriggerOnAbility(v, "BattleScriptStart", false);

--- a/Assembly-CSharp/Memoria/Battle/SFX/UnifiedBattleSequencer.cs
+++ b/Assembly-CSharp/Memoria/Battle/SFX/UnifiedBattleSequencer.cs
@@ -910,7 +910,7 @@ public static class UnifiedBattleSequencer
 								c.fig_info = 0;
 								c.fig = c.m_fig = 0;
 							}
-							btl_cmd.ExecVfxCommand(btl, cmd);
+                            btl_cmd.ExecVfxCommand(btl, cmd, runningThread);
 							foreach (BTL_DATA c in allBtl)
 							{
 								if (c.fig_info != 0)

--- a/Assembly-CSharp/NCalc/NCalcUtility.cs
+++ b/Assembly-CSharp/NCalc/NCalcUtility.cs
@@ -555,6 +555,7 @@ namespace NCalc
             expr.Parameters["CommandTargetId"] = (Int32)command.Data.tar_id;
             expr.Parameters["CommandTargetCount"] = command.TargetCount;
             expr.Parameters["CalcMainCounter"] = (Int32)command.Data.info.effect_counter;
+            expr.Parameters["CommandIsCounter"] = command.Id == BattleCommandId.EnemyCounter || command.Id == BattleCommandId.Counter || command.Id == BattleCommandId.MagicCounter; // Might check also if command.Data == command.Data.regist?.cmd[1] except for JumpAttack/JumpTrance
         }
 
         public static void InitializeExpressionRawAbility(ref Expression expr, AA_DATA aa, BattleAbilityId abilId = BattleAbilityId.Void)


### PR DESCRIPTION
Very vague PR name for something that may or may not consist of a lot of interactions between different parts of the abilities ([Ability features](https://github.com/Albeoris/Memoria/wiki/Supporting-ability-features) , [SFX sequences](https://github.com/Albeoris/Memoria/wiki/Battle-SFX-Sequence), [C# ability effects](https://github.com/Albeoris/Memoria/wiki/External-Battle-scripts)...).

It would sometimes be nice to have more "interoperability" between these, in the sense that a SA feature or a ``CalcContext`` has informations about the SFX that lead to the ability's effect or can communicate with it through accessible variables.

I am not sure exactly which form it should take yet, I'm a bit scratching my head over that.
The concrete issue that pointed out that such interactions could be developped is for a SFX sequence that can randomly use multiple SFX (eg. Blizzaga, Thundaga or Firaga, without knowing which one will be used at which time beforehand) and the ability's C# effect doesn't know which one was picked. It's even worse when they are randomly chained, so there can be concurrent SFX for the same command at the same time.