### PR TITLE
Hotfix Mix feature

### DIFF
--- a/Assembly-CSharp/FF9/btl_util.cs
+++ b/Assembly-CSharp/FF9/btl_util.cs
@@ -288,7 +288,9 @@ namespace FF9
 				return BattleAbilityId.Void;
 			if (IsCommandMonsterTransformAttack(cmd))
 				return BattleAbilityId.Attack;
-			switch (cmd.cmd_no)
+            if (BattleHUD.MixCommandSet.Contains(cmd.cmd_no))
+                return BattleAbilityId.Void;
+            switch (cmd.cmd_no)
 			{
 				case BattleCommandId.SysEscape:
 					return BattleAbilityId.Flee2;

--- a/Assembly-CSharp/FF9/btl_util.cs
+++ b/Assembly-CSharp/FF9/btl_util.cs
@@ -315,8 +315,8 @@ namespace FF9
                 return RegularItem.NoItem;
             if (IsCommandMonsterTransform(cmd) || IsCommandMonsterTransformAttack(cmd))
                 return RegularItem.NoItem;
-            if (BattleHUD.MixCommandSet.Contains(cmd.cmd_no))
-                return ff9mixitem.MixItemsData[cmd.sub_no].Result;
+            if (BattleHUD.MixCommandSet.Contains(cmd.cmd_no) && ff9mixitem.MixItemsData.TryGetValue(cmd.sub_no, out MixItems MixChoosen))
+                return MixChoosen.Result;
             switch (cmd.cmd_no)
             {
                 case BattleCommandId.Throw:

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
@@ -113,8 +113,8 @@ public partial class BattleHUD : UIScene
                 return aaData.Name;
             return String.Empty;
         }
-        if (MixCommandSet.Contains(pCmd.cmd_no))
-            return FF9TextTool.ItemName(ff9mixitem.MixItemsData[pCmd.sub_no].Result);
+        if (MixCommandSet.Contains(pCmd.cmd_no) && ff9mixitem.MixItemsData.TryGetValue(pCmd.sub_no, out MixItems MixChoosen))
+            return FF9TextTool.ItemName(MixChoosen.Result);
         switch (pCmd.cmd_no)
         {
             case BattleCommandId.Item:

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Scene.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Scene.cs
@@ -333,7 +333,10 @@ public partial class BattleHUD : UIScene
                             SetItemPanelVisibility(true, true);
                             break;
                         }
-                        SetCommandVisibility(true, true);
+                        if (IsMixCast)
+                            SetItemPanelVisibility(true, true);
+                        else
+                            SetCommandVisibility(true, true);
                         break;
                     case BattleCommandMenu.Item:
                         SetItemPanelVisibility(true, true);

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Scene.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Scene.cs
@@ -191,6 +191,13 @@ public partial class BattleHUD : UIScene
                         SetCommandVisibility(false, false);
                         SetItemPanelVisibility(true, false);
                     }
+                    else if (ff9Command.Type == CharacterCommandType.Item)
+                    {
+                        _subMenuType = SubMenuType.Item;
+                        DisplayItem(false);
+                        SetCommandVisibility(false, false);
+                        SetItemPanelVisibility(true, false);
+                    }
                     break;
                 case BattleCommandMenu.Item:
                     DisplayItem(false);

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
@@ -2426,8 +2426,7 @@ public partial class BattleHUD : UIScene
         }
 
         if (IsMixCast)
-            try { SendMixCommand([_firstCommand, ProcessCommand(battleIndex, _cursorType)]); } catch (Exception err) { Log.Error(err); }
-        
+            SendMixCommand([_firstCommand, ProcessCommand(battleIndex, _cursorType)]);
         else if (IsDoubleCast)
             SendDoubleCastCommand(_firstCommand, ProcessCommand(battleIndex, _cursorType));
         else

--- a/Assembly-CSharp/Global/btl_cmd.cs
+++ b/Assembly-CSharp/Global/btl_cmd.cs
@@ -715,8 +715,8 @@ public class btl_cmd
                             FF9StateSystem.EventState.IncreaseAAUsageCounter(aaIndex);
                     }
                     RegularItem itemId = btl_util.GetCommandItem(cmd);
-                    if (BattleHUD.MixCommandSet.Contains(cmd.cmd_no))
-                        foreach (RegularItem ingredient in ff9mixitem.MixItemsData[cmd.sub_no].Ingredients)
+                    if (BattleHUD.MixCommandSet.Contains(cmd.cmd_no) && ff9mixitem.MixItemsData.TryGetValue(cmd.sub_no, out MixItems MixChoosen))
+                        foreach (RegularItem ingredient in MixChoosen.Ingredients)
                             UIManager.Battle.ItemUse(ingredient);
                     else if (itemId != RegularItem.NoItem)
                         UIManager.Battle.ItemUse(itemId);
@@ -1041,7 +1041,7 @@ public class btl_cmd
             return true;
 
         Boolean notEnoughItems = false;
-        if (BattleHUD.MixCommandSet.Contains(cmd.cmd_no))
+        if (BattleHUD.MixCommandSet.Contains(cmd.cmd_no) && cmd.cmd_no != BattleCommandId.Item)
         {
             Dictionary<RegularItem, Int32> allIngredients = ff9mixitem.MixItemsData[cmd.sub_no].GetIngredientsAsDict();
             foreach (KeyValuePair<RegularItem, Int32> requirement in allIngredients)

--- a/Assembly-CSharp/Global/btl_vfx.cs
+++ b/Assembly-CSharp/Global/btl_vfx.cs
@@ -43,7 +43,7 @@ public static class btl_vfx
     {
         BTL_DATA regist = cmd.regist;
         BattleCommandId cmd_no = cmd.cmd_no;
-        if (cmd_no == BattleCommandId.AutoPotion || cmd_no == BattleCommandId.Item)
+        if (cmd_no == BattleCommandId.AutoPotion || cmd_no == BattleCommandId.Item || BattleHUD.MixCommandSet.Contains(cmd.cmd_no))
             return (SpecialEffect)ff9item.GetItemEffect(btl_util.GetCommandItem(cmd)).info.VfxIndex;
         else if (cmd_no == BattleCommandId.SysTrans)
             return btl_stat.CheckStatus(regist, BattleStatus.Trance) ? SpecialEffect.Special_Trance_Activate : SpecialEffect.Special_Trance_End;


### PR DESCRIPTION
An issue was reported for the new Mix feature : indeed, it's currently impossible to use an item type command instead of an ability one (Ability1 or Ability2).

With this commit, it's now possible and that's fix the mix feature for custom command.

I still have one last problem to solve: the command won't run if the mix doesn't exist, even though a check is in place... in progress.

EDIT : There is also a bug if we cancel the mix command when reaching the target window, it didn't reset properly.