### PR TITLE
Removed waits on save/load & Fixes

### DIFF
--- a/Assembly-CSharp/Global/AbilityUI.cs
+++ b/Assembly-CSharp/Global/AbilityUI.cs
@@ -140,6 +140,8 @@ public class AbilityUI : UIScene
         this.DisplayAllButton();
         this.activeAbilityScrollList.ScrollButton.DisplayScrollButton(false, false);
         this.supportAbilityScrollList.ScrollButton.DisplayScrollButton(false, false);
+        this.CommandPanel.SetActive(true);
+        this.MagicStonePanel.SetActive(false);
         this.UpdateUserInterface();
     }
 

--- a/Assembly-CSharp/Global/Hono/HonoFading.cs
+++ b/Assembly-CSharp/Global/Hono/HonoFading.cs
@@ -31,12 +31,6 @@ public class HonoFading : MonoBehaviour
 
 	public void Fade(Single alphaFrom, Single alphaTo, Single duration, Single delay, AnimationCurve animCurve, UIScene.SceneVoidDelegate callback = null)
 	{
-	    if (Configuration.Graphics.SkipIntros > 0)
-	    {
-	        duration = 0;
-	        delay = 0;
-	    }
-
         if (base.gameObject.activeInHierarchy && !this.busy)
 		{
 			if (Configuration.Graphics.WidescreenSupport && widescreenRescale)

--- a/Assembly-CSharp/Global/Hono/HonoFading.cs
+++ b/Assembly-CSharp/Global/Hono/HonoFading.cs
@@ -59,12 +59,14 @@ public class HonoFading : MonoBehaviour
 
 	public void FadeIn(UIScene.SceneVoidDelegate callback = null)
 	{
-		this.Fade(this.fadeInFrom, this.fadeInTo, this.fadeInDuration, this.fadeInDelay, this.fadeInCurve, callback);
+        // We don't fade to black if fadeInDuration is too short to avoid flashing
+        this.Fade(this.fadeInFrom, (this.fadeInDuration > 0.05f) ? this.fadeInTo : this.fadeInFrom, this.fadeInDuration, this.fadeInDelay, this.fadeInCurve, callback);
 	}
 
 	public void FadeOut(UIScene.SceneVoidDelegate callback = null)
-	{
-		this.Fade(this.fadeOutFrom, this.fadeOutTo, this.fadeOutDuration, this.fadeOutDelay, this.fadeOutCurve, callback);
+    {
+        // We don't fade from black if fadeInDuration is too short to avoid flashing
+        this.Fade((this.fadeOutDuration > 0.05f) ? this.fadeOutFrom : this.fadeOutTo, this.fadeOutTo, this.fadeOutDuration, this.fadeOutDelay, this.fadeOutCurve, callback);
 	}
 
 	public void FadePingPong(UIScene.SceneVoidDelegate blackSceneCallback = null, UIScene.SceneVoidDelegate finishCallback = null)

--- a/Assembly-CSharp/Global/MainMenuUI.cs
+++ b/Assembly-CSharp/Global/MainMenuUI.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using Assets.Scripts.Common;
 using Assets.Sources.Scripts.UI.Common;
+using Memoria;
 using Memoria.Data;
 using Memoria.Assets;
 using Memoria.Scenes;
 using UnityEngine;
-using Object = System.Object;
 
 public class MainMenuUI : UIScene
 {
@@ -101,7 +101,7 @@ public class MainMenuUI : UIScene
 		else
 		{
 			this.screenFadePanel.depth = 7;
-			this.submenuTransition.AnimationTime = FF9StateSystem.Settings.IsFastForward ? 0.1f : 0.2f;
+			this.submenuTransition.AnimationTime = (!FF9StateSystem.Settings.IsFastForward) ? Configuration.Interface.FadeDuration : Configuration.Interface.FadeDuration / FF9StateSystem.Settings.FastForwardFactor;
 			this.submenuTransition.TweenOut(null);
 		}
 		base.Hide(afterHideAction);
@@ -109,7 +109,7 @@ public class MainMenuUI : UIScene
 
 	public void StartSubmenuTweenIn()
 	{
-		this.submenuTransition.AnimationTime = ((!FF9StateSystem.Settings.IsFastForward) ? 0.2f : 0.1f);
+		this.submenuTransition.AnimationTime = (!FF9StateSystem.Settings.IsFastForward) ? Configuration.Interface.FadeDuration : Configuration.Interface.FadeDuration / FF9StateSystem.Settings.FastForwardFactor;
 		this.submenuTransition.TweenIn((Action)null);
 	}
 

--- a/Assembly-CSharp/Global/SaveLoadUI.cs
+++ b/Assembly-CSharp/Global/SaveLoadUI.cs
@@ -446,7 +446,6 @@ public class SaveLoadUI : UIScene
 
 	private IEnumerator HideSuccessfulAccessDialog()
 	{
-		yield return new WaitForSeconds(1.5f);
 		this.SuccessfulAccessPanel.SetActive(false);
 		FF9UIDataTool.DisplayTextLocalize(this.HelpTitleLabel, "SaveHelpBlock");
 		if (this.type == SaveLoadUI.SerializeType.Save)
@@ -459,12 +458,7 @@ public class SaveLoadUI : UIScene
 
 	private IEnumerator RunProgressBar()
 	{
-		this.progressBar.value = 0f;
-		while ((Double)this.progressBar.value < 0.95)
-		{
-			yield return new WaitForSeconds(0.01f);
-			this.progressBar.value += 0.01f;
-		}
+		this.progressBar.value = 1f;
 		yield break;
 	}
 
@@ -544,8 +538,6 @@ public class SaveLoadUI : UIScene
 
 	private IEnumerator OnFinishedLoadPreview_delay(DataSerializerErrorCode errNo, Int32 slotID, List<SharedDataPreviewSlot> data)
 	{
-		Single remainTime = Mathf.Max(2f - (Time.time - this.timeCounter), 0f);
-		yield return new WaitForSeconds(remainTime);
 		base.Loading = false;
 		if (errNo == DataSerializerErrorCode.Success)
 		{
@@ -608,10 +600,7 @@ public class SaveLoadUI : UIScene
 
 	private IEnumerator OnFinishedLoadFile_delay(DataSerializerErrorCode errNo, Int32 slotID, Int32 saveID, Boolean isSuccess)
 	{
-		Single remainTime = Mathf.Max(2f - (Time.time - this.timeCounter), 0f);
-		yield return new WaitForSeconds(remainTime);
 		this.progressBar.value = 1f;
-		yield return new WaitForSeconds(0.1f);
 		this.LoadingAccessPanel.SetActive(false);
 		if (isSuccess && errNo == DataSerializerErrorCode.Success)
 		{
@@ -658,10 +647,7 @@ public class SaveLoadUI : UIScene
 
 	private IEnumerator OnFinishedSaveFile_delay(DataSerializerErrorCode errNo, Int32 slotID, Int32 saveID, Boolean isSuccess, SharedDataPreviewSlot data)
 	{
-		Single remainTime = Mathf.Max(2f - (Time.time - this.timeCounter), 0f);
-		yield return new WaitForSeconds(remainTime);
 		this.progressBar.value = 1f;
-		yield return new WaitForSeconds(0.1f);
 		base.Loading = false;
 		this.LoadingAccessPanel.SetActive(false);
 		if (isSuccess && errNo == DataSerializerErrorCode.Success)
@@ -686,10 +672,7 @@ public class SaveLoadUI : UIScene
 
 	private IEnumerator OnFinishedUploadToCloud_delay(DataSerializerErrorCode errNo, Boolean isSuccess, SharedDataPreviewSlot localData, SharedDataPreviewSlot cloudData)
 	{
-		Single remainTime = Mathf.Max(2f - (Time.time - this.timeCounter), 0f);
-		yield return new WaitForSeconds(remainTime);
 		this.progressBar.value = 1f;
-		yield return new WaitForSeconds(0.1f);
 		base.Loading = false;
 		this.LoadingAccessPanel.SetActive(false);
 		if (isSuccess && errNo == DataSerializerErrorCode.Success)

--- a/Assembly-CSharp/Global/TitleUI.cs
+++ b/Assembly-CSharp/Global/TitleUI.cs
@@ -1456,9 +1456,10 @@ public class TitleUI : UIScene
             ButtonGroupState.ActiveGroup = MenuGroupButton;
 
             if (Configuration.Graphics.SkipIntros > 2)
-            Configuration.Graphics.SkipIntros = 0;
-            
-            this.timer.Start();
+                this.timer.Stop();
+            else
+                this.timer.Start();
+
             if (this.IsJustLaunchApp)
             {
                 SiliconStudio.Social.Authenticate(true);
@@ -2081,25 +2082,22 @@ public class TitleUI : UIScene
                 this.logoSprite.spriteName = this.logoIndex == 0 ? "logo_sqex" : "logo_sst";
                 this.honoFading.Fade(1f, 0f, 0.7f, 1.3f, this.honoFading.fadeInCurve, this.preLogoFadeOut);
             };
-            if (Configuration.Graphics.SkipIntros > 1)
-                this.onLogoFinish = delegate { this.onMovieFinish(); };
-            else
-                this.onLogoFinish = delegate
+            this.onLogoFinish = delegate
+            {
+                this.type = Type.Movie1;
+                postMenuFadeOut();
+                this.logoContainer.gameObject.SetActive(false);
+                this.honoFading.Fade(1f, 0f, 1f, 0f, this.honoFading.fadeInCurve, delegate
                 {
-                    this.type = Type.Movie1;
-                    postMenuFadeOut();
-                    this.logoContainer.gameObject.SetActive(false);
-                    this.honoFading.Fade(1f, 0f, 1f, 0f, this.honoFading.fadeInCurve, delegate
-                    {
-                    });
+                });
 
-                    MBG.Instance.SetFinishCallback(this.onMovieFinish);
-                    MBG.Instance.gameObject.SetActive(true);
-                    MBG.Instance.LoadMovie("FMV000");
-                    MBG.Instance.SetDepthForTitle();
-                    MBG.Instance.Play();
-                    this.stopEnable = true;
-                };
+                MBG.Instance.SetFinishCallback(this.onMovieFinish);
+                MBG.Instance.gameObject.SetActive(true);
+                MBG.Instance.LoadMovie("FMV000");
+                MBG.Instance.SetDepthForTitle();
+                MBG.Instance.Play();
+                this.stopEnable = true;
+            };
             this.onMovieFinish = delegate
             {
                 this.honoFading.Fade(0f, 1f, 1f, 0f, this.honoFading.fadeInCurve, delegate
@@ -2107,6 +2105,23 @@ public class TitleUI : UIScene
                     this.preMenuFadeIn();
                 });
             };
+            if (Configuration.Graphics.SkipIntros == 1 && kind == Type.Logo)
+            {
+                postMenuFadeOut();
+                this.logoIndex = 2;
+                this.honoFading.Fade(0f, 1f, this.skipFadeInTime, 0f, this.honoFading.fadeOutCurve, this.onLogoFinish);
+                return;
+            }
+            else if (Configuration.Graphics.SkipIntros > 0 && (kind == Type.SplashScreen || kind == Type.Logo))
+            {
+                postMenuFadeOut();
+                postIdleScreenFadeOut();
+                this.stopEnable = false;
+                this.honoFading.Fade(1f, 0f, this.skipFadeInTime, 0f, this.honoFading.fadeInCurve, delegate {
+                    postMenuFadeIn();
+                });
+                return;
+            }
             switch (kind)
             {
                 case Type.SplashScreen:

--- a/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
+++ b/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
@@ -273,7 +273,6 @@ public class UIKeyTrigger : MonoBehaviour
             PersistenSingleton<UIManager>.Instance.HideAllHUD();
             ButtonGroupState.DisableAllGroup(true);
             UIManager.Battle.FF9BMenu_EnableMenu(false);
-            Configuration.Graphics.SkipIntros = 3;
             PersistenSingleton<UIManager>.Instance.PauseScene.Hide(null);
             EventHUD.Cleanup();
             EventInput.ClearPadMask();

--- a/Assembly-CSharp/Memoria/Assets/Text/Dialogs/DialogBoxConstructor.cs
+++ b/Assembly-CSharp/Memoria/Assets/Text/Dialogs/DialogBoxConstructor.cs
@@ -560,7 +560,7 @@ namespace Memoria.Assets
         {
             _sb.Append("[C8B040][HSHD]");
             _sb.Append(ETb.GetItemName(_textEngine.gMesValue[oneParameterFromTag6]));
-            _sb.Append("[C8C8C8]");
+            _sb.Append("[C8C8C8][HSHD]");
         }
 
         private void OnVariable(Int32 oneParameterFromTag5)

--- a/Assembly-CSharp/Memoria/Configuration/Access/Graphics.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Access/Graphics.cs
@@ -17,7 +17,7 @@ namespace Memoria
             public static Int32 MenuFPS => Instance._graphics.MenuFPS;
             public static Int32 MenuTPS => Instance._graphics.MenuTPS;
             public static Int32 BattleSwirlFrames => Instance._graphics.BattleSwirlFrames;
-            public static Int32 SkipIntros = Instance._graphics.SkipIntros;
+            public static Int32 SkipIntros => Instance._graphics.SkipIntros;
             public static Int32 GarnetHair => Instance._graphics.GarnetHair;
             public static Int32 TileSize => Instance._graphics.TileSize;
             public static Int32 AntiAliasing => Instance._graphics.AntiAliasing;


### PR DESCRIPTION
Fixed SkipIntros. Option now works as advertised:
- 0: No skip
- 1: Skips logos
- 2: Skips logos and movie but still shows movies when idle for some time
- 3: Skips logos and movie, no idle movie
It will now work at all time: when returning to title screen from the Config menu or after a game over.

Removed black flashes when FadeDuration < 50ms
Fixed sub-menu animation not matching FadeDuration (would bug out if going in and out too fast)

Fixed gems displayed instead of command in the Ability menu when going on Equip, going back out and back in Ability (steam version bug)
![image](https://github.com/Albeoris/Memoria/assets/2388532/20bfa4e3-e5d2-49b2-8dd3-7a0b787b708c)
