### PR TITLE
Turn-based balance + WM Camera rotation with R-Stick + Fix #511

### DIFF
--- a/Assembly-CSharp/Global/AbilityUI.cs
+++ b/Assembly-CSharp/Global/AbilityUI.cs
@@ -990,7 +990,7 @@ public class AbilityUI : UIScene
             this.activeAbilityScrollList.SetOriginalData(inDataList);
             if (ButtonGroupState.HaveCursorMemorize(ActionAbilityGroupButton))
                 return;
-            this.activeAbilityScrollList.JumpToIndex(this.firstActiveAbility, false);
+            this.activeAbilityScrollList.JumpToIndex(this.firstActiveAbility, true);
         }
     }
 
@@ -1067,7 +1067,7 @@ public class AbilityUI : UIScene
             this.supportAbilityScrollList.SetOriginalData(inDataList);
             if (ButtonGroupState.HaveCursorMemorize(SupportAbilityGroupButton))
                 return;
-            this.supportAbilityScrollList.JumpToIndex(this.firstActiveAbility, false);
+            this.supportAbilityScrollList.JumpToIndex(this.firstActiveAbility, true);
         }
     }
 

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
@@ -668,13 +668,13 @@ public partial class BattleHUD : UIScene
 
         // Stops the ATB if any of these are true
         Boolean isMenuing = _commandPanel.IsActive || _targetPanel.IsActive || _itemPanel.IsActive || _abilityPanel.IsActive;
-        Boolean isEnemyActing = FF9StateSystem.Battle.FF9Battle.cur_cmd != null && FF9StateSystem.Battle.FF9Battle.cur_cmd.regist?.bi.player == 0;
+        //Boolean isEnemyActing = FF9StateSystem.Battle.FF9Battle.cur_cmd != null && FF9StateSystem.Battle.FF9Battle.cur_cmd.regist?.bi.player == 0;
         Boolean hasQueue = btl_cmd.GetFirstCommandReadyToDequeue(FF9StateSystem.Battle.FF9Battle) != null;
 
-        if (ForceNextTurn && !hasQueue && !isEnemyActing)
+        if (ForceNextTurn && !hasQueue /*&& !isEnemyActing*/)
             return true;
 
-        return !(isMenuing || hasQueue || isEnemyActing);
+        return !(isMenuing || hasQueue /*|| isEnemyActing*/);
     }
 
     public Boolean IsNativeEnableAtb()

--- a/Assembly-CSharp/Global/ff9/ff9.cs
+++ b/Assembly-CSharp/Global/ff9/ff9.cs
@@ -6372,6 +6372,8 @@ public static class ff9
 			ff9.w_moveCHRControl_LR = true;
 			ff9.w_cameraSysDataCamera.rotation += ff9.PsxRot(32);
 		}
+		var RightStick = UnityXInput.XInputManager.Instance.CurrentState.ThumbSticks.Right;
+		ff9.w_cameraSysDataCamera.rotation += RightStick.X * 6.0f;
 		ff9.w_cameraSysDataCamera.rotation %= 360f;
 		if (num4 != 0 || ff9.w_movePadLR)
 		{
@@ -6473,6 +6475,8 @@ public static class ff9
 			ff9.w_cameraSysDataCamera.rotation += ff9.PsxRot(32);
 			ff9.w_moveCHRControl_LR = true;
 		}
+		var RightStick = UnityXInput.XInputManager.Instance.CurrentState.ThumbSticks.Right;
+		ff9.w_cameraSysDataCamera.rotation += RightStick.X * 6.0f;
 		ff9.w_cameraSysDataCamera.rotation %= 360f;
 		ff9.w_cameraSysDataCamera.rotationRev = 0f;
 		Single num4 = ff9.S(ff9.w_moveCHRControlPtr.speed_move * num3 / ff9.p1);
@@ -6568,6 +6572,9 @@ public static class ff9
 				ff9.w_moveCHRControl_LR = true;
 			}
 		}
+		var RightStick = UnityXInput.XInputManager.Instance.CurrentState.ThumbSticks.Right;
+		ff9.w_cameraSysDataCamera.rotation += RightStick.X * 6.0f;
+		ff9.w_cameraSysDataCamera.rotation %= 360f;
 		ff9.w_cameraSysDataCamera.rotationRev = 0f;
 		ff9.w_moveCHRControl_RotSpeed = ff9.PsxRot(ff9.w_moveCHRControlPtr.speed_rotation * leftStickX >> 7);
 		Single verticalMovementSpeed = ff9.S(-(Int32)ff9.w_moveCHRControlPtr.speed_updown * leftStickY / ff9.p1);


### PR DESCRIPTION
- Turn-based balance: Removing the wait when enemies are acting roughly restores the balance of turn-based mode similar to normal mode.
- World camera can now be rotated with the right analog stick
- Fixed #511 
