### PR TITLE
Custom SPS + Model

### DIFF
--- a/Assembly-CSharp/Global/Model/ModelFactory.cs
+++ b/Assembly-CSharp/Global/Model/ModelFactory.cs
@@ -82,7 +82,24 @@ public static class ModelFactory
 				renderer.material.SetTexture("_MainTex", texture);
 			}
 		}
-		Shader shader;
+        if (CustomModelField.Count > 0 && !isBattle)
+        {
+            foreach (KeyValuePair<String, String[]> CustomModelFieldEntry in CustomModelField)
+            {
+                if (CustomModelFieldEntry.Key.Contains(modelNameId))
+                {
+                    string[] SplitEntry = CustomModelFieldEntry.Key.Split('#');
+                    Int32 FieldID = Int32.Parse(SplitEntry[0]);
+                    Renderer[] renderers = gameObject.GetComponentsInChildren<Renderer>();
+                    if (FF9StateSystem.Common.FF9.fldMapNo == FieldID)
+                    {
+                        CustomModelField.TryGetValue(CustomModelFieldEntry.Key, out String[] NewTextures);
+                        ChangeModelTexture(gameObject, NewTextures);
+                    }
+                }
+            }
+        }
+        Shader shader;
 		if (modelNameId.Contains("GEO_SUB_W0"))
 			shader = ShadersLoader.Find(modelNameId.Contains("GEO_SUB_W0_025") ? "WorldMap/ShadowActor" : "WorldMap/Actor");
 		else
@@ -1684,4 +1701,6 @@ public static class ModelFactory
 		"GEO_MAIN_B0_026",
 		"GEO_MAIN_B0_027"
 	};
+
+    public static Dictionary<String, String[]> CustomModelField = new Dictionary<String, String[]>();
 }

--- a/Assembly-CSharp/Global/Model/ModelFactory.cs
+++ b/Assembly-CSharp/Global/Model/ModelFactory.cs
@@ -89,11 +89,11 @@ public static class ModelFactory
                 if (CustomModelFieldEntry.Key.Contains(modelNameId))
                 {
                     string[] SplitEntry = CustomModelFieldEntry.Key.Split('#');
-                    Int32 FieldID = Int32.Parse(SplitEntry[0]);
+                    Int32.TryParse(SplitEntry[0], out Int32 FieldID);
                     Renderer[] renderers = gameObject.GetComponentsInChildren<Renderer>();
                     if (FF9StateSystem.Common.FF9.fldMapNo == FieldID)
                     {
-                        CustomModelField.TryGetValue(CustomModelFieldEntry.Key, out String[] NewTextures);
+                        String[] NewTextures = CustomModelFieldEntry.Value;
                         ChangeModelTexture(gameObject, NewTextures);
                     }
                 }

--- a/Assembly-CSharp/Global/battle/BattleSPS.cs
+++ b/Assembly-CSharp/Global/battle/BattleSPS.cs
@@ -397,7 +397,13 @@ public class BattleSPS : MonoBehaviour
 
 	public Vector3 rot;
 
-	public Vector3 rotArg;
+    public Boolean rotate;
+
+    public BTL_DATA btl;
+
+    public Int32 bone;
+
+    public Vector3 rotArg;
 
 	public Vector3 posOffset;
 

--- a/Assembly-CSharp/Global/battle/BattleSPSSystem.cs
+++ b/Assembly-CSharp/Global/battle/BattleSPSSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Memoria;
 using Memoria.Data;
 using UnityEngine;
@@ -130,32 +131,49 @@ public class BattleSPSSystem : MonoBehaviour
 			BattleSPS special_sps = this._specialSpsList[i];
 			if ((special_sps.type != 0 || special_sps.spsBin != null) && (special_sps.attr & 1) != 0 && special_sps.isUpdate)
 			{
-				double rotation_cos = Math.Cos(2 * Math.PI * special_sps.curFrame / 10000) * this._specialSpsFadingList[i]; // 1 turn every 10 seconds
-				double rotation_sin = Math.Sin(2 * Math.PI * special_sps.curFrame / 10000) * this._specialSpsFadingList[i];
-				Vector3 rotated_pos = BattleSPSSystem.statusTextures[special_sps.refNo].extraPos;
-				float tmp = rotated_pos.x;
-				rotated_pos.x = (float)(rotation_cos * tmp - rotation_sin * rotated_pos.z);
-				rotated_pos.z = (float)(rotation_sin * tmp + rotation_cos * rotated_pos.z);
-				for (int j = 0; j < special_sps.shpGo.Length; j++)
-					special_sps.shpGo[j].transform.localPosition = rotated_pos;
-				special_sps.isUpdate = show_special;
-				special_sps.AnimateSHP();
-				special_sps.lastFrame = special_sps.curFrame;
-				if (this._specialSpsRemovingList[i])
-					this._specialSpsFadingList[i] -= 0.05f;
-				if (this._specialSpsFadingList[i] > 0.0f)
-					special_sps.isUpdate = true;
-				else
-					for (int j = 0; j < special_sps.shpGo.Length; j++)
-						special_sps.shpGo[j].SetActive(false);
-			}
+                if (special_sps.rotate)
+                {
+                    double rotation_cos = Math.Cos(2 * Math.PI * special_sps.curFrame / 10000) * this._specialSpsFadingList[i]; // 1 turn every 10 seconds
+                    double rotation_sin = Math.Sin(2 * Math.PI * special_sps.curFrame / 10000) * this._specialSpsFadingList[i];
+                    Vector3 rotated_pos = BattleSPSSystem.statusTextures[special_sps.refNo].extraPos;
+                    float tmp = rotated_pos.x;
+                    rotated_pos.x = (float)(rotation_cos * tmp - rotation_sin * rotated_pos.z);
+                    rotated_pos.z = (float)(rotation_sin * tmp + rotation_cos * rotated_pos.z);
+                    for (int j = 0; j < special_sps.shpGo.Length; j++)
+                        special_sps.shpGo[j].transform.localPosition = rotated_pos;
+                }
+                else
+                {
+                    Vector3 sps_pos = statusTextures[special_sps.refNo].extraPos;
+                    Vector3 bone_pos = special_sps.btl.gameObject.transform.GetChildByName("bone" + special_sps.bone.ToString("D3")).position;
+                    btl2d.GetIconPosition(special_sps.btl, out Byte[] iconBones, out SByte[] iconOffsY, out SByte[] iconOffsZ);
+                    Int16 dy = (Int16)(sps_pos.y * 8);
+                    Int16 dz = (Int16)(sps_pos.z * 8);
+                    Int32 angledx = ff9.rsin((Int32)(special_sps.btl.rot.eulerAngles.y / 360f * 4096f));
+                    Int32 angledz = ff9.rcos((Int32)(special_sps.btl.rot.eulerAngles.y / 360f * 4096f));
+                    bone_pos.x += dz * angledx >> 12;
+                    bone_pos.y -= dy;
+                    bone_pos.z += dz * angledz >> 12;
+                    special_sps.pos = bone_pos;
+                }
+                special_sps.isUpdate = show_special;
+                special_sps.AnimateSHP();
+                special_sps.lastFrame = special_sps.curFrame;
+                if (this._specialSpsRemovingList[i])
+                    this._specialSpsFadingList[i] -= special_sps.rotate ? 0.05f : 1f;
+                if (this._specialSpsFadingList[i] > 0.0f)
+                    special_sps.isUpdate = true;
+                else
+                    for (int j = 0; j < special_sps.shpGo.Length; j++)
+                        special_sps.shpGo[j].SetActive(false);
+            }
 		}
 	}
 
 	private Boolean _loadSPSTexture()
 	{
-		for (Int32 i = 0; i < BattleSPSSystem.statusTextures.Length; i++)
-		{
+        for (Int32 i = 0; i < BattleSPSSystem.statusTextures.Count; i++)
+        {
 			BattleSPSSystem.SPSTexture spstexture = BattleSPSSystem.statusTextures[i];
 			for (Int32 j = 0; j < spstexture.textures.Length; j++)
 			{
@@ -384,11 +402,11 @@ public class BattleSPSSystem : MonoBehaviour
 		return (Int32)(btl.bi.line_no * 12) + statusSPSIndex;
 	}
 
-	public void AddBtlSPSObj(BattleUnit btl, BattleStatus status)
-	{
+    public void AddBtlSPSObj(BTL_DATA btl, BattleStatus status)
+    {
 		Int32 statusSPSIndex = this.GetStatusSPSIndex(status);
-		Int32 objSpsIndex = this.GetObjSpsIndex(btl.Data, status);
-		btl2d.STAT_ICON_TBL stat_ICON_TBL = btl2d.wStatIconTbl[statusSPSIndex];
+        Int32 objSpsIndex = this.GetObjSpsIndex(btl, status);
+        btl2d.STAT_ICON_TBL stat_ICON_TBL = btl2d.wStatIconTbl[statusSPSIndex];
 		this.SetBtlStatus(objSpsIndex, statusSPSIndex, stat_ICON_TBL.Abr, (Int32)stat_ICON_TBL.Type);
 	}
 
@@ -400,7 +418,14 @@ public class BattleSPSSystem : MonoBehaviour
 		this.SetBtlStatus(objSpsIndex, -1, stat_ICON_TBL.Abr, (Int32)stat_ICON_TBL.Type);
 	}
 
-	public void SetActiveSHP(Boolean active)
+    public void ResetBtlSPSObj(BTL_DATA btl, BattleStatus status)
+    {
+        btl2d.STAT_ICON_TBL stat_ICON_TBL = btl2d.wStatIconTbl[GetStatusSPSIndex(status)];
+        SetBtlStatus(GetObjSpsIndex(btl, status), -1, stat_ICON_TBL.Abr, (Int32)stat_ICON_TBL.Type);
+        SetBtlStatus(GetObjSpsIndex(btl, status), GetStatusSPSIndex(status), stat_ICON_TBL.Abr, (Int32)stat_ICON_TBL.Type);
+    }
+
+    public void SetActiveSHP(Boolean active)
 	{
 		for (Int32 i = 0; i < this._spsList.Count; i++)
 		{
@@ -416,9 +441,9 @@ public class BattleSPSSystem : MonoBehaviour
 		}
 	}
 
-	public void AddSpecialSPSObj(int specialid, uint spstype, Vector3 pos, float scale)
-	{
-		BattleSPS special_sps;
+    public void AddSpecialSPSObj(int specialid, uint spstype, BTL_DATA btl, int bone, float scale, out int SPSid, Boolean rotate = false)
+    {
+        BattleSPS special_sps;
 		if (specialid < 0 || specialid > _specialSpsList.Count)
 			specialid = _specialSpsList.Count;
 		if (specialid == _specialSpsList.Count)
@@ -445,11 +470,20 @@ public class BattleSPSSystem : MonoBehaviour
 			this._specialSpsFadingList[specialid] = 1.0f;
 			this._specialSpsRemovingList[specialid] = false;
 		}
-		special_sps.pos = pos;
-		special_sps.curFrame = 0;
-		special_sps.lastFrame = 0;
+        if (bone < 0 || bone > FF9StateSystem.Battle.FF9Battle.enemy[btl.bi.slot_no].et.icon_bone[5])
+        {
+            btl2d.GetIconPosition(btl, out Byte[] iconBones, out _, out _);
+            bone = iconBones[3];
+        }
+        SPSid = specialid;
+        special_sps.pos = btl.gameObject.transform.GetChildByName("bone" + bone.ToString("D3")).position;
+        special_sps.curFrame = 0;
+        special_sps.lastFrame = 0;
 		special_sps.frameCount = 10000;
-		special_sps.attr |= 1;
+        special_sps.rotate = rotate;
+        special_sps.btl = btl;
+        special_sps.bone = bone;
+        special_sps.attr |= 1;
 		special_sps.isUpdate = true;
 		special_sps.refNo = (int)spstype;
 		special_sps.type = (BattleSPSSystem.statusTextures[(int)spstype].type.Equals("shp") ? 1 : 0);
@@ -480,9 +514,9 @@ public class BattleSPSSystem : MonoBehaviour
 
 	public Vector3 rot;
 
-	public static BattleSPSSystem.SPSTexture[] statusTextures = new BattleSPSSystem.SPSTexture[]
-	{
-		new BattleSPSSystem.SPSTexture("poison", "sps", 1, Vector3.zero, 6f, 4f),
+    public static List<BattleSPSSystem.SPSTexture> statusTextures = new List<BattleSPSSystem.SPSTexture>()
+    {
+        new BattleSPSSystem.SPSTexture("poison", "sps", 1, Vector3.zero, 6f, 4f),
 		new BattleSPSSystem.SPSTexture("venom", "sps", 1, Vector3.zero, 2f, 1.5f),
 		new BattleSPSSystem.SPSTexture("slow", "shp", 6, new Vector3(212f, 0f, 0f), 4f, 5f),
 		new BattleSPSSystem.SPSTexture("haste", "shp", 6, new Vector3(-148f, 0f, 0f), 4f, 5f),

--- a/Assembly-CSharp/Global/btl_scrp.cs
+++ b/Assembly-CSharp/Global/btl_scrp.cs
@@ -660,11 +660,11 @@ public class btl_scrp
 		case 130u: // Note: Very crafty. Creates elemental orbs (special SPS) rotating around the BTL_DATA...
 			if (val == 3)
 			{
-				UnityEngine.Vector3 btl_pos = btl.gameObject.transform.GetChildByName("bone000").position;
-				HonoluluBattleMain.battleSPS.AddSpecialSPSObj(0, 12, btl_pos, 4.0f);
-				HonoluluBattleMain.battleSPS.AddSpecialSPSObj(1, 13, btl_pos, 4.0f);
-				HonoluluBattleMain.battleSPS.AddSpecialSPSObj(2, 14, btl_pos, 4.0f);
-			}
+                // UnityEngine.Vector3 btl_pos = btl.gameObject.transform.GetChildByName("bone000").position;
+                HonoluluBattleMain.battleSPS.AddSpecialSPSObj(0, 12, btl, 0, 4.0f, out _, true);
+                HonoluluBattleMain.battleSPS.AddSpecialSPSObj(1, 13, btl, 0, 4.0f, out _, true);
+                HonoluluBattleMain.battleSPS.AddSpecialSPSObj(2, 14, btl, 0, 4.0f, out _, true);
+                }
 			else if (val == 2) // ... and remove them 1 by 1
 				HonoluluBattleMain.battleSPS.RemoveSpecialSPSObj(2);
 			else if (val == 1)

--- a/Assembly-CSharp/Memoria/Configuration/DataPatchers.cs
+++ b/Assembly-CSharp/Memoria/Configuration/DataPatchers.cs
@@ -475,7 +475,45 @@ namespace Memoria
 						FF9BattleDB.Animation[ID[idindex]] = entry[entry.Length - 1];
 					}
 				}
-			}
+                else if (String.Compare(entry[0], "SwapFieldModelTexture") == 0)
+                {
+                    // eg.: SwapFieldModelTexture 2250 GEO_MON_B3_093 CustomTextures/OeilvertGuardian/342_0.png CustomTextures/OeilvertGuardian/342_1.png CustomTextures/OeilvertGuardian/342_2.png CustomTextures/OeilvertGuardian/342_3.png CustomTextures/OeilvertGuardian/342_4.png CustomTextures/OeilvertGuardian/342_5.png
+                    List<string> TexturesList = new List<string>();
+                    if (!Int32.TryParse(entry[1], out Int32 FieldID))
+                        continue;
+                    if (entry[1] == null || entry[2] == null)
+                        continue;
+                    for (Int32 i = 3; i < entry.Length; i++)
+                    {
+                        TexturesList.Add(entry[i]);
+                    }
+                    String[] TexturesCustomModel = TexturesList.ToArray();
+                    ModelFactory.CustomModelField.Add(entry[1] + "#" + entry[2], TexturesCustomModel);
+                }
+                else if (String.Compare(entry[0], "SPSTexture") == 0)
+                {
+                    // eg.: SPSTexture customfireorb shp 3 400 0 0 5 5
+                    if (entry[1] == null || entry[2] == null)
+                        continue;
+
+                    if (!Int32.TryParse(entry[3], out Int32 numbertexture))
+                        continue;
+                    if (!float.TryParse(entry[4], out float posx))
+                        continue;
+                    if (!float.TryParse(entry[5], out float posy))
+                        continue;
+                    if (!float.TryParse(entry[6], out float posz))
+                        continue;
+
+                    if (!float.TryParse(entry[7], out float SPSScale))
+                        SPSScale = 4;
+                    if (!float.TryParse(entry[8], out float SPSDistance))
+                        SPSDistance = 5;
+
+                    Vector3 SPSpos = new Vector3(posx, posy, posz);
+                    BattleSPSSystem.statusTextures.Add(new BattleSPSSystem.SPSTexture(entry[1], entry[2], numbertexture, SPSpos, SPSScale, SPSDistance));
+                }
+            }
 			if (shouldUpdateBattleStatus)
 				BattleStatusConst.Update();
 		}


### PR DESCRIPTION
Add two new options on DictionaryPatch : 

- Custom SPS modification (will be modified much later, but necessary for Trance Seek CD3)
Exemple : `SPSTexture dragon shp 1 -350 20 5 2 5`
- Possibility of modifying the texture of certain models on the fields.
Exemple : `SwapFieldModelTexture 2553 GEO_MON_B3_142 CustomTextures/WaterGuardian/378_0.png CustomTextures/WaterGuardian/378_1.png CustomTextures/WaterGuardian/378_2.png CustomTextures/WaterGuardian/378_3.png CustomTextures/WaterGuardian/378_4.png CustomTextures/WaterGuardian/378_5.png `