### PR TITLE
Fixes

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -26,7 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NoWarn>CS0414;CS0649;CS0169;CS0108;CS0618</NoWarn>
+    <NoWarn>CS0414;CS0649;CS0169;CS0108;CS0618;CS8632</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
+++ b/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
@@ -1261,7 +1261,15 @@ public partial class EventEngine
             }
             case EBin.event_code_binary.BGAANIME: // 0x5F, "RunTileAnimation", "Run a field tile animation", true, 2, { 1, 1 }, { "Field Animation", "Frame" }, { AT_TILEANIM, AT_USPIN }, 0
             {
-                this.fieldmap.EBG_animAnimate(this.getv1(), this.getv1()); //arg1: background animation.arg2: starting frame
+                Int32 animID = this.getv1(); // arg1: background animation
+                Int32 startFrame = this.getv1(); // arg2: starting frame
+                if (mapNo == 2925 && animID == 0) // Restore animation in Crystal World (missing in every version)
+                {
+                    this.fieldmap.EBG_animAnimate(1, 0);
+                    this.fieldmap.EBG_animSetFlags(1, 16);
+                    this.fieldmap.EBG_animSetFrameRate(1, 128);
+                }
+                this.fieldmap.EBG_animAnimate(animID, startFrame);
                 return 0;
             }
             case EBin.event_code_binary.BGAACTIVE: // 0x60, "ActivateTileAnimation", "Make a field tile animation active..", true, 2, { 1, 1 }, { "Tile Animation", "Activate" }, { AT_TILEANIM, AT_BOOL }, 0

--- a/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
+++ b/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
@@ -1462,9 +1462,10 @@ public partial class EventEngine
             {
                 Int32 newCamIdx = this.getv1(); // arg1: camera ID
                 Obj player = this.GetObjUID(250);
-                if (player != null && player.cid == 4)
+                if (player != null && player.cid == 4 && (mapNo == 153 || mapNo == 1214 || mapNo == 1806) && newCamIdx == 0) // Fix #493 - flapping camera
                 {
-                    if ((mapNo == 153 || mapNo == 1214 || mapNo == 1806) && newCamIdx == 0 && (((Actor)player).fieldMapActorController.lastPos.x > 500 || ((Actor)player).fieldMapActorController.lastPos.y > 240)) // Fix #493 - flapping camera //  
+                    Vector3 pos = ((Actor)player).fieldMapActorController.lastPos;
+                    if ((pos.x > 500 || pos.y > 240) && !(scCounter == 1190 && pos.y > 314 && pos.y < 317)) //exception for scene with Steiner and plutos
                         return 0;
                 }
                 this.fieldmap.SetCurrentCameraIndex(newCamIdx);

--- a/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
+++ b/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
@@ -1236,7 +1236,7 @@ public partial class EventEngine
             }
             case EBin.event_code_binary.BGLMOVE: // 0x5A, "SetTilePositionEx", "Move a field tile block.", true, 4, { 1, 2, 2, 2 }, { "Tile Block", "Position X", "Position Y", "Position Closeness" }, { AT_TILE, AT_SPIN, AT_SPIN, AT_SPIN }, 0
             {
-                this.fieldmap.EBG_overlayMove(this.getv1(), (Int16)this.getv2(), (Int16)this.getv2(), (Int16)this.getv2()); // arg1: background tile block. 2nd and arg3: movement in (dX, dY) format.arg4: depth, with higher value being further away from camera.
+                this.fieldmap.EBG_overlayMove(this.getv1(), (Single)this.getv2(), (Single)this.getv2(), (Int16)this.getv2()); // arg1: background tile block. 2nd and arg3: movement in (dX, dY) format.arg4: depth, with higher value being further away from camera.
                 return 0;
             }
             case EBin.event_code_binary.BGLACTIVE: // 0x5B, "ShowTile", "Show or hide a field tile block", true, 2, { 1, 1 }, { "Tile Block", "Show" }, { AT_TILE, AT_BOOL }, 0

--- a/Assembly-CSharp/Global/Field/Map/FieldMap.cs
+++ b/Assembly-CSharp/Global/Field/Map/FieldMap.cs
@@ -2521,6 +2521,7 @@ public class FieldMap : HonoBehavior
         [2922,0,10,3179],   // Crystal world (was not active on PSX)
         [2922,0,11,3179],   // Crystal world (was not active on PSX)
         [2922,0,12,6080],   // Crystal world (was not active on PSX)
+        [2924,0,1,0],   // Crystal world (was not active on PSX)
     };
 
     public static readonly HashSet<Int32> SmoothCamExcludeMaps = new HashSet<Int32>()

--- a/Assembly-CSharp/Global/Field/Map/FieldMap.cs
+++ b/Assembly-CSharp/Global/Field/Map/FieldMap.cs
@@ -2525,6 +2525,7 @@ public class FieldMap : HonoBehavior
         [2600,0,13,8000],   // Branbal, background
         [2605,0,3,2200],    // Branbal, light of light net
         [2657,0,4,2040],    // Branbal, light in the room
+        [2800,0,26,1700],   // Dagguereo Zidane behind beckground on left path
         [2922,0,8,4329],    // Crystal world (was not active on PSX)
         [2922,0,10,3179],   // Crystal world (was not active on PSX)
         [2922,0,11,3179],   // Crystal world (was not active on PSX)

--- a/Assembly-CSharp/Global/Field/Map/FieldMap.cs
+++ b/Assembly-CSharp/Global/Field/Map/FieldMap.cs
@@ -1166,19 +1166,27 @@ public class FieldMap : HonoBehavior
     }
 
     /// <summary>0x5A, "SetTilePositionEx", "Move a field tile block.arg1: background tile block.2nd and arg3: movement in (dX, dY) format.arg4: depth, with higher value being further away from camera." </summary>
-    public Int32 EBG_overlayMove(Int32 overlayNdx, Int16 dx, Int16 dy, Int16 dz)
+    public Int32 EBG_overlayMove(Int32 overlayNdx, Single dx, Single dy, Int16 dz)
     {
+        Int16 MapNo = FF9StateSystem.Common.FF9.fldMapNo;
         BGOVERLAY_DEF bgOverlay = this.scene.overlayList[overlayNdx];
+
+        if (MapNo == 2755 && overlayNdx == 5 && dx == 1 && Configuration.Graphics.WidescreenSupport)
+        {
+            dx = 0.75f;
+            bgOverlay.transform.localScale = new Vector3(1.1f, 1.1f, 1);
+        }
+
         FieldMapInfo.fieldmapExtraOffset.UpdateOverlayOffset(this.mapName, overlayNdx, ref dz);
         Single destX = Mathf.Clamp(bgOverlay.orgX + dx, bgOverlay.minX, bgOverlay.maxX);
         Single destY = Mathf.Clamp(bgOverlay.orgY + dy, bgOverlay.minY, bgOverlay.maxY);
 
         // TODO Check Native: #147
-        UInt16 destZ;
-        if (FF9StateSystem.Common.FF9.fldMapNo == 2351 && overlayNdx >= 3 && overlayNdx <= 17) // official fix of the mine bucket
+        UInt16 destZ = (UInt16)(bgOverlay.orgZ + (UInt16)dz);
+
+        if (MapNo == 2351 && overlayNdx >= 3 && overlayNdx <= 17) // official fix of the mine bucket
             destZ = 3000;
-        else
-            destZ = (UInt16)(bgOverlay.orgZ + (UInt16)dz);
+
 
         bgOverlay.orgX = destX;
         bgOverlay.orgY = destY;

--- a/Assembly-CSharp/Global/Field/Map/FieldMap.cs
+++ b/Assembly-CSharp/Global/Field/Map/FieldMap.cs
@@ -2449,7 +2449,7 @@ public class FieldMap : HonoBehavior
     public static readonly Int32[][] FixDepthOfLayer =
     {
         // [mapNo,camIdx,LayerIndex,Depth],
-        [51,1,20,600],      // Kidnap scene, candle light
+        [51,1,19,800],      // Kidnap scene, candle light
         [202,0,20,0],       // Prima Vista light
         [252,0,6,1600],     // Evil Forest light
         [350,0,0,730],      // Dali shop door cropped

--- a/Assembly-CSharp/Global/Field/Map/FieldMap.cs
+++ b/Assembly-CSharp/Global/Field/Map/FieldMap.cs
@@ -2521,7 +2521,13 @@ public class FieldMap : HonoBehavior
         [2922,0,10,3179],   // Crystal world (was not active on PSX)
         [2922,0,11,3179],   // Crystal world (was not active on PSX)
         [2922,0,12,6080],   // Crystal world (was not active on PSX)
-        [2924,0,1,0],   // Crystal world (was not active on PSX)
+        [2924,0,1,0],       // Crystal world (was not active on PSX)
+        [3100,0,0,2300],    // Mognet - static tiles on top of anim
+        [3100,0,1,2300],    // Mognet - static tiles on top of anim
+        [3100,0,2,2300],    // Mognet - static tiles on top of anim
+        [3100,0,3,2300],    // Mognet - static tiles on top of anim
+        [3100,0,4,2300],    // Mognet - static tiles on top of anim
+        [3100,0,5,2300],    // Mognet - static tiles on top of anim
     };
 
     public static readonly HashSet<Int32> SmoothCamExcludeMaps = new HashSet<Int32>()

--- a/Memoria.Launcher/ModManagerWindow.cs
+++ b/Memoria.Launcher/ModManagerWindow.cs
@@ -511,6 +511,15 @@ namespace Memoria.Launcher
 
         private void UpdateCatalog()
         {
+            if (File.Exists(CATALOG_PATH))
+            {
+                FileInfo fi = new FileInfo(CATALOG_PATH);
+                if (fi.IsReadOnly) // Local testing of catalog: put it as read-only
+                {
+                    ReadCatalog();
+                    return;
+                }
+            }
             modListCatalog.Clear();
             ReadCatalog();
             downloadCatalogThread = new Thread(() =>


### PR DESCRIPTION
- Launcher removes double keys from Memoria.ini
- If ModCatalog is readonly, don't update it, read it
- restoring anim on f2925 (never seen before)
---
- removed warning CS8632
- fixed scene 2755, ship edges visible
- fixed light/anim of 4 fields
- fixed regression on scene Steiner field 153