### PR TITLE
DoubleCast command compatible with Item/Throw + Mix command script

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -355,6 +355,8 @@
     <Compile Include="Memoria\Configuration\Structure\InterfaceSection.cs" />
     <Compile Include="Memoria\Data\Battle\BattleCommandMenu.cs" />
     <Compile Include="Memoria\Data\Battle\BattleMagicSwordSet.cs" />
+    <Compile Include="Memoria\Data\ff9mixitem.cs" />
+    <Compile Include="Memoria\Data\Items\MixItems.cs" />
     <Compile Include="Memoria\Data\TetraMaster\TripleTriad.cs" />
     <Compile Include="Memoria\Data\TetraMaster\TripleTriadCard.cs" />
     <Compile Include="Memoria\Data\TetraMaster\TetraMasterCardId.cs" />

--- a/Assembly-CSharp/Assets/Sources/Scripts/UI/Common/FF9TextTool.cs
+++ b/Assembly-CSharp/Assets/Sources/Scripts/UI/Common/FF9TextTool.cs
@@ -19,6 +19,7 @@ namespace Assets.Sources.Scripts.UI.Common
         public static Color Cyan => new Color(0.407843143f, 0.7529412f, 0.847058833f);
         public static Color Red => new Color(0.8156863f, 0.3764706f, 0.3137255f);
         public static Color Yellow => new Color(0.784313738f, 0.6901961f, 0.2509804f);
+        public static Color DarkYellow => new Color(0.588f, 0.584f, 0.267f);
         public static Color Magenta => new Color(0.721568644f, 0.5019608f, 0.8784314f);
 
         public static Int32 FieldZoneId => fieldZoneId;

--- a/Assembly-CSharp/FF9/btl_mot.cs
+++ b/Assembly-CSharp/FF9/btl_mot.cs
@@ -547,7 +547,7 @@ namespace FF9
 			BattlePlayerCharacter.PlayerMotionIndex currentAnim = btl_mot.getMotion(btl);
 			if (btl_stat.CheckStatus(btl, BattleStatusConst.Immobilized))
 			{
-				if (btl.bi.player != 0 && !btl.is_monster_transform && btl_stat.CheckStatus(btl, BattleStatusConst.IdleDying))
+				if (btl.bi.player != 0 && !btl.is_monster_transform && btl_stat.CheckStatus(btl, BattleStatusConst.Immobilized & BattleStatusConst.IdleDying))
 				{
 					btl_mot.setMotion(btl, BattlePlayerCharacter.PlayerMotionIndex.MP_IDLE_DYING);
 					btl.evt.animFrame = 0;

--- a/Assembly-CSharp/FF9/btl_mot.cs
+++ b/Assembly-CSharp/FF9/btl_mot.cs
@@ -547,7 +547,7 @@ namespace FF9
 			BattlePlayerCharacter.PlayerMotionIndex currentAnim = btl_mot.getMotion(btl);
 			if (btl_stat.CheckStatus(btl, BattleStatusConst.Immobilized))
 			{
-				if (btl.bi.player != 0 && !btl.is_monster_transform && btl_stat.CheckStatus(btl, BattleStatus.Venom & BattleStatusConst.IdleDying))
+				if (btl.bi.player != 0 && !btl.is_monster_transform && btl_stat.CheckStatus(btl, BattleStatusConst.IdleDying))
 				{
 					btl_mot.setMotion(btl, BattlePlayerCharacter.PlayerMotionIndex.MP_IDLE_DYING);
 					btl.evt.animFrame = 0;
@@ -599,15 +599,15 @@ namespace FF9
 				targetAnim = BattlePlayerCharacter.PlayerMotionIndex.MP_ESCAPE;
 			else if (btl.bi.cmd_idle == 1)
 				targetAnim = BattlePlayerCharacter.PlayerMotionIndex.MP_IDLE_CMD;
-			if (currentAnim == targetAnim)
+            if (currentAnim == targetAnim)
 			{
 				if (isEndOfAnim)
 					btl.evt.animFrame = 0;
 				return;
 			}
-			BattlePlayerCharacter.PlayerMotionStance previousStance = btl_mot.EndingMotionStance(currentAnim);
+            BattlePlayerCharacter.PlayerMotionStance previousStance = btl_mot.EndingMotionStance(currentAnim);
 			BattlePlayerCharacter.PlayerMotionStance nextStance = btl_mot.StartingMotionStance(targetAnim);
-			if (previousStance == BattlePlayerCharacter.PlayerMotionStance.SPECIAL_ANY_IDLE)
+            if (previousStance == BattlePlayerCharacter.PlayerMotionStance.SPECIAL_ANY_IDLE)
 			{
 				if (nextStance == BattlePlayerCharacter.PlayerMotionStance.NORMAL || nextStance == BattlePlayerCharacter.PlayerMotionStance.CMD || nextStance == BattlePlayerCharacter.PlayerMotionStance.DYING || nextStance == BattlePlayerCharacter.PlayerMotionStance.DEFEND)
 				{

--- a/Assembly-CSharp/FF9/btl_util.cs
+++ b/Assembly-CSharp/FF9/btl_util.cs
@@ -282,7 +282,7 @@ namespace FF9
 
 		public static BattleAbilityId GetCommandMainActionIndex(CMD_DATA cmd)
 		{
-			if (cmd.regist != null && cmd.regist.bi.player == 0)
+            if (cmd.regist != null && cmd.regist.bi.player == 0)
 				return BattleAbilityId.Void;
 			if (IsCommandMonsterTransform(cmd))
 				return BattleAbilityId.Void;
@@ -307,24 +307,26 @@ namespace FF9
 			}
 		}
 
-		public static RegularItem GetCommandItem(CMD_DATA cmd)
-		{
-			if (cmd.regist != null && cmd.regist.bi.player == 0)
-				return RegularItem.NoItem;
-			if (IsCommandMonsterTransform(cmd) || IsCommandMonsterTransformAttack(cmd))
-				return RegularItem.NoItem;
-			switch (cmd.cmd_no)
-			{
-				case BattleCommandId.Throw:
-				case BattleCommandId.Item:
-				case BattleCommandId.AutoPotion:
-					return (RegularItem)cmd.sub_no;
-				default:
-					return RegularItem.NoItem;
-			}
-		}
+        public static RegularItem GetCommandItem(CMD_DATA cmd)
+        {
+            if (cmd.regist != null && cmd.regist.bi.player == 0)
+                return RegularItem.NoItem;
+            if (IsCommandMonsterTransform(cmd) || IsCommandMonsterTransformAttack(cmd))
+                return RegularItem.NoItem;
+            if (BattleHUD.MixCommandSet.Contains(cmd.cmd_no))
+                return ff9mixitem.MixItemsData[cmd.sub_no].Result;
+            switch (cmd.cmd_no)
+            {
+                case BattleCommandId.Throw:
+                case BattleCommandId.Item:
+                case BattleCommandId.AutoPotion:
+                    return (RegularItem)cmd.sub_no;
+                default:
+                    return RegularItem.NoItem;
+            }
+        }
 
-		public static AA_DATA GetCommandMonsterAttack(CMD_DATA cmd)
+        public static AA_DATA GetCommandMonsterAttack(CMD_DATA cmd)
 		{
 			if (IsCommandMonsterTransform(cmd))
 				return cmd.regist.monster_transform.spell[cmd.sub_no];
@@ -347,7 +349,9 @@ namespace FF9
 
 		public static Int32 GetCommandScriptId(CMD_DATA cmd)
 		{
-			switch (cmd.cmd_no)
+            if (BattleHUD.MixCommandSet.Contains(cmd.cmd_no))
+                return ff9item.GetItemEffect(btl_util.GetCommandItem(cmd)).Ref.ScriptId;
+            switch (cmd.cmd_no)
 			{
 				case BattleCommandId.Jump:
 				case BattleCommandId.Jump2:

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
@@ -113,6 +113,8 @@ public partial class BattleHUD : UIScene
                 return aaData.Name;
             return String.Empty;
         }
+        if (MixCommandSet.Contains(pCmd.cmd_no))
+            return FF9TextTool.ItemName(ff9mixitem.MixItemsData[pCmd.sub_no].Result);
         switch (pCmd.cmd_no)
         {
             case BattleCommandId.Item:

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
@@ -20,6 +20,7 @@ public partial class BattleHUD : UIScene
     public GameObject PlayerTargetPanel => TargetPanel.GetChild(0);
     public GameObject EnemyTargetPanel => TargetPanel.GetChild(1);
     public Boolean IsDoubleCast => DoubleCastSet.Contains(_currentCommandId) || MixCommandSet.Contains(_currentCommandId);
+    public Boolean IsMixCast => MixCommandSet.Contains(_currentCommandId);
     public Boolean CanForceNextTurn => Configuration.Battle.Speed == 2 && UIManager.Battle.FF9BMenu_IsEnable() && !ForceNextTurn
         && ReadyQueue.Count > 0 && FF9StateSystem.Battle.FF9Battle.cur_cmd == null && btl_cmd.GetFirstCommandReadyToDequeue(FF9StateSystem.Battle.FF9Battle) == null;
     public List<Int32> ReadyQueue { get; }

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
@@ -19,7 +19,7 @@ public partial class BattleHUD : UIScene
     public Boolean BtlWorkPeep => _currentPeepingMessageCount > 0;
     public GameObject PlayerTargetPanel => TargetPanel.GetChild(0);
     public GameObject EnemyTargetPanel => TargetPanel.GetChild(1);
-    public Boolean IsDoubleCast => DoubleCastSet.Contains(_currentCommandId);
+    public Boolean IsDoubleCast => DoubleCastSet.Contains(_currentCommandId) || MixCommandSet.Contains(_currentCommandId);
     public Boolean CanForceNextTurn => Configuration.Battle.Speed == 2 && UIManager.Battle.FF9BMenu_IsEnable() && !ForceNextTurn
         && ReadyQueue.Count > 0 && FF9StateSystem.Battle.FF9Battle.cur_cmd == null && btl_cmd.GetFirstCommandReadyToDequeue(FF9StateSystem.Battle.FF9Battle) == null;
     public List<Int32> ReadyQueue { get; }
@@ -29,6 +29,7 @@ public partial class BattleHUD : UIScene
         BattleCommandId.DoubleBlackMagic,
         BattleCommandId.DoubleWhiteMagic
     };
+    public static HashSet<BattleCommandId> MixCommandSet = new HashSet<BattleCommandId>();
     public static Boolean ForceNextTurn = false;
     public static Int32 switchBtlId = -1;
 

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Scene.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Scene.cs
@@ -334,8 +334,17 @@ public partial class BattleHUD : UIScene
             else if (ButtonGroupState.ActiveGroup == ItemGroupButton)
             {
                 FF9Sfx.FF9SFX_Play(101);
-                SetItemPanelVisibility(false, false);
-                SetCommandVisibility(true, true);
+                if (IsDoubleCast && _doubleCastCount > 0)
+                    --_doubleCastCount;
+                if (_doubleCastCount == 0)
+                {
+                    SetItemPanelVisibility(false, false);
+                    SetCommandVisibility(true, true);
+                }
+                else
+                {
+                    SetItemPanelVisibility(true, false);
+                }
             }
             else if (ButtonGroupState.ActiveGroup == String.Empty && UIManager.Input.ContainsAndroidQuitKey())
             {

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Scene.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Scene.cs
@@ -267,8 +267,18 @@ public partial class BattleHUD : UIScene
                 FF9Sfx.FF9SFX_Play(103);
                 _currentSubMenuIndex = go.GetComponent<RecycleListItem>().ItemDataIndex;
                 _abilityCursorMemorize[new PairCharCommand(CurrentPlayerIndex, _currentCommandId)] = _currentSubMenuIndex;
-                SetItemPanelVisibility(false, false);
-                SetTargetVisibility(true);
+                if (IsMixCast && _doubleCastCount < 2)
+                {
+                    ++_doubleCastCount;
+                    _firstCommand = ProcessCommand(1, _cursorType);
+                    DisplayItem(CharacterCommands.Commands[_firstCommand.CommandId].Type == CharacterCommandType.Throw);
+                    SetItemPanelVisibility(true, true);
+                }
+                else
+                {
+                    SetItemPanelVisibility(false, false);
+                    SetTargetVisibility(true);
+                }
             }
             else
             {

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Scene.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Scene.cs
@@ -344,6 +344,7 @@ public partial class BattleHUD : UIScene
                 else
                 {
                     SetItemPanelVisibility(true, false);
+                    DisplayItem(CharacterCommands.Commands[_currentCommandId].Type == CharacterCommandType.Throw);
                 }
             }
             else if (ButtonGroupState.ActiveGroup == String.Empty && UIManager.Input.ContainsAndroidQuitKey())

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Scene.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Scene.cs
@@ -1,4 +1,5 @@
-﻿using FF9;
+﻿using Assets.Sources.Scripts.UI.Common;
+using FF9;
 using Memoria;
 using Memoria.Data;
 using Memoria.Database;
@@ -264,6 +265,12 @@ public partial class BattleHUD : UIScene
         {
             if (_itemIdList[_currentSubMenuIndex] != RegularItem.NoItem)
             {
+                ItemListDetailWithIconHUD detailHUD = new ItemListDetailWithIconHUD(go, true);
+                if (detailHUD.NameLabel.color == FF9TextTool.Gray || detailHUD.NameLabel.color == FF9TextTool.DarkYellow)
+                {
+                    FF9Sfx.FF9SFX_Play(102);
+                    return true;
+                }
                 FF9Sfx.FF9SFX_Play(103);
                 _currentSubMenuIndex = go.GetComponent<RecycleListItem>().ItemDataIndex;
                 _abilityCursorMemorize[new PairCharCommand(CurrentPlayerIndex, _currentCommandId)] = _currentSubMenuIndex;

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
@@ -1126,11 +1126,23 @@ public partial class BattleHUD : UIScene
 
             ++_doubleCastCount;
             _firstCommand = ProcessCommand(battleIndex, cursorGroup);
-            _subMenuType = SubMenuType.Ability;
 
-            DisplayAbility();
-            SetTargetVisibility(false);
-            SetAbilityPanelVisibility(true, true);
+            CharacterCommandType commandType = CharacterCommands.Commands[_firstCommand.CommandId].Type;
+
+            if (commandType == CharacterCommandType.Item || commandType == CharacterCommandType.Throw)
+            {
+                _subMenuType = commandType == CharacterCommandType.Item ? SubMenuType.Item : SubMenuType.Throw;
+                DisplayItem(commandType == CharacterCommandType.Throw);
+                SetTargetVisibility(false);
+                SetItemPanelVisibility(true, true);
+            }                
+            else
+            {
+                _subMenuType = SubMenuType.Ability;
+                DisplayAbility();
+                SetTargetVisibility(false);
+                SetAbilityPanelVisibility(true, true);
+            }
             BackButton.SetActive(FF9StateSystem.MobilePlatform);
         }
     }
@@ -1645,15 +1657,24 @@ public partial class BattleHUD : UIScene
     {
         if (isVisible)
         {
-            ItemPanel.SetActive(true);
-            ButtonGroupState.RemoveCursorMemorize(ItemGroupButton);
-            PairCharCommand cursorKey = new PairCharCommand(CurrentPlayerIndex, _currentCommandId);
-            if (_abilityCursorMemorize.ContainsKey(cursorKey) && FF9StateSystem.Settings.cfg.cursor != 0 || forceCursorMemo)
-                _itemScrollList.JumpToIndex(_abilityCursorMemorize[cursorKey], true);
+            if (!ItemPanel.activeSelf)
+            {
+                ItemPanel.SetActive(true);
+                ButtonGroupState.RemoveCursorMemorize(ItemGroupButton);
+                PairCharCommand cursorKey = new PairCharCommand(CurrentPlayerIndex, _currentCommandId);
+                if (_abilityCursorMemorize.ContainsKey(cursorKey) && FF9StateSystem.Settings.cfg.cursor != 0 || forceCursorMemo)
+                    _itemScrollList.JumpToIndex(_abilityCursorMemorize[cursorKey], true);
+                else
+                    _itemScrollList.JumpToIndex(0, false);
+            }
+            if (IsDoubleCast && _doubleCastCount == 1)
+                ButtonGroupState.SetPointerNumberToGroup(1, ItemGroupButton);
+            else if (IsDoubleCast && _doubleCastCount == 2)
+                ButtonGroupState.SetPointerNumberToGroup(2, ItemGroupButton);
             else
-                _itemScrollList.JumpToIndex(0, false);
-            ButtonGroupState.RemoveCursorMemorize(ItemGroupButton);
+                ButtonGroupState.SetPointerNumberToGroup(0, ItemGroupButton);
             ButtonGroupState.ActiveGroup = ItemGroupButton;
+            ButtonGroupState.UpdateActiveButton();
         }
         else
         {

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
@@ -1587,7 +1587,7 @@ public partial class BattleHUD : UIScene
         CMD_DATA cmd2 = FF9StateSystem.Battle.FF9Battle.btl_data[CurrentPlayerIndex].cmd[0]; // The second command sent/performed is the main one (it resets the ATB correctly amongst other things)
         cmd1.regist.sel_mode = 1;
         btl_cmd.SetCommand(cmd1, first.CommandId, first.SubId, first.TargetId, first.TargetType, cmdMenu: first.Menu);
-        btl_cmd.SetCommand(cmd2, second.CommandId, second.SubId, second.TargetId, second.TargetType, cmdMenu: second.Menu);
+        btl_cmd.SetCommand(cmd2, second.CommandId, second.SubId, second.TargetId, second.TargetType, cmdMenu: second.Menu, IdleAnim: false); // Disable IdleAnim otherwise, the animation will skip to MP_IDLE_CMD
         SetPartySwapButtonActive(false);
         InputFinishList.Add(CurrentPlayerIndex);
 

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
@@ -1734,7 +1734,7 @@ public partial class BattleHUD : UIScene
     private void SetTargetVisibility(Boolean isVisible)
     {
         if (isVisible)
-        {
+        {     
             TargetType targetType = 0;
             TargetDisplay subMode = 0;
             _defaultTargetAlly = false;
@@ -1760,27 +1760,6 @@ public partial class BattleHUD : UIScene
                 testCommand.SetAAData(aaData);
                 testCommand.ScriptId = btl_util.GetCommandScriptId(testCommand);
 
-                SelectBestTarget(targetType, testCommand);
-            }
-            else if (_currentCommandIndex == BattleCommandMenu.Item)
-            {
-                RegularItem itemId = _itemIdList[_currentSubMenuIndex];
-                ITEM_DATA itemData = ff9item.GetItemEffect(itemId);
-                targetType = itemData.info.Target;
-                _defaultTargetAlly = itemData.info.DefaultAlly;
-                _defaultTargetDead = itemData.info.ForDead;
-                _targetDead = itemData.info.ForDead;
-                subMode = itemData.info.DisplayStats;
-
-                CMD_DATA testCommand = new CMD_DATA
-                {
-                    regist = FF9StateSystem.Battle.FF9Battle.btl_data[CurrentPlayerIndex],
-                    cmd_no = _currentCommandId,
-                    sub_no = (Int32)itemId
-                };
-                testCommand.SetAAData(FF9StateSystem.Battle.FF9Battle.aa_data[BattleAbilityId.Void]);
-                testCommand.ScriptId = btl_util.GetCommandScriptId(testCommand);
-
                 if (Configuration.Mod.TranceSeek && _currentCommandId == BattleCommandId.Throw) // [DV] Change TargetType for throwing items (magic scrolls for Trance Seek)
                 { // Or i can make it with the DictionaryPatch.txt instead ?
                     ItemAttack weapon = ff9item.GetItemWeapon(_itemIdList[_currentSubMenuIndex]);
@@ -1803,6 +1782,26 @@ public partial class BattleHUD : UIScene
                         }
                     }
                 }
+                SelectBestTarget(targetType, testCommand);
+            }
+            else if (_currentCommandIndex == BattleCommandMenu.Item)
+            {
+                RegularItem itemId = _itemIdList[_currentSubMenuIndex];
+                ITEM_DATA itemData = ff9item.GetItemEffect(itemId);
+                targetType = itemData.info.Target;
+                _defaultTargetAlly = itemData.info.DefaultAlly;
+                _defaultTargetDead = itemData.info.ForDead;
+                _targetDead = itemData.info.ForDead;
+                subMode = itemData.info.DisplayStats;
+
+                CMD_DATA testCommand = new CMD_DATA
+                {
+                    regist = FF9StateSystem.Battle.FF9Battle.btl_data[CurrentPlayerIndex],
+                    cmd_no = _currentCommandId,
+                    sub_no = (Int32)itemId
+                };
+                testCommand.SetAAData(FF9StateSystem.Battle.FF9Battle.aa_data[BattleAbilityId.Void]);
+                testCommand.ScriptId = btl_util.GetCommandScriptId(testCommand);
 
                 SelectBestTarget(targetType, testCommand);
             }

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
@@ -1599,6 +1599,17 @@ public partial class BattleHUD : UIScene
         _partyDetail.SetBlink(CurrentPlayerIndex, false);
     }
 
+    private void SendMixCommand(CommandDetail first, CommandDetail second)
+    {
+        BTL_DATA btl = FF9StateSystem.Battle.FF9Battle.btl_data[CurrentPlayerIndex];
+        CMD_DATA cmd = btl.cmd[0];
+        cmd.regist.sel_mode = 1;
+        btl_cmd.SetCommand(cmd, first.CommandId, first.SubId, first.TargetId, first.TargetType, cmdMenu: first.Menu, ItemMix: second.SubId);
+        SetPartySwapButtonActive(false);
+        InputFinishList.Add(CurrentPlayerIndex);
+        _partyDetail.SetBlink(CurrentPlayerIndex, false);
+    }
+
     private void SetCommandVisibility(Boolean isVisible, Boolean forceCursorMemo)
     {
         SetPartySwapButtonActive(isVisible);
@@ -2392,7 +2403,9 @@ public partial class BattleHUD : UIScene
             }
         }
 
-        if (IsDoubleCast)
+        if (MixCommandSet.Contains(_currentCommandId))
+            SendMixCommand(_firstCommand, ProcessCommand(battleIndex, _cursorType));
+        else if (IsDoubleCast)
             SendDoubleCastCommand(_firstCommand, ProcessCommand(battleIndex, _cursorType));
         else
             SendCommand(ProcessCommand(battleIndex, _cursorType));

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
@@ -656,6 +656,12 @@ public partial class BattleHUD : UIScene
                     Count = ff9Item.count,
                     Id = ff9Item.id
                 };
+                if (_doubleCastCount == 2 && battleItemListData.Id == (RegularItem)_firstCommand.SubId)
+                {
+                    battleItemListData.Count--;
+                    if (battleItemListData.Count <= 0)
+                        continue;
+                }
                 inDataList.Add(battleItemListData);
             }
         }
@@ -1126,7 +1132,6 @@ public partial class BattleHUD : UIScene
 
             ++_doubleCastCount;
             _firstCommand = ProcessCommand(battleIndex, cursorGroup);
-
             CharacterCommandType commandType = CharacterCommands.Commands[_firstCommand.CommandId].Type;
 
             if (commandType == CharacterCommandType.Item || commandType == CharacterCommandType.Throw)

--- a/Assembly-CSharp/Global/btl_cmd.cs
+++ b/Assembly-CSharp/Global/btl_cmd.cs
@@ -145,7 +145,7 @@ public class btl_cmd
         }
     }
 
-    public static void SetCommand(CMD_DATA cmd, BattleCommandId commandId, Int32 sub_no, UInt16 tar_id, UInt32 cursor, Boolean forcePriority = false, BattleCommandMenu cmdMenu = BattleCommandMenu.None, Boolean IdleAnim = true)
+    public static void SetCommand(CMD_DATA cmd, BattleCommandId commandId, Int32 sub_no, UInt16 tar_id, UInt32 cursor, Boolean forcePriority = false, BattleCommandMenu cmdMenu = BattleCommandMenu.None, Boolean IdleAnim = true, Int32 ItemMix = -1)
     {
         if (btl_cmd.CheckUsingCommand(cmd))
             return;
@@ -243,6 +243,21 @@ public class btl_cmd
             btl_cmd.SetCommand(first_cmd, commandId, cmd.Power, first_tar_id, first_cursor, cmdMenu: cmdMenu);
             btl_cmd.SetCommand(second_cmd, commandId, cmd.HitRate, second_tar_id, second_cursor, cmdMenu: cmdMenu);
             return;
+        }
+        // Mix Command
+        if (caster != null && caster.bi.player != 0 && ItemMix >= 0)
+        {
+            RegularItem ingredient1 = (RegularItem)sub_no;
+            RegularItem ingredient2 = (RegularItem)ItemMix;
+
+            foreach (MixItems mixitem in ff9mixitem.MixItemsData.Values)
+            {
+                if (mixitem.Ingredients.Contains(ingredient1) && mixitem.Ingredients.Contains(ingredient2))
+                {
+                    cmd.sub_no = mixitem.Result;
+                    break;
+                }
+            }
         }
 
         cmd.tar_id = tar_id;

--- a/Assembly-CSharp/Global/btl_cmd.cs
+++ b/Assembly-CSharp/Global/btl_cmd.cs
@@ -145,7 +145,7 @@ public class btl_cmd
         }
     }
 
-    public static void SetCommand(CMD_DATA cmd, BattleCommandId commandId, Int32 sub_no, UInt16 tar_id, UInt32 cursor, Boolean forcePriority = false, BattleCommandMenu cmdMenu = BattleCommandMenu.None)
+    public static void SetCommand(CMD_DATA cmd, BattleCommandId commandId, Int32 sub_no, UInt16 tar_id, UInt32 cursor, Boolean forcePriority = false, BattleCommandMenu cmdMenu = BattleCommandMenu.None, Boolean IdleAnim = true)
     {
         if (btl_cmd.CheckUsingCommand(cmd))
             return;
@@ -276,7 +276,7 @@ public class btl_cmd
             //    }
             //}
             caster.bi.cmd_idle = 1;
-            if (Configuration.Battle.Speed < 3 && caster != null && caster.bi.player != 0)
+            if (Configuration.Battle.Speed < 3 && caster != null && caster.bi.player != 0 && IdleAnim)
                 btl_mot.SetDefaultIdle(caster); // Don't wait for the "Idle" animation to finish its cycle to get ready
         }
         if (commandId == BattleCommandId.SummonGarnet || commandId == BattleCommandId.Phantom || commandId == BattleCommandId.SummonEiko)

--- a/Assembly-CSharp/Memoria/Assets/Text/DataResources.cs
+++ b/Assembly-CSharp/Memoria/Assets/Text/DataResources.cs
@@ -41,6 +41,7 @@ namespace Memoria.Assets
             public static String ItemEffectsFile => "ItemEffects.csv";
             public static String ShopItems => "ShopItems.csv";
             public static String InitialItemsFile => "InitialItems.csv";
+            public static String MixItemsFile => "MixItems.csv";
             public static String ItemEquipPatchFile => "ItemEquipPatch.txt";
 
             public static String ModDirectory(String modFolder)

--- a/Assembly-CSharp/Memoria/Configuration/DataPatchers.cs
+++ b/Assembly-CSharp/Memoria/Configuration/DataPatchers.cs
@@ -294,7 +294,24 @@ namespace Memoria
 						}
 					}
 				}
-				else if (String.Compare(entry[0], "WorldMusicList") == 0 && entry.Length >= 7)
+                else if (String.Compare(entry[0], "MixCommand") == 0)
+                {
+                    // eg.: MixCommand Add 1000
+                    Boolean add = String.Compare(entry[1], "Remove") != 0;
+                    if (String.Compare(entry[1], "Set") == 0)
+                        BattleHUD.MixCommandSet.Clear();
+                    for (Int32 i = 2; i < entry.Length; i++)
+                    {
+                        if (entry[i].TryEnumParse(out BattleCommandId cmdId))
+                        {
+                            if (add)
+                                BattleHUD.MixCommandSet.Add(cmdId);
+                            else
+                                BattleHUD.MixCommandSet.Remove(cmdId);
+                        }
+                    }
+                }
+                else if (String.Compare(entry[0], "WorldMusicList") == 0 && entry.Length >= 7)
 				{
 					// eg.: WorldMusicList 69 22 112 45 95 96 61 62
 					if (ff9.w_musicSet == null)

--- a/Assembly-CSharp/Memoria/Data/Items/MixItems.cs
+++ b/Assembly-CSharp/Memoria/Data/Items/MixItems.cs
@@ -8,8 +8,8 @@ namespace Memoria.Data
     public class MixItems : ICsvEntry
     {
         public String Comment;
-        public Int32 Result;
-
+        public Int32 Id;
+        public RegularItem Result;
         public List<RegularItem> Ingredients = new List<RegularItem>();
 
         public RegularItem this[Int32 index] => Ingredients[index];
@@ -18,10 +18,11 @@ namespace Memoria.Data
         public void ParseEntry(String[] raw, CsvMetaData metadata)
         {
             Comment = CsvParser.String(raw[0]);
-            Result = CsvParser.Int32(raw[1]);
+            Id = CsvParser.Int32(raw[1]);
+            Result = (RegularItem)CsvParser.Int32(raw[2]);
 
             Ingredients.Clear();
-            for (Int32 i = 2; i < raw.Length; i++)
+            for (Int32 i = 3; i < raw.Length; i++)
             {
                 String value = raw[i];
                 if (String.IsNullOrEmpty(value))
@@ -36,7 +37,7 @@ namespace Memoria.Data
                     {
                         stop = true;
                         break;
-                    }
+                    }                 
                     Ingredients.Add(itemId);
                 }
                 if (stop)
@@ -47,9 +48,24 @@ namespace Memoria.Data
         public void WriteEntry(CsvWriter writer, CsvMetaData metadata)
         {
             writer.String(Comment);
-            writer.Int32(Result);
+            writer.Int32(Id);
+            writer.Item((Int32)Result);
 
             writer.ItemArray(Ingredients.Select(it => (Int32)it).ToArray());
+        }
+
+        public Dictionary<RegularItem, Int32> GetIngredientsAsDict()
+        {
+            Dictionary<RegularItem, Int32> ingrCount = new Dictionary<RegularItem, Int32>();
+            foreach (RegularItem ingr in Ingredients)
+            {
+                if (ingr == RegularItem.NoItem)
+                    continue;
+                if (!ingrCount.TryGetValue(ingr, out Int32 count))
+                    count = 0;
+                ingrCount[ingr] = ++count;
+            }
+            return ingrCount;
         }
     }
 }

--- a/Assembly-CSharp/Memoria/Data/Items/MixItems.cs
+++ b/Assembly-CSharp/Memoria/Data/Items/MixItems.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Memoria.Prime.CSV;
+
+namespace Memoria.Data
+{
+    public class MixItems : ICsvEntry
+    {
+        public String Comment;
+        public Int32 Result;
+
+        public List<RegularItem> Ingredients = new List<RegularItem>();
+
+        public RegularItem this[Int32 index] => Ingredients[index];
+        public Int32 Length => Ingredients.Count;
+
+        public void ParseEntry(String[] raw, CsvMetaData metadata)
+        {
+            Comment = CsvParser.String(raw[0]);
+            Result = CsvParser.Int32(raw[1]);
+
+            Ingredients.Clear();
+            for (Int32 i = 2; i < raw.Length; i++)
+            {
+                String value = raw[i];
+                if (String.IsNullOrEmpty(value))
+                    continue;
+
+                Int32[] itemArray = CsvParser.ItemArray(value);
+                Boolean stop = false;
+                foreach (Int32 itemInt in itemArray)
+                {
+                    RegularItem itemId = (RegularItem)itemInt;
+                    if (itemId == RegularItem.NoItem)
+                    {
+                        stop = true;
+                        break;
+                    }
+                    Ingredients.Add(itemId);
+                }
+                if (stop)
+                    break;
+            }
+        }
+
+        public void WriteEntry(CsvWriter writer, CsvMetaData metadata)
+        {
+            writer.String(Comment);
+            writer.Int32(Result);
+
+            writer.ItemArray(Ingredients.Select(it => (Int32)it).ToArray());
+        }
+    }
+}

--- a/Assembly-CSharp/Memoria/Data/ff9mixitem.cs
+++ b/Assembly-CSharp/Memoria/Data/ff9mixitem.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using Memoria.Assets;
 using Memoria.Data;
 using Memoria.Prime;
@@ -9,22 +8,23 @@ namespace FF9
 {
     public class ff9mixitem
     {
-        public static readonly Dictionary<RegularItem, MixItems> MixItemsData;
+        public static readonly Dictionary<Int32, MixItems> MixItemsData;
 
         static ff9mixitem()
         {
             MixItemsData = LoadSynthesis();
         }
 
-        private static Dictionary<RegularItem, MixItems> LoadSynthesis()
+        private static Dictionary<Int32, MixItems> LoadSynthesis()
         {
             try
             {
                 String inputPath = DataResources.Items.PureDirectory + DataResources.Items.MixItemsFile;
-                Dictionary<RegularItem, MixItems> result = new Dictionary<RegularItem, MixItems>();
-                foreach (MixItems[] ingredients in AssetManager.EnumerateCsvFromLowToHigh<MixItems>(inputPath))
-                    foreach (MixItems ItemMixed in ingredients)
-                        result[(RegularItem)ItemMixed.Result] = ItemMixed;
+                Dictionary<Int32, MixItems> result = new Dictionary<Int32, MixItems>();
+                foreach (MixItems[] mixDatabase in AssetManager.EnumerateCsvFromLowToHigh<MixItems>(inputPath))
+                    foreach (MixItems mix in mixDatabase)
+                        result[mix.Id] = mix;
+                        
                 return result;
             }
             catch (Exception ex)

--- a/Assembly-CSharp/Memoria/Data/ff9mixitem.cs
+++ b/Assembly-CSharp/Memoria/Data/ff9mixitem.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Memoria.Assets;
+using Memoria.Data;
+using Memoria.Prime;
+
+namespace FF9
+{
+    public class ff9mixitem
+    {
+        public static readonly Dictionary<RegularItem, MixItems> MixItemsData;
+
+        static ff9mixitem()
+        {
+            MixItemsData = LoadSynthesis();
+        }
+
+        private static Dictionary<RegularItem, MixItems> LoadSynthesis()
+        {
+            try
+            {
+                String inputPath = DataResources.Items.PureDirectory + DataResources.Items.MixItemsFile;
+                Dictionary<RegularItem, MixItems> result = new Dictionary<RegularItem, MixItems>();
+                foreach (MixItems[] ingredients in AssetManager.EnumerateCsvFromLowToHigh<MixItems>(inputPath))
+                    foreach (MixItems ItemMixed in ingredients)
+                        result[(RegularItem)ItemMixed.Result] = ItemMixed;
+                return result;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "[ff9mixitem] Load mix items failed.");
+                UIManager.Input.ConfirmQuit();
+                return null;
+            }
+        }
+    }
+}

--- a/Assembly-CSharp/NCalc/NCalcUtility.cs
+++ b/Assembly-CSharp/NCalc/NCalcUtility.cs
@@ -536,7 +536,6 @@ namespace NCalc
             expr.Parameters["AbilityElementForBonus"] = (Int32)command.ElementForBonus;
             expr.Parameters["ItemUseId"] = (Int32)command.ItemId;
             expr.Parameters["WeaponThrowShape"] = command.Id == BattleCommandId.Throw ? ff9item._FF9Item_Data[command.ItemId].shape : -1;
-            expr.Parameters["WeaponThrowColor"] = command.Id == BattleCommandId.Throw ? ff9item._FF9Item_Data[command.ItemId].color : -1;
             expr.Parameters["SpecialEffectId"] = (Int32)command.SpecialEffect;
             expr.Parameters["TargetType"] = (Int32)command.TargetType;
             expr.Parameters["IsATBCommand"] = command.IsATBCommand;

--- a/Assembly-CSharp/NCalc/NCalcUtility.cs
+++ b/Assembly-CSharp/NCalc/NCalcUtility.cs
@@ -536,6 +536,7 @@ namespace NCalc
             expr.Parameters["AbilityElementForBonus"] = (Int32)command.ElementForBonus;
             expr.Parameters["ItemUseId"] = (Int32)command.ItemId;
             expr.Parameters["WeaponThrowShape"] = command.Id == BattleCommandId.Throw ? ff9item._FF9Item_Data[command.ItemId].shape : -1;
+            expr.Parameters["WeaponThrowColor"] = command.Id == BattleCommandId.Throw ? ff9item._FF9Item_Data[command.ItemId].color : -1;
             expr.Parameters["SpecialEffectId"] = (Int32)command.SpecialEffect;
             expr.Parameters["TargetType"] = (Int32)command.TargetType;
             expr.Parameters["IsATBCommand"] = command.IsATBCommand;

--- a/Memoria.Patcher/Memoria.Patcher.csproj
+++ b/Memoria.Patcher/Memoria.Patcher.csproj
@@ -507,6 +507,9 @@
     <None Include="StreamingAssets\Data\Items\InitialItems.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="StreamingAssets\Data\Items\MixItems.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="StreamingAssets\Data\Items\ShopItems.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Memoria.Patcher/StreamingAssets/Data/Items/MixItems.csv
+++ b/Memoria.Patcher/StreamingAssets/Data/Items/MixItems.csv
@@ -1,0 +1,7 @@
+# This file contains a set of game items that can be mixed in battle.
+# You can set any number of different items.
+# -----------------------------------------------
+# Comment;Result;Ingredients
+# ;Int32;Int32[]
+# -----------------------------------------------
+Hi-Potion;237;236, 236

--- a/Memoria.Patcher/StreamingAssets/Data/Items/MixItems.csv
+++ b/Memoria.Patcher/StreamingAssets/Data/Items/MixItems.csv
@@ -1,7 +1,7 @@
 # This file contains a set of game items that can be mixed in battle.
 # You can set any number of different items.
 # -----------------------------------------------
-# Comment;Result;Ingredients
-# ;Int32;Int32[]
+# Comment;Id;Result;Ingredients
+# String;Int32;Int32;Int32[]
 # -----------------------------------------------
-Hi-Potion;237;236, 236
+Hi-Potion;0;237;236, 236


### PR DESCRIPTION
- DoubleCast command is now compatible with Item/Throw commands.

```
DoubleCastCommand Add Item
DoubleCastCommand Add Throw
```

- Small correction on a condition in `btl_mot.SetDefaultIdle`
- Fix a bug where animation is skipped when a character uses a DoubleCast command type.

[OnGoing] => Create a script to make a Mix command, like the chemist in FFV.