### PR TITLE
Some fixes + improvement on Model viewer

### DIFF
--- a/Assembly-CSharp/Global/AnimationFactory.cs
+++ b/Assembly-CSharp/Global/AnimationFactory.cs
@@ -86,7 +86,8 @@ public class AnimationFactory
 			String text = "Animations/" + str + "/" + animationName;
 			text = AnimationFactory.GetRenameAnimationPath(text);
 			AnimationClip clip = AssetManager.Load<AnimationClip>(text, false);
-			component.AddClip(clip, animationName);
+            if (clip != null)
+			    component.AddClip(clip, animationName);
 		}
 	}
 

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -186,7 +186,7 @@ namespace Memoria.Assets
                 }
                 if (Input.GetKeyDown(KeyCode.N))
                     displayModelAnimNames = !displayModelAnimNames;
-                if (Input.GetKeyDown(KeyCode.H)) // TODO - Find a way to activate an animation if model is hidden.
+                if (Input.GetKeyDown(KeyCode.H)) // TODO - Replace it by changing the color instead, to hide the model
                 {
                     displayCurrentModel = !displayCurrentModel;
                     Renderer[] componentsInChildren = currentModel.GetComponentsInChildren<Renderer>();
@@ -435,7 +435,7 @@ namespace Memoria.Assets
                 currentModel.transform.localScale = new Vector3(-scaleFactor.x, -scaleFactor.y, scaleFactor.z);
                 currentModel.transform.LookAt(currentModel.transform.position + directionForward, -directionDown);
             }
-            if (currentModel != null && currentModelBones != null)
+            if (currentModel != null && currentModelBones != null && !isLoadingModel)
             {
                 foreach (BoneHierarchyNode bone in currentModelBones)
                 {
@@ -457,7 +457,7 @@ namespace Memoria.Assets
                                     boneDialogs[i].Phrase = "";
                                     boneDialogs[boneDialogCount].Phrase = "";
                                     boneDialogs[i] = Singleton<DialogManager>.Instance.AttachDialog(ID, ID.Length, 1, Dialog.TailPosition.Center, Dialog.WindowStyle.WindowStyleTransparent, bone.Position, Dialog.CaptionType.None);
-                                    boneDialogs[i].transform.localPosition = BonePos;                                  
+                                    boneDialogs[i].transform.localPosition = BonePos;
                                     break;
                                 }
                             }
@@ -549,6 +549,7 @@ namespace Memoria.Assets
             currentGeoIndex = index;
             animList = GetAnimationsOfModel(geoList[index]);
             Log.Message($"[ModelViewerScene] Change model: {geoList[index].Name}");
+            UpdateRender(); // Force refresh bones between different models
             if (geoList[index].Kind == 0)
             {
                 currentModel = ModelFactory.CreateModel(geoList[index].Name);

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -613,9 +613,9 @@ namespace Memoria.Assets
             currentGeoIndex = index;
             animList = GetAnimationsOfModel(geoList[index]);
             Log.Message($"[ModelViewerScene] Change model: {geoList[index].Name}");
-            UpdateRender(); // Force refresh bones between different models
             if (geoList[index].Kind == 0)
             {
+                UpdateRender(); // Force refresh bones between different models
                 currentModel = ModelFactory.CreateModel(geoList[index].Name);
             }
             else

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -19,6 +19,7 @@ namespace Memoria.Assets
         private static Boolean displayBoneConnections = false;
         private static Boolean displayBoneNames = false;
         private static Boolean displayModelAnimNames = false;
+        private static Boolean displayCurrentModel = true;
         private static List<ModelObject> geoList;
         private static List<ModelObject> weapongeoList;
         private static List<KeyValuePair<Int32, String>> animList;
@@ -185,6 +186,16 @@ namespace Memoria.Assets
                 }
                 if (Input.GetKeyDown(KeyCode.N))
                     displayModelAnimNames = !displayModelAnimNames;
+                if (Input.GetKeyDown(KeyCode.H)) // TODO - Find a way to activate an animation if model is hidden.
+                {
+                    displayCurrentModel = !displayCurrentModel;
+                    Renderer[] componentsInChildren = currentModel.GetComponentsInChildren<Renderer>();
+                    for (Int32 i = 0; i < componentsInChildren.Length; i++)
+                    {
+                        Renderer renderer = componentsInChildren[i];
+                        renderer.enabled = displayCurrentModel;
+                    }
+                }
 
                 if (Input.GetKeyDown(KeyCode.P) && currentBonesID.Count > 0)
                 {
@@ -527,6 +538,8 @@ namespace Memoria.Assets
             isLoadingModel = true;
             if (currentModel != null && geoList[currentGeoIndex].Kind == 0)
                 UnityEngine.Object.Destroy(currentModel);
+            if (currentWeaponModel != null)
+                UnityEngine.Object.Destroy(currentWeaponModel);
             else if (geoList[currentGeoIndex].Kind == 1)
                 spsEffect.Unload();
             while (index < 0)

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -160,7 +160,11 @@ namespace Memoria.Assets
                     speedFactor = 1f;
                 else if (Input.GetKeyDown(KeyCode.Alpha2) || Input.GetKeyDown(KeyCode.Keypad2))
                     speedFactor = 0.5f;
-                if (Input.GetKeyDown(KeyCode.B))
+                if (Input.GetKeyDown(KeyCode.B) && (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift)))
+                {
+                    displayBoneConnections = !displayBoneConnections;
+                }
+                else if (Input.GetKeyDown(KeyCode.B))
                 {
                     displayBones = !displayBones;
                     displayBoneNames = !displayBoneNames;
@@ -371,15 +375,34 @@ namespace Memoria.Assets
                 foreach (BoneHierarchyNode bone in currentModelBones)
                 {
                     if (displayBoneNames)
-                    {
-                        Vector3 dialPos = camera.WorldToScreenPoint(bone.Position) / 4; // TODO: fix offsetting
-                        dialPos.y = camera.pixelHeight / 4 - dialPos.y;
-                        dialPos.x *= 5f / 4f;
-                        dialPos.y *= 5f / 4f;
+                    {                       
                         while (boneDialogCount >= boneDialogs.Count)
-                            boneDialogs.Add(Singleton<DialogManager>.Instance.AttachDialog($"[STRT=20,1][IMME][NFOC]{bone.Id}[ENDN]", 20, 1, Dialog.TailPosition.Center, Dialog.WindowStyle.WindowStyleTransparent, dialPos, Dialog.CaptionType.None));
-                        Dialog dialog = boneDialogs[boneDialogCount];
-                        dialog.Position = dialPos; // TODO: updating position is not currently working
+                        {
+                            boneDialogs.Add(Singleton<DialogManager>.Instance.AttachDialog($"[IMME][NFOC][b]{bone.Id}[/b][ENDN]", 10, 1, Dialog.TailPosition.Center, Dialog.WindowStyle.WindowStyleTransparent, bone.Position, Dialog.CaptionType.None));
+                            Boolean samebones = false;
+                            Vector3 BonePos = -bone.Position * 5f;
+                            string ID = $"[IMME][NFOC][b]{bone.Id}[/b]";
+                            for (Int32 i = 0; i < (boneDialogs.Count - 1); i++)
+                            {
+                                if ((BonePos - boneDialogs[i].transform.localPosition).sqrMagnitude < 1 && boneDialogs[i].Phrase.Length > 8)
+                                {
+                                    String IDBone = boneDialogs[i].Phrase.Remove(0, 14);
+                                    ID += $",{IDBone}[ENDN]";
+                                    boneDialogs[i].Phrase = "";
+                                    boneDialogs[boneDialogCount].Phrase = "";
+                                    boneDialogs[i] = Singleton<DialogManager>.Instance.AttachDialog(ID, ID.Length, 1, Dialog.TailPosition.Center, Dialog.WindowStyle.WindowStyleTransparent, bone.Position, Dialog.CaptionType.None);
+                                    boneDialogs[i].transform.localPosition = BonePos;                                  
+                                    break;
+                                }
+                            }
+                            if (samebones)
+                            {
+                                ID += "[ENDN]";                           
+                                boneDialogs[boneDialogCount] = Singleton<DialogManager>.Instance.AttachDialog(ID, 10, 1, Dialog.TailPosition.Center, Dialog.WindowStyle.WindowStyleTransparent, bone.Position, Dialog.CaptionType.None);
+                            }
+                        }
+                        boneDialogs[boneDialogCount].transform.localPosition = -bone.Position * 5f;
+                        boneDialogs[boneDialogCount].transform.localScale = scaleFactor;
                         boneDialogCount++;
                     }
                     if (displayBones)
@@ -387,6 +410,7 @@ namespace Memoria.Assets
                         while (boneCount >= boneModels.Count)
                             boneModels.Add(CreateModelForBone());
                         boneModels[boneCount].transform.position = bone.Position;
+                        boneModels[boneCount].transform.localScale = scaleFactor;
                         boneCount++;
                     }
                     if (displayBoneConnections && bone.Parent != null)
@@ -513,7 +537,7 @@ namespace Memoria.Assets
                 currentAnimIndex = 0;
                 currentAnimName = $"Frame {(spsEffect.curFrame >> 4) + 1}/{spsEffect.frameCount >> 4}";
                 currentModelBones = null;
-            }
+            }  
             isLoadingModel = false;
         }
 

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -347,8 +347,8 @@ namespace Memoria.Assets
                         targetModel.transform.localPosition += 0.5f * Vector3.forward;
                 if (Input.GetKey(KeyCode.Keypad5) && !DontSpamMessage)
                 {
-                    Log.Message("" + targetModel.name + "(currentpos) = " + targetModel.transform.localPosition.ToString("F9") + "");
-                    Log.Message("" + targetModel.name + "(currentrot) = " + targetModel.transform.localRotation.ToString("F9") + "");
+                    Log.Message("[MODEL]" + geoList[currentWeaponGeoIndex].Name + "(currentpos) = " + targetModel.transform.localPosition.ToString("F9") + "");
+                    Log.Message("[WEAPON]" + weapongeoList[currentWeaponGeoIndex].Name + "(currentrot) = " + targetModel.transform.localRotation.eulerAngles.ToString("F9") + "");
                     DontSpamMessage = true;
                 }
                 if (Input.GetKeyUp(KeyCode.Keypad5))

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -76,7 +76,7 @@ namespace Memoria.Assets
             spsEffect.meshRenderer = meshRenderer;
             spsEffect.meshFilter = meshFilter;
             infoPanel = new ControlPanel(PersistenSingleton<UIManager>.Instance.transform, "");
-            infoLabel = infoPanel.AddSimpleLabel("", NGUIText.Alignment.Left, 4);
+            infoLabel = infoPanel.AddSimpleLabel("", NGUIText.Alignment.Left, 5);
             infoPanel.EndInitialization(UIWidget.Pivot.BottomRight);
             infoPanel.BasePanel.SetRect(-50f, 0f, 1000f, 580f);
             foreach (UISprite sprite in infoPanel.BasePanel.GetComponentsInChildren<UISprite>(true))
@@ -301,6 +301,10 @@ namespace Memoria.Assets
                         ChangeAnimation(currentAnimIndex + 1);
                     }
                 }
+                if (Input.GetKey(KeyCode.M))
+                {
+                    infoPanel.BasePanel.transform.localPosition = infoPanel.BasePanel.transform.localPosition + new Vector3(Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift) ? -5 : 5, 0 , 0);
+                }
                 if (Input.mouseScrollDelta.y != 0f)
                 {
                     if (Input.mouseScrollDelta.y > 0f)
@@ -501,9 +505,14 @@ namespace Memoria.Assets
                 if (geoList[currentGeoIndex].Kind == 1)
                     label += $"\nShader: {spsEffect.materials[Math.Min((Int32)spsEffect.abr, 4)].shader.name}\nColour intensity: {spsEffect.fade}";
                 else if (animList.Count > 0)
-                    label += $" ({animList[currentAnimIndex].Key})\n\n";
+                    label += $" ({animList[currentAnimIndex].Key})\n";
+                if (currentWeaponModel)
+                {
+                    label += $" Weapon Attach : {weapongeoList[currentWeaponGeoIndex].Name}\n";
+                    label += $" Bone Attach : {currentWeaponBoneIndex}\n";
+                }
                 else
-                    label += $"\n\n";
+                    label += $"\n\n";              
                 if (!String.Equals(infoLabel.text, label))
                     infoLabel.text = label;
                 if (!infoPanel.Show)
@@ -609,7 +618,7 @@ namespace Memoria.Assets
 
         private static void ChangeWeaponModel(Int32 index)
         {
-            if (currentWeaponModel != null && index == currentWeaponBoneIndex)
+            if (currentWeaponModel != null && index == currentWeaponGeoIndex)
             {
                 UnityEngine.Object.Destroy(currentWeaponModel);
             }

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -188,9 +188,9 @@ namespace Memoria.Assets
                     }
                 }
                 if (!downUpProcessed && Input.GetKeyDown(KeyCode.UpArrow))
-                    ChangeAnimation(currentAnimIndex + 1);
+                    ChangeAnimation(currentAnimIndex + (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl) ? 5 : 1));
                 else if (!downUpProcessed && Input.GetKeyDown(KeyCode.DownArrow))
-                    ChangeAnimation(currentAnimIndex - 1);
+                    ChangeAnimation(currentAnimIndex - (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl) ? 5 : 1));
                 else if (Input.GetKeyDown(KeyCode.L))
                 {
                     Animation anim = currentModel.GetComponent<Animation>();

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -335,12 +335,12 @@ namespace Memoria.Assets
                     else
                         targetModel.transform.localPosition += 0.5f * Vector3.up;
 
-                if (Input.GetKey(KeyCode.Keypad7) || Input.GetKey(KeyCode.Keypad3))
+                if (Input.GetKey(KeyCode.Keypad7) || Input.GetKey(KeyCode.Keypad9))
                     if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl))
                         targetModel.transform.localRotation *= Quaternion.Euler(0f, 0f, 1f);
                     else
                         targetModel.transform.localPosition += 0.5f * Vector3.back;
-                if (Input.GetKey(KeyCode.Keypad1) || Input.GetKey(KeyCode.Keypad9))
+                if (Input.GetKey(KeyCode.Keypad1) || Input.GetKey(KeyCode.Keypad3))
                     if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl))
                         targetModel.transform.localRotation *= Quaternion.Euler(0f, 0f, -1f);
                     else

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -42,6 +42,8 @@ namespace Memoria.Assets
         private static Boolean isLoadingWeaponModel;
         private static Boolean mouseLeftPressed;
         private static Boolean mouseRightPressed;
+        private static Boolean ControlWeapon = false;
+        private static Boolean DontSpamMessage = false;
         private static Vector3 mousePreviousPosition;
         private static BoneHierarchyNode currentModelBones;
         private static List<GameObject> boneModels = new List<GameObject>();
@@ -144,7 +146,7 @@ namespace Memoria.Assets
             try
             {
                 if (isLoadingModel || isLoadingWeaponModel)
-                    return;
+                    return;              
                 Boolean mouseLeftWasPressed = mouseLeftPressed;
                 Boolean mouseRightWasPressed = mouseRightPressed;
                 mouseLeftPressed = false;
@@ -199,7 +201,11 @@ namespace Memoria.Assets
 
                 if (Input.GetKeyDown(KeyCode.P) && currentBonesID.Count > 0)
                 {
-                    if (Input.GetKey(KeyCode.LeftShift))
+                    if (Input.GetKey(KeyCode.AltGr))
+                    {
+                        ControlWeapon = !ControlWeapon;
+                    }                
+                    else if (Input.GetKey(KeyCode.LeftShift))
                     {
                         currentWeaponBoneIndex--;
                         if (currentWeaponBoneIndex < 0)
@@ -305,7 +311,49 @@ namespace Memoria.Assets
                 {
                     infoPanel.BasePanel.transform.localPosition = infoPanel.BasePanel.transform.localPosition + new Vector3(Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift) ? -5 : 5, 0 , 0);
                 }
-                if (Input.mouseScrollDelta.y != 0f)
+                GameObject targetModel = ControlWeapon ? currentWeaponModel : currentModel;
+                if (Input.GetKey(KeyCode.Keypad6))
+                    if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl))
+                        targetModel.transform.localRotation *= Quaternion.Euler(0f, 1f, 0f);
+                    else
+                        targetModel.transform.localPosition += 0.5f * Vector3.left;
+                if (Input.GetKey(KeyCode.Keypad4))
+                    if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl))
+                        targetModel.transform.localRotation *= Quaternion.Euler(0f, -1f, 0f);
+
+                    else
+                        targetModel.transform.localPosition += 0.5f * Vector3.right;
+                if (Input.GetKey(KeyCode.Keypad8))
+                    if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl))
+                        targetModel.transform.localRotation *= Quaternion.Euler(-1f, 0f, 0f);
+                    else
+                        targetModel.transform.localPosition += 0.5f * Vector3.down;
+
+                if (Input.GetKey(KeyCode.Keypad2))
+                    if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl))
+                        targetModel.transform.localRotation *= Quaternion.Euler(1f, 0f, 0f);
+                    else
+                        targetModel.transform.localPosition += 0.5f * Vector3.up;
+
+                if (Input.GetKey(KeyCode.Keypad7) || Input.GetKey(KeyCode.Keypad3))
+                    if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl))
+                        targetModel.transform.localRotation *= Quaternion.Euler(0f, 0f, 1f);
+                    else
+                        targetModel.transform.localPosition += 0.5f * Vector3.back;
+                if (Input.GetKey(KeyCode.Keypad1) || Input.GetKey(KeyCode.Keypad9))
+                    if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl))
+                        targetModel.transform.localRotation *= Quaternion.Euler(0f, 0f, -1f);
+                    else
+                        targetModel.transform.localPosition += 0.5f * Vector3.forward;
+                if (Input.GetKey(KeyCode.Keypad5) && !DontSpamMessage)
+                {
+                    Log.Message("" + targetModel.name + "(currentpos) = " + targetModel.transform.localPosition.ToString("F9") + "");
+                    Log.Message("" + targetModel.name + "(currentrot) = " + targetModel.transform.localRotation.ToString("F9") + "");
+                    DontSpamMessage = true;
+                }
+                if (Input.GetKeyUp(KeyCode.Keypad5))
+                    DontSpamMessage = false;
+                if (Input.mouseScrollDelta.y != 0f) // Scroll wheel on mouse (zoom in/out)
                 {
                     if (Input.mouseScrollDelta.y > 0f)
                         scaleFactor *= 1f + 0.05f * Input.mouseScrollDelta.y;
@@ -313,35 +361,35 @@ namespace Memoria.Assets
                         scaleFactor /= 1f - 0.05f * Input.mouseScrollDelta.y;
                     currentModel.transform.localScale = scaleFactor;
                 }
-                if (Input.GetMouseButton(0) && geoList[currentGeoIndex].Kind == 0)
+                if (Input.GetMouseButton(0) && geoList[currentGeoIndex].Kind == 0) // Left Click
                 {
                     if (mouseLeftWasPressed)
                     {
                         Vector3 mouseDelta = Input.mousePosition - mousePreviousPosition;
                         if (Math.Abs(mouseDelta.x) >= Math.Abs(mouseDelta.y))
                         {
-                            currentModel.transform.localRotation *= Quaternion.Euler(0f, mouseDelta.x, 0f);
+                            targetModel.transform.localRotation *= Quaternion.Euler(0f, mouseDelta.x, 0f);
                         }
                         else
                         {
-                            Quaternion angles = currentModel.transform.localRotation;
+                            Quaternion angles = targetModel.transform.localRotation;
                             Single angley = angles.eulerAngles[1];
                             Single factorx = -(Single)Math.Cos(Math.PI * angley / 180f);
                             Single factorz = -(Single)Math.Sin(Math.PI * angley / 180f);
                             Quaternion performedRot = Quaternion.Euler(factorx * mouseDelta.y, 0f, factorz * mouseDelta.y);
                             Single horizontalFactor = (angles * performedRot * Vector3.up).y;
                             if (horizontalFactor > 0.5f)
-                                currentModel.transform.localRotation *= performedRot;
+                                targetModel.transform.localRotation *= performedRot;
                         }
                     }
                     mouseLeftPressed = true;
                 }
-                if (Input.GetMouseButton(1))
+                if (Input.GetMouseButton(1)) // Right Click
                 {
                     if (mouseRightWasPressed)
                     {
                         Vector3 mouseDelta = Input.mousePosition - mousePreviousPosition;
-                        currentModel.transform.localPosition -= 0.5f * mouseDelta.y * Vector3.up;
+                        targetModel.transform.localPosition -= 0.5f * new Vector3(mouseDelta.x, mouseDelta.y, mouseDelta.z);
                         if (geoList[currentGeoIndex].Kind == 1)
                             spsEffect.pos = currentModel.transform.localPosition;
                     }
@@ -510,6 +558,10 @@ namespace Memoria.Assets
                 {
                     label += $" Weapon Attach : {weapongeoList[currentWeaponGeoIndex].Name}\n";
                     label += $" Bone Attach : {currentWeaponBoneIndex}\n";
+                    if (ControlWeapon)
+                        label += $" Control : [00FF00]Enabled\n";
+                    else
+                        label += $" Control : [FF0000]Disabled\n";
                 }
                 else
                     label += $"\n\n";              
@@ -548,7 +600,10 @@ namespace Memoria.Assets
             if (currentModel != null && geoList[currentGeoIndex].Kind == 0)
                 UnityEngine.Object.Destroy(currentModel);
             if (currentWeaponModel != null)
+            {
+                ControlWeapon = false;
                 UnityEngine.Object.Destroy(currentWeaponModel);
+            }
             else if (geoList[currentGeoIndex].Kind == 1)
                 spsEffect.Unload();
             while (index < 0)

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -146,7 +146,7 @@ namespace Memoria.Assets
             try
             {
                 if (isLoadingModel || isLoadingWeaponModel)
-                    return;              
+                    return;
                 Boolean mouseLeftWasPressed = mouseLeftPressed;
                 Boolean mouseRightWasPressed = mouseRightPressed;
                 mouseLeftPressed = false;
@@ -564,7 +564,7 @@ namespace Memoria.Assets
                         label += $" Control : [FF0000]Disabled\n";
                 }
                 else
-                    label += $"\n\n";              
+                    label += $"\n\n";
                 if (!String.Equals(infoLabel.text, label))
                     infoLabel.text = label;
                 if (!infoPanel.Show)


### PR DESCRIPTION
- Fix a major issue when the model is frozen if the animation can't be loaded.
- Can switch animations 5 by 5, using `LeftControl or RightControl` + `Up or Down`
- Fix bones positions

![image](https://github.com/Albeoris/Memoria/assets/17729817/11616a78-c4c2-4e0c-8176-98143c090832)
![image](https://github.com/Albeoris/Memoria/assets/17729817/9b0e0b2f-c1a9-47cc-b020-b109fb9096a8)

- If bones had the same position, they get merged in the same line 
![image](https://github.com/Albeoris/Memoria/assets/17729817/8eb2c1f9-d8b7-4981-a055-07766addf3da)

- Display bones connections by using `LeftShift or RightShift` + `B` (made by @Tirlititi but wasn't bind on a key)

![image](https://github.com/Albeoris/Memoria/assets/17729817/39aec528-e436-4fc2-80dc-ce6f3dab9d15)
![image](https://github.com/Albeoris/Memoria/assets/17729817/1bfcd211-60c0-4633-91d6-492bd07d00de)