### PR TITLE
Poison SPS dissapear randomly.

### DIFF
--- a/Assembly-CSharp/Global/btl_stat.cs
+++ b/Assembly-CSharp/Global/btl_stat.cs
@@ -364,7 +364,7 @@ public static class btl_stat
                 btl_cmd.KillSpecificCommand(btl, BattleCommandId.SysStone);
                 break;
         }
-        HonoluluBattleMain.battleSPS.RemoveBtlSPSObj(btl, status);
+        // HonoluluBattleMain.battleSPS.RemoveBtlSPSObj(btl, status); [DV] Somehow, fix a bug when Poison SPS randomly dissapear in battle.
         BattleVoice.TriggerOnStatusChange(btl, "Removed", status);
         return 2;
     }


### PR DESCRIPTION
Sometimes, the poison (the purple bubbles above a character or enemy) disappears randomly.

By commenting this line, this bug no longer appears... but I don't understand why 👀.

I'll have to run more tests first to see if it's not a problem (it shouldn't be, but there have been a lot of commits since i found this fix).