### PR TITLE
Fixed return to title warning partially showing

### DIFF
--- a/Assembly-CSharp/Global/Config/ConfigUI.cs
+++ b/Assembly-CSharp/Global/Config/ConfigUI.cs
@@ -679,6 +679,7 @@ public class ConfigUI : UIScene
         }
         ButtonGroupState.HelpEnabled = false;
         HelpDespLabelGameObject.SetActive(false);
+        WarningDialog.SetActive(false);
         // Disable soft-reset and tutorials in battles (it leads to bugs because things are not cleaned correctly yet)
         if (PersistenSingleton<UIManager>.Instance.UnityScene == UIManager.Scene.Battle)
         {


### PR DESCRIPTION
This would happen when you return to the title and go back in the Config menu
![image](https://github.com/Albeoris/Memoria/assets/2388532/ae6b8517-676b-48dc-8616-d3a7c65294af)
