### PR TITLE
Fix "Could not find file" on import localized strings

### DIFF
--- a/Assembly-CSharp/Memoria/Assets/Import/Fields/FieldImporter.cs
+++ b/Assembly-CSharp/Memoria/Assets/Import/Fields/FieldImporter.cs
@@ -191,9 +191,8 @@ namespace Memoria.Assets
                 String extension = Path.GetExtension(fileName); // .strings
 
                 fileName = fileName.Substring(0, fileName.Length - "_Tags".Length - extension.Length); // 0074_EVT_BATTLE_SIOTES01
-                TextResourceFormat format = TextResourceFormatHelper.ResolveFileFormat(extension);
 
-                TextResourcePath inputPath = new(new TextResourceReference(path), format);
+                TextResourcePath inputPath = TextResourcePath.ForImportExistingFile(path);
                 fieldNames[fileName] = ReadTagReplacements(inputPath);
             }
 

--- a/Assembly-CSharp/Memoria/Assets/Text/Strings/TextResourcePath.cs
+++ b/Assembly-CSharp/Memoria/Assets/Text/Strings/TextResourcePath.cs
@@ -31,8 +31,9 @@ namespace Memoria.Assets
                 throw new FileNotFoundException(existingPath);
 
             String extension = Path.GetExtension(existingPath);
+            String pathWithoutExtension = existingPath.Substring(0, existingPath.Length - extension.Length);
             TextResourceFormat format = TextResourceFormatHelper.ResolveFileFormat(extension);
-            TextResourceReference reference = new(existingPath);
+            TextResourceReference reference = new(pathWithoutExtension);
             return new TextResourcePath(reference, format);
         }
 


### PR DESCRIPTION
I forget to cut extension when replaced strings with TextResourcePath. :( 

```
11.06.2024 11:53:58 |M| [LocationNameImporter] Importing from [./StreamingAssets/Text/US/Location]...
11.06.2024 11:53:58 |E| [LocationNameImporter] Failed to import resource from.
11.06.2024 11:53:58 |E| System.IO.IsolatedStorage.IsolatedStorageException: Could not find file "D:\SteamLibrary\steamapps\common\FINAL FANTASY IX\StreamingAssets\Text\US\Location\Names of A. Castle.strings.strings".
11.06.2024 11:53:58 |E|   at System.IO.FileStream..ctor (System.String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean anonymous, FileOptions options) [0x00000] in <filename unknown>:0 
11.06.2024 11:53:58 |E|   at System.IO.FileStream..ctor (System.String path, FileMode mode, FileAccess access, FileShare share) [0x00000] in <filename unknown>:0 
11.06.2024 11:53:58 |E|   at System.IO.File.OpenRead (System.String path) [0x00000] in <filename unknown>:0 
11.06.2024 11:53:58 |E|   at System.IO.StreamReader..ctor (System.String path, System.Text.Encoding encoding, Boolean detectEncodingFromByteOrderMarks, Int32 bufferSize) [0x00000] in <filename unknown>:0 
11.06.2024 11:53:58 |E|   at System.IO.StreamReader..ctor (System.String path) [0x00000] in <filename unknown>:0 
11.06.2024 11:53:58 |E|   at System.IO.File.OpenText (System.String path) [0x00000] in <filename unknown>:0 
11.06.2024 11:53:58 |E|   at Memoria.Assets.TextStringsFormatter+Reader.ReadAll (System.String inputPath) [0x00000] in <filename unknown>:0 
11.06.2024 11:53:58 |E|   at Memoria.Assets.TextResourcePath.ReadAll () [0x00000] in <filename unknown>:0 
11.06.2024 11:53:58 |E|   at Memoria.Assets.LocationNameImporter.LoadExternal () [0x00000] in <filename unknown>:0 
```