### PR TITLE
Bug fixes, external textures, small improvements...

### DIFF
--- a/Assembly-CSharp/FF9/btl_abil.cs
+++ b/Assembly-CSharp/FF9/btl_abil.cs
@@ -79,7 +79,7 @@ namespace FF9
             if (defender.IsUnderAnyStatus(BattleStatusConst.NoReaction) || !btl_util.IsCommandDeclarable(command.Id))
                 return;
 
-            RegularItem itemId = IsDefualtAutoPotionBehaviourEnabled()
+            RegularItem itemId = IsDefaultAutoPotionBehaviourEnabled()
                 ? GetFirstPotionUseableByAutoItemAbility()
                 : FindSuitablePotion(defender, Configuration.Battle.AutoPotionOverhealLimit);
 
@@ -92,7 +92,7 @@ namespace FF9
             btl_cmd.SetCounter(defender.Data, BattleCommandId.AutoPotion, (Int32)itemId, defender.Id);
         }
 
-        private static bool IsDefualtAutoPotionBehaviourEnabled()
+        private static Boolean IsDefaultAutoPotionBehaviourEnabled()
         {
             return Configuration.Battle.AutoPotionOverhealLimit < 0;
         }
@@ -116,7 +116,7 @@ namespace FF9
         /// </returns>
         private static RegularItem FindSuitablePotion(BattleTarget defender, Int32 autoPotionOverhealLimitInPercent)
         {
-            RegularItem id = 0;
+            RegularItem id = RegularItem.NoItem;
             foreach (RegularItem itemId in AutoPotionsItemIds)
             {
                 if (ff9item.FF9Item_GetCount(itemId) < 1)
@@ -126,19 +126,18 @@ namespace FF9
 
                 // Every value below is in Hit Points, expect if specified otherwise.
                 UInt32 heal = (UInt32)calc.Target.HpDamage;
-                UInt32 toGain = defender.HasSupportAbility(SupportAbility1.Chemist) ? heal * 2 : heal;
                 UInt32 missing = calc.Target.MaximumHp - calc.Target.CurrentHp;
 
                 // If character gets healed by value smaller than missing hp it means
                 // there is no over healing done yet. Otherwise, check over healing limit set by user.
-                if (toGain <= missing)
+                if (heal <= missing)
                 {
                     id = itemId;
                 }
                 else
                 {
-                    UInt32 overhealDone = toGain - missing;
-                    UInt32 overhealLimit = (UInt32)(toGain * (autoPotionOverhealLimitInPercent / 100));
+                    UInt32 overhealDone = heal - missing;
+                    UInt32 overhealLimit = (UInt32)(heal * autoPotionOverhealLimitInPercent / 100);
 
                     if (overhealDone <= overhealLimit)
                         id = itemId;

--- a/Assembly-CSharp/Global/BTL_DATA.cs
+++ b/Assembly-CSharp/Global/BTL_DATA.cs
@@ -7,6 +7,12 @@ using UnityEngine;
 
 public partial class BTL_DATA
 {
+    public void ChangeModel(GameObject newModel)
+    {
+        gameObject = newModel;
+        _smoothUpdateRegistered = false;
+    }
+
 	public void SetDisappear(Boolean disappear, Byte priority)
 	{
 		Byte value = disappear ? Math.Max(this.bi.disappear, priority) :
@@ -259,7 +265,9 @@ public partial class BTL_DATA
 
 	public BTL_DATA killer_track;
 
-	public Boolean is_monster_transform;
+    public Boolean builtin_weapon_mode = false;
+
+    public Boolean is_monster_transform;
 	public MONSTER_TRANSFORM monster_transform;
 
 	public class MONSTER_TRANSFORM

--- a/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
+++ b/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
@@ -2663,7 +2663,6 @@ public partial class EventEngine
                 this.fieldmap.walkMesh.BGI_animShowFrame((UInt32)this.getv1(), (UInt32)this.getv1());
                 return 0;
             }
-            // TODO: no more information from Hades Workshop
             case EBin.event_code_binary.PLAYER_EQUIP: // "SetCharacterEquipment" Change the piece of equipment of a player, using it from the player's inventory
             {
                 CharacterId charId = this.chr2slot(this.getv3()); // character to (re-)equip.
@@ -2768,11 +2767,11 @@ public partial class EventEngine
                 }
                 return 1;
             }
-            case EBin.event_code_binary.TURN_OBJ_EX:
+            case EBin.event_code_binary.TURN_OBJ_EX: // "TurnTowardObjectEx" Make the specified character turn toward the specified object
             {
-                Actor turner = this.GetObj3() as Actor;
-                PosObj target = this.GetObj3() as PosObj;
-                Int32 tspeed = this.getv3();
+                Actor turner = this.GetObj3() as Actor; // character to turn
+                PosObj target = this.GetObj3() as PosObj; // object to look at
+                Int32 tspeed = this.getv3(); // turn speed
                 if (turner != null && target != null)
                 {
                     Single angle = this.eBin.angleAsm(target.pos[0] - turner.pos[0], target.pos[2] - turner.pos[2]);
@@ -2780,11 +2779,11 @@ public partial class EventEngine
                 }
                 return 0;
             }
-            case EBin.event_code_binary.AANIM_EX:
+            case EBin.event_code_binary.AANIM_EX: // "SetLogicalAnimationEx" Change the logical animation of the specified entry
             {
-                actor = this.GetObj3() as Actor;
-                Int32 kind = this.getv3();
-                UInt16 anim = (UInt16)(Int32)this.getv3();
+                actor = this.GetObj3() as Actor; // object re-animated
+                Int32 kind = this.getv3(); // type of logical animation
+                UInt16 anim = (UInt16)this.getv3(); // animation to use
                 switch (kind)
                 {
                     case 0: actor.idle = anim; break;
@@ -2798,21 +2797,21 @@ public partial class EventEngine
                 AnimationFactory.AddAnimWithAnimatioName(actor.go, FF9DBAll.AnimationDB.GetValue((Int32)anim));
                 return 0;
             }
-            case EBin.event_code_binary.VECTOR_CLEAR:
+            case EBin.event_code_binary.VECTOR_CLEAR: // "ClearMemoriaVector" Empty a vector in the vector system provided by Memoria
             {
-                Int32 vectID = this.getv3();
+                Int32 vectID = this.getv3(); // vector ID to clear
                 if (FF9StateSystem.EventState.gScriptVector.TryGetValue(vectID, out List<Int32> vect))
                     vect.Clear();
                 return 0;
             }
-            case EBin.event_code_binary.DICTIONARY_CLEAR:
+            case EBin.event_code_binary.DICTIONARY_CLEAR: // "ClearMemoriaDictionary" Empty a dictionary in the dictionary system provided by Memoria
             {
-                Int32 dictID = this.getv3();
+                Int32 dictID = this.getv3(); // dictionary ID to clear
                 if (FF9StateSystem.EventState.gScriptDictionary.TryGetValue(dictID, out Dictionary<Int32, Int32> dict))
                     dict.Clear();
                 return 0;
             }
-            case EBin.event_code_binary.BGLMOVE_TIMED:
+            case EBin.event_code_binary.BGLMOVE_TIMED: // "SetTilePositionTimed" Move a tile block over time
             {
                 this.fieldmap.EBG_overlayMoveTimed(this.getv3(), this.getv3(), this.getv3(), this.getv3(), this.getv3());
                 return 0;

--- a/Assembly-CSharp/Global/Field/Map/FieldMap.cs
+++ b/Assembly-CSharp/Global/Field/Map/FieldMap.cs
@@ -510,11 +510,10 @@ public class FieldMap : HonoBehavior
         gameObject.transform.parent = base.transform;
         gameObject.transform.localScale = new Vector3(1f, 1f, 1f);
         FieldMapActor actor = gameObject.AddComponent<FieldMapActor>();
-        Boolean flag = true;
-        if (flag)
+        if (true)
         {
             GeoTexAnim geoTexAnim = gameObject.AddComponent<GeoTexAnim>();
-            geoTexAnim.Load("Models/GeoTexAnim/GEO_MAIN_B0_000", 1, 1, 4);
+            geoTexAnim.Load("Models/GeoTexAnim/GEO_MAIN_B0_000", [1], [1]);
         }
         FieldMapActorController fieldMapActorController = gameObject.AddComponent<FieldMapActorController>();
         fieldMapActorController.fieldMap = this;

--- a/Assembly-CSharp/Global/GEOTEXANIMHEADER.cs
+++ b/Assembly-CSharp/Global/GEOTEXANIMHEADER.cs
@@ -3,110 +3,85 @@ using System.IO;
 using System.Text;
 using Memoria.Scripts;
 using UnityEngine;
-using Object = System.Object;
 
 public class GEOTEXANIMHEADER
 {
-	public void ReadData(BinaryReader reader)
-	{
-		this.flags = reader.ReadByte();
-		this.numframes = reader.ReadByte();
-		this.rate = reader.ReadInt16();
-		this.randmin = reader.ReadUInt16();
-		this.randrange = reader.ReadUInt16();
-		this.frame = reader.ReadInt32();
-		this.count = reader.ReadByte();
-		this.texID = reader.ReadByte();
-		this.lastframe = reader.ReadInt16();
-		this.geotexanimoffset = reader.ReadUInt32();
-		Int64 position = reader.BaseStream.Position;
-		this.lastframe = 1;
-		reader.BaseStream.Seek((Int64)((UInt64)this.geotexanimoffset), SeekOrigin.Begin);
-		this.target = new Rect
-		{
-			x = (Single)(reader.ReadUInt16() * 2),
-			y = (Single)reader.ReadUInt16(),
-			width = (Single)(reader.ReadUInt16() * 2),
-			height = (Single)reader.ReadUInt16()
-		};
-		this.targetuv = this.target;
-		UInt32 num = reader.ReadUInt32();
-		this.coords = new Vector2[(Int32)this.numframes];
-		this.rectuvs = new Rect[(Int32)this.numframes];
-		reader.BaseStream.Seek((Int64)((UInt64)num), SeekOrigin.Begin);
-		for (Int32 i = 0; i < (Int32)this.numframes; i++)
-		{
-			Int32 num2 = (Int32)(reader.ReadInt16() * 2);
-			Int32 num3 = (Int32)reader.ReadInt16();
-			this.coords[i] = new Vector2((Single)num2, (Single)num3);
-			this.rectuvs[i] = new Rect((Single)num2, (Single)num3, this.target.width, this.target.height);
-		}
-		reader.BaseStream.Seek(position, SeekOrigin.Begin);
-	}
+    public void ReadData(BinaryReader reader)
+    {
+        this.flags = reader.ReadByte();
+        this.numframes = reader.ReadByte();
+        this.rate = reader.ReadInt16();
+        this.randmin = reader.ReadUInt16();
+        this.randrange = reader.ReadUInt16();
+        this.frame = reader.ReadInt32();
+        this.count = reader.ReadByte();
+        this.texID = reader.ReadByte();
+        this.lastframe = reader.ReadInt16();
+        this.geotexanimoffset = reader.ReadUInt32();
+        Int64 nextPos = reader.BaseStream.Position;
+        this.lastframe = 1;
+        reader.BaseStream.Seek(this.geotexanimoffset, SeekOrigin.Begin);
+        this.target = new Rect
+        {
+            x = reader.ReadUInt16() * 2,
+            y = reader.ReadUInt16(),
+            width = reader.ReadUInt16() * 2,
+            height = reader.ReadUInt16()
+        };
+        this.targetuv = this.target;
+        UInt32 animPos = reader.ReadUInt32();
+        this.coords = new Vector2[this.numframes];
+        this.rectuvs = new Rect[this.numframes];
+        reader.BaseStream.Seek(animPos, SeekOrigin.Begin);
+        for (Int32 i = 0; i < this.numframes; i++)
+        {
+            Int32 x = reader.ReadInt16() * 2;
+            Int32 y = reader.ReadInt16();
+            this.coords[i] = new Vector2(x, y);
+            this.rectuvs[i] = new Rect(x, y, this.target.width, this.target.height);
+        }
+        reader.BaseStream.Seek(nextPos, SeekOrigin.Begin);
+    }
 
-	public void DumpData()
-	{
-		StringBuilder stringBuilder = new StringBuilder();
-		stringBuilder.Append("flags = " + this.flags + "\n");
-		stringBuilder.Append("numframes = " + this.numframes + "\n");
-		stringBuilder.Append("rate = " + this.rate + "\n");
-		stringBuilder.Append("randmin = " + this.randmin + "\n");
-		stringBuilder.Append("randrange = " + this.randrange + "\n");
-		stringBuilder.Append("frame = " + this.frame + "\n");
-		stringBuilder.Append("count = " + this.count + "\n");
-		stringBuilder.Append("texID = " + this.texID + "\n");
-		stringBuilder.Append("lastframe = " + this.lastframe + "\n");
-		stringBuilder.Append("target = " + this.target + "\n");
-		for (Int32 i = 0; i < (Int32)this.numframes; i++)
-		{
-			stringBuilder.Append(String.Concat(new Object[]
-			{
-				"coords[",
-				i,
-				"] = ",
-				this.coords[i],
-				"\n"
-			}));
-			stringBuilder.Append(String.Concat(new Object[]
-			{
-				"rectuvs[",
-				i,
-				"] = ",
-				this.rectuvs[i],
-				"\n"
-			}));
-		}
-		stringBuilder.Append("-----------");
-		global::Debug.Log(stringBuilder.ToString());
-	}
+    public void DumpData()
+    {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.Append("flags = " + this.flags + "\n");
+        stringBuilder.Append("numframes = " + this.numframes + "\n");
+        stringBuilder.Append("rate = " + this.rate + "\n");
+        stringBuilder.Append("randmin = " + this.randmin + "\n");
+        stringBuilder.Append("randrange = " + this.randrange + "\n");
+        stringBuilder.Append("frame = " + this.frame + "\n");
+        stringBuilder.Append("count = " + this.count + "\n");
+        stringBuilder.Append("texID = " + this.texID + "\n");
+        stringBuilder.Append("lastframe = " + this.lastframe + "\n");
+        stringBuilder.Append("target = " + this.target + "\n");
+        for (Int32 i = 0; i < this.numframes; i++)
+        {
+            stringBuilder.Append($"coords[{i}] = {this.coords[i]}\n");
+            stringBuilder.Append($"rectuvs[{i}] = {this.rectuvs[i]}\n");
+        }
+        stringBuilder.Append("-----------");
+        global::Debug.Log(stringBuilder.ToString());
+    }
 
-	public Byte flags;
+    public Byte count;
+    public Byte flags;
+    public Byte texID;
 
-	public Byte numframes;
+    public Byte numframes;
+    public Int16 rate;
+    public UInt16 randmin;
+    public UInt16 randrange;
+    public Int32 frame;
+    public Int16 lastframe;
 
-	public Int16 rate;
+    public UInt32 geotexanimoffset;
 
-	public UInt16 randmin;
+    public Rect target;
+    public Vector2[] coords;
+    public Rect targetuv;
+    public Rect[] rectuvs;
 
-	public UInt16 randrange;
-
-	public Int32 frame;
-
-	public Byte count;
-
-	public Byte texID;
-
-	public Int16 lastframe;
-
-	public UInt32 geotexanimoffset;
-
-	public Rect target;
-
-	public Vector2[] coords;
-
-	public Rect targetuv;
-
-	public Rect[] rectuvs;
-
-	public static Material texAnimMat = new Material(ShadersLoader.Find("PSX/BattleMap_TexAnim"));
+    public static Material texAnimMat = new Material(ShadersLoader.Find("PSX/BattleMap_TexAnim"));
 }

--- a/Assembly-CSharp/Global/GEOTEXHEADER.cs
+++ b/Assembly-CSharp/Global/GEOTEXHEADER.cs
@@ -1,304 +1,256 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.IO;
 using UnityEngine;
 
 public class GEOTEXHEADER
 {
-	static GEOTEXHEADER()
-	{
-		// Note: this type is marked as 'beforefieldinit'.
-		Dictionary<Int32, BGObjIndex> dictionary = new Dictionary<Int32, BGObjIndex>();
-		dictionary.Add(4, new BGObjIndex(new Int32[1], new Int32[1]));
-		Dictionary<Int32, BGObjIndex> dictionary2 = dictionary;
-		Int32 key = 7;
-		Int32[] array = new Int32[3];
-		array[0] = 1;
-		Int32[] array2 = new Int32[3];
-		array2[0] = 1;
-		dictionary2.Add(key, new BGObjIndex(array, array2));
-		dictionary.Add(9, new BGObjIndex(new Int32[1], new Int32[]
-		{
-			10
-		}));
-		dictionary.Add(29, new BGObjIndex(new Int32[1], new Int32[1]));
-		dictionary.Add(32, new BGObjIndex(new Int32[]
-		{
-			2
-		}, new Int32[]
-		{
-			3
-		}));
-		dictionary.Add(42, new BGObjIndex(new Int32[]
-		{
-			1
-		}, new Int32[]
-		{
-			3
-		}));
-		dictionary.Add(51, new BGObjIndex(new Int32[1], new Int32[]
-		{
-			10
-		}));
-		dictionary.Add(52, new BGObjIndex(new Int32[1], new Int32[]
-		{
-			6
-		}));
-		dictionary.Add(56, new BGObjIndex(new Int32[]
-		{
-			1
-		}, new Int32[1]));
-		dictionary.Add(57, new BGObjIndex(new Int32[1], new Int32[]
-		{
-			2
-		}));
-		dictionary.Add(66, new BGObjIndex(new Int32[1], new Int32[]
-		{
-			1
-		}));
-		dictionary.Add(67, new BGObjIndex(new Int32[1], new Int32[]
-		{
-			10
-		}));
-		Dictionary<Int32, BGObjIndex> dictionary3 = dictionary;
-		Int32 key2 = 69;
-		Int32[] array3 = new Int32[4];
-		array3[0] = 2;
-		array3[1] = 3;
-		dictionary3.Add(key2, new BGObjIndex(array3, new Int32[]
-		{
-			5,
-			0,
-			5,
-			4
-		}));
-		dictionary.Add(71, new BGObjIndex(new Int32[]
-		{
-			0,
-			0,
-			2
-		}, new Int32[]
-		{
-			10,
-			9,
-			4
-		}));
-		dictionary.Add(82, new BGObjIndex(new Int32[]
-		{
-			2
-		}, new Int32[1]));
-		dictionary.Add(92, new BGObjIndex(new Int32[]
-		{
-			2
-		}, new Int32[]
-		{
-			3
-		}));
-		dictionary.Add(108, new BGObjIndex(new Int32[1], new Int32[]
-		{
-			11
-		}));
-		dictionary.Add(118, new BGObjIndex(new Int32[1], new Int32[]
-		{
-			4
-		}));
-		dictionary.Add(128, new BGObjIndex(new Int32[2], new Int32[]
-		{
-			2,
-			3
-		}));
-		dictionary.Add(137, new BGObjIndex(new Int32[2], new Int32[]
-		{
-			2,
-			3
-		}));
-		dictionary.Add(143, new BGObjIndex(new Int32[1], new Int32[1]));
-		dictionary.Add(147, new BGObjIndex(new Int32[1], new Int32[1]));
-		dictionary.Add(155, new BGObjIndex(new Int32[1], new Int32[1]));
-		dictionary.Add(164, new BGObjIndex(new Int32[1], new Int32[1]));
-		dictionary.Add(172, new BGObjIndex(new Int32[1], new Int32[]
-		{
-			5
-		}));
-		GEOTEXHEADER.bgObjMappings = dictionary;
-	}
+    public void ReadTextureAnim(String path)
+    {
+        Byte[] binAsset = AssetManager.LoadBytes(path, true);
+        if (binAsset == null)
+        {
+            global::Debug.LogWarning("Cannot find GeoTexAnim for : " + path);
+            return;
+        }
+        using (BinaryReader binaryReader = new BinaryReader(new MemoryStream(binAsset)))
+        {
+            this.count = binaryReader.ReadUInt16();
+            this.pad = binaryReader.ReadUInt16();
+            this.geotex = new GEOTEXANIMHEADER[this.count];
+            for (Int32 i = 0; i < this.count; i++)
+            {
+                this.geotex[i] = new GEOTEXANIMHEADER();
+                this.geotex[i].ReadData(binaryReader);
+            }
+        }
+    }
 
-	public void ReadTextureAnim(String path)
-	{
-		Byte[] binAsset = AssetManager.LoadBytes(path, true);
-		if (binAsset == null)
-		{
-			global::Debug.LogWarning("Cannot find GeoTexAnim for : " + path);
-			return;
-		}
-		using (BinaryReader binaryReader = new BinaryReader(new MemoryStream(binAsset)))
-		{
-			this.count = binaryReader.ReadUInt16();
-			this.pad = binaryReader.ReadUInt16();
-			this.geotex = new GEOTEXANIMHEADER[(Int32)this.count];
-			for (Int32 i = 0; i < (Int32)this.count; i++)
-			{
-				this.geotex[i] = new GEOTEXANIMHEADER();
-				this.geotex[i].ReadData(binaryReader);
-			}
-		}
-	}
+    public void ReadBattleTextureAnim(BTL_DATA btl, String path)
+    {
+        this.ReadTextureAnim(path);
+        if (this.geotex == null)
+            return;
+        String geoName = FF9BattleDB.GEO.GetValue(btl.dms_geo_id);
+        if (btl.originalGo != null)
+            this.materials = btl.originalGo.GetComponentsInChildren<SkinnedMeshRenderer>().Select(smr => smr.material).ToArray();
+        else
+            this.materials = btl.gameObject.GetComponentsInChildren<SkinnedMeshRenderer>().Select(smr => smr.material).ToArray();
+        GeoTexAnim.SetTexAnimIndexs(geoName, out this._mainTextureIndexs, out this._subTextureIndexs);
+        this.InitMultiTexAnim(geoName);
+    }
 
-	public void ReadPlayerTextureAnim(BTL_DATA btl, String path, Int32 scale = 1)
-	{
-		this.ReadTextureAnim(path);
-		if (this.geotex == null)
-		{
-			return;
-		}
-		String geoName = FF9BattleDB.GEO.GetValue((Int32)btl.dms_geo_id);
-		if (btl.originalGo != (UnityEngine.Object)null)
-		{
-			this._smrs = btl.originalGo.GetComponentsInChildren<SkinnedMeshRenderer>();
-		}
-		else
-		{
-			this._smrs = btl.gameObject.GetComponentsInChildren<SkinnedMeshRenderer>();
-		}
-		this.MultiTexAnim(geoName, scale);
-	}
+    public void ReadTranceTextureAnim(BTL_DATA btl, String geoName)
+    {
+        this.ReadTextureAnim($"Models/GeoTexAnim/{geoName}.tab");
+        if (this.geotex == null)
+            return;
+        btl.tranceGo.SetActive(true);
+        this.materials = btl.tranceGo.GetComponentsInChildren<SkinnedMeshRenderer>().Select(smr => smr.material).ToArray();
+        btl.tranceGo.SetActive(false);
+        GeoTexAnim.SetTexAnimIndexs(geoName, out this._mainTextureIndexs, out this._subTextureIndexs);
+        this.InitMultiTexAnim(geoName);
+    }
 
-	public void ReadTrancePlayerTextureAnim(BTL_DATA btl, String geoName, Int32 scale = 1)
-	{
-		this.ReadTextureAnim("Models/GeoTexAnim/" + geoName + ".tab");
-		if (this.geotex == null)
-		{
-			return;
-		}
-		btl.tranceGo.SetActive(true);
-		this._smrs = btl.tranceGo.GetComponentsInChildren<SkinnedMeshRenderer>();
-		btl.tranceGo.SetActive(false);
-		this.MultiTexAnim(geoName, scale);
-	}
+    public void InitMultiTexAnim(String geoName)
+    {
+        for (Int32 i = 0; i < this.count; i++)
+        {
+            MapTextureToTexAnimIndex(this._mainTextureIndexs[i], this.materials[this._mainTextureIndexs[i]].mainTexture);
+            MapTextureToTexAnimIndex(this._subTextureIndexs[i], this.materials[this._subTextureIndexs[i]].mainTexture);
+            MapRenderTexToTexAnimIndex(this._mainTextureIndexs[i], this.materials[this._mainTextureIndexs[i]], this.TextureMapping[this._mainTextureIndexs[i]]);
+        }
+        for (Int32 i = 0; i < this.count; i++)
+        {
+            Single scalex = this.TextureMapping[this._mainTextureIndexs[i]].width / 128f;
+            Single scaley = this.TextureMapping[this._mainTextureIndexs[i]].height / 128f;
+            Single subw = this.TextureMapping[this._subTextureIndexs[i]].width;
+            Single subh = this.TextureMapping[this._subTextureIndexs[i]].height;
+            Single subscalex = subw / 128f;
+            Single subscaley = subh / 128f;
+            Rect rect = this.geotex[i].targetuv;
+            rect.x *= scalex;
+            rect.y *= scaley;
+            rect.width *= scalex;
+            rect.height *= scaley;
+            this.geotex[i].targetuv = rect;
+            for (Int32 j = 0; j < this.geotex[i].numframes; j++)
+            {
+                rect = this.geotex[i].rectuvs[j];
+                rect.x = (rect.x * subscalex + 0.5f) / subw;
+                rect.y = (subh - (rect.y + rect.height) * subscaley + 0.5f) / subh;
+                rect.width = (rect.width * subscalex - 1f) / subw;
+                rect.height = (rect.height * subscaley - 1f) / subh;
+                this.geotex[i].rectuvs[j] = rect;
+            }
+        }
+    }
 
-	private void MultiTexAnim(String geoName, Int32 scale)
-	{
-		GeoTexAnim.SetTexAnimIndexs(geoName, out this._mainTextureIndexs, out this._subTextureIndexs);
-		this.RenderTexWidth = (Single)this._smrs[this._mainTextureIndexs[0]].material.mainTexture.width;
-		this.RenderTexHeight = (Single)this._smrs[this._mainTextureIndexs[0]].material.mainTexture.height;
-		for (Int32 i = 0; i < (Int32)this.count; i++)
-		{
-			GeoTexAnim.MapTextureToTexAnimIndex(this._mainTextureIndexs[i], this._smrs[this._mainTextureIndexs[i]].material.mainTexture, this.TextureMapping);
-			GeoTexAnim.MapTextureToTexAnimIndex(this._subTextureIndexs[i], this._smrs[this._subTextureIndexs[i]].material.mainTexture, this.TextureMapping);
-			GeoTexAnim.MapRenderTexToTexAnimIndex(this._mainTextureIndexs[i], this.RenderTexWidth, this.RenderTexHeight, this._smrs[this._mainTextureIndexs[i]], this.TextureMapping[this._mainTextureIndexs[i]], this.RenderTexMapping);
-		}
-		Single renderTexWidth = this.RenderTexWidth;
-		Single renderTexHeight = this.RenderTexHeight;
-		for (Int32 j = 0; j < (Int32)this.count; j++)
-		{
-			Rect rect = this.geotex[j].targetuv;
-			rect.x *= (Single)scale;
-			rect.y *= (Single)scale;
-			rect.width *= (Single)scale;
-			rect.height *= (Single)scale;
-			this.geotex[j].targetuv = rect;
-			for (Int32 k = 0; k < (Int32)this.geotex[j].numframes; k++)
-			{
-				rect = this.geotex[j].rectuvs[k];
-				rect.x *= (Single)scale;
-				rect.y *= (Single)scale;
-				rect.width *= (Single)scale;
-				rect.height *= (Single)scale;
-				rect.y = renderTexHeight - rect.y - rect.height;
-				rect.x += 0.5f;
-				rect.y += 0.5f;
-				rect.width -= 1f;
-				rect.height -= 1f;
-				rect.x /= renderTexWidth;
-				rect.y /= renderTexHeight;
-				rect.width /= renderTexWidth;
-				rect.height /= renderTexHeight;
-				this.geotex[j].rectuvs[k] = rect;
-			}
-		}
-	}
+    private void MapTextureToTexAnimIndex(Int32 texAnimIndex, Texture texture)
+    {
+        if (!this.TextureMapping.ContainsKey(texAnimIndex))
+            this.TextureMapping.Add(texAnimIndex, texture);
+    }
 
-	public void ReadBGTextureAnim(String battleModelPath)
-	{
-		this.bbgnumber = Int32.Parse(battleModelPath.Replace("BBG_B", String.Empty));
-		String path = "BattleMap/BattleTexAnim/" + battleModelPath.Replace("BBG", "TAM") + ".tab";
-		this.ReadTextureAnim(path);
-	}
+    private void MapRenderTexToTexAnimIndex(Int32 texAnimIndex, Material mat, Texture mainTexture)
+    {
+        Single textureWidth = mainTexture.width;
+        Single textureHeight = mainTexture.height;
+        if (!this.RenderTexMapping.ContainsKey(texAnimIndex))
+        {
+            RenderTexture renderTexture = new RenderTexture((Int32)textureWidth, (Int32)textureHeight, 24);
+            renderTexture.filterMode = FilterMode.Bilinear;
+            renderTexture.wrapMode = TextureWrapMode.Repeat;
+            renderTexture.name = mat.name + "_RT";
+            mat.mainTexture = renderTexture;
+            this.RenderTexMapping.Add(texAnimIndex, renderTexture);
+            RenderTexture active = RenderTexture.active;
+            RenderTexture.active = renderTexture;
+            GL.PushMatrix();
+            GL.Clear(true, true, Color.clear);
+            GL.LoadPixelMatrix(0f, textureWidth, textureHeight, 0f);
+            Graphics.DrawTexture(new Rect(0f, 0f, textureWidth, textureHeight), mainTexture);
+            GL.PopMatrix();
+            RenderTexture.active = active;
+        }
+    }
 
-	public void InitTextureAnim()
-	{
-		if (this.geotex == null)
-		{
-			return;
-		}
-		this._mrs = FF9StateSystem.Battle.FF9Battle.map.btlBGPtr.GetComponentsInChildren<MeshRenderer>();
-		MeshRenderer[][] array = new MeshRenderer[2][];
-		if (this.bbgnumber == 7)
-		{
-			array[0] = FF9StateSystem.Battle.FF9Battle.map.btlBGObjAnim[0].GetComponentsInChildren<MeshRenderer>();
-			array[1] = FF9StateSystem.Battle.FF9Battle.map.btlBGObjAnim[1].GetComponentsInChildren<MeshRenderer>();
-		}
-		BGObjIndex bgobjIndex = GEOTEXHEADER.bgObjMappings[this.bbgnumber];
-		this.texAnimMaterials = new Material[(Int32)this.count];
-		this.TexAnimTextures = new Texture[(Int32)this.count];
-		this.extraTexAimMaterials = new Material[(Int32)this.count];
-		this.extraTexAnimTrTextures = new Texture[(Int32)this.count];
-		for (Int32 i = 0; i < (Int32)this.count; i++)
-		{
-			if (this.bbgnumber == 7 && i != 0)
-			{
-				this.texAnimMaterials[i] = array[i - 1][bgobjIndex.groupIndex[i]].materials[bgobjIndex.materialIndex[i]];
-				this.TexAnimTextures[i] = this.texAnimMaterials[i].mainTexture;
-			}
-			else
-			{
-				this.texAnimMaterials[i] = this._mrs[bgobjIndex.groupIndex[i]].materials[bgobjIndex.materialIndex[i]];
-				this.TexAnimTextures[i] = this.texAnimMaterials[i].mainTexture;
-				if (this.bbgnumber == 57)
-				{
-					this.extraTexAimMaterials[i] = this._mrs[2].materials[0];
-					this.extraTexAnimTrTextures[i] = this.extraTexAimMaterials[i].mainTexture;
-				}
-				else if (this.bbgnumber == 71)
-				{
-					this.extraTexAimMaterials[i] = this._mrs[0].materials[11];
-					this.extraTexAnimTrTextures[i] = this.extraTexAimMaterials[i].mainTexture;
-				}
-			}
-		}
-	}
+    public void MultiTexAnimService(Int32 i, Int16 framenum)
+    {
+        GEOTEXANIMHEADER animHeader = this.geotex[i];
+        RenderTexture active = RenderTexture.active;
+        RenderTexture.active = this.RenderTexMapping[this._mainTextureIndexs[i]];
+        GL.PushMatrix();
+        GL.LoadPixelMatrix(0f, RenderTexture.active.width, RenderTexture.active.height, 0f);
+        Graphics.DrawTexture(new Rect(0f, 0f, RenderTexture.active.width, RenderTexture.active.height), this.TextureMapping[this._mainTextureIndexs[i]], GEOTEXANIMHEADER.texAnimMat);
+        Graphics.DrawTexture(animHeader.targetuv, this.TextureMapping[this._subTextureIndexs[i]], animHeader.rectuvs[framenum], 0, 0, 0, 0);
+        GL.PopMatrix();
+        RenderTexture.active = active;
+    }
 
-	public UInt16 count;
+    public void ReadBGTextureAnim(String battleModelPath)
+    {
+        this.bbgnumber = Int32.Parse(battleModelPath.Replace("BBG_B", String.Empty));
+        this.ReadTextureAnim($"BattleMap/BattleTexAnim/{battleModelPath.Replace("BBG", "TAM")}.tab");
+    }
 
-	public UInt16 pad;
+    public void CheckRenderTextures(MonoBehaviour framework)
+    {
+        for (Int32 i = 0; i < this.count; i++)
+        {
+            RenderTexture renderTexture = this.RenderTexMapping[this._mainTextureIndexs[i]];
+            if (!renderTexture.IsCreated())
+            {
+                if (this.geotex != null)
+                    framework.StartCoroutine(this.WaitForRecreateRenderTexture(i));
+            }
+        }
+    }
 
-	public GEOTEXANIMHEADER[] geotex;
+    private void SetDefaultTextures(Int32 i)
+    {
+        this.materials[this._mainTextureIndexs[i]].mainTexture = this.TextureMapping[this._mainTextureIndexs[i]];
+        this.materials[this._subTextureIndexs[i]].mainTexture = this.TextureMapping[this._subTextureIndexs[i]];
+    }
 
-	public SkinnedMeshRenderer[] _smrs;
+    private void SetBackRenderTexture(Int32 i)
+    {
+        this.materials[this._mainTextureIndexs[i]].mainTexture = this.RenderTexMapping[this._mainTextureIndexs[i]];
+    }
 
-	private MeshRenderer[] _mrs;
+    public void RecreateMultiTexAnim(Int32 i)
+    {
+        RenderTexture active = RenderTexture.active;
+        RenderTexture.active = this.RenderTexMapping[this._mainTextureIndexs[i]];
+        GL.PushMatrix();
+        GL.Clear(true, true, Color.clear);
+        GL.LoadPixelMatrix(0f, RenderTexture.active.width, RenderTexture.active.height, 0f);
+        Graphics.DrawTexture(new Rect(0f, 0f, RenderTexture.active.width, RenderTexture.active.height), this.TextureMapping[this._mainTextureIndexs[i]]);
+        GL.PopMatrix();
+        RenderTexture.active = active;
+    }
 
-	public Material[] texAnimMaterials;
+    private IEnumerator WaitForRecreateRenderTexture(Int32 i)
+    {
+        this.SetDefaultTextures(i);
+        yield return new WaitForEndOfFrame();
+        this.SetBackRenderTexture(i);
+        this.RecreateMultiTexAnim(i);
+        yield break;
+    }
 
-	public Texture[] TexAnimTextures;
+    public void InitBBGTextureAnim()
+    {
+        if (this.geotex == null)
+            return;
+        BGObjIndex bgobjIndex = GEOTEXHEADER.bgObjMappings[this.bbgnumber];
+        MeshRenderer[] bbgmrs = FF9StateSystem.Battle.FF9Battle.map.btlBGPtr.GetComponentsInChildren<MeshRenderer>();
+        this.materials = new Material[this.count];
+        this.bbgExtraAimMaterials = new Material[this.count];
+        for (Int32 i = 0; i < this.count; i++)
+        {
+            if (this.bbgnumber == 7 && i != 0) // Memoria, Nova Dragon battle
+            {
+                if (i == 1)
+                    this.materials[i] = FF9StateSystem.Battle.FF9Battle.map.btlBGObjAnim[0].GetComponentsInChildren<MeshRenderer>()[bgobjIndex.groupIndex[i]].materials[bgobjIndex.materialIndex[i]];
+                else
+                    this.materials[i] = FF9StateSystem.Battle.FF9Battle.map.btlBGObjAnim[1].GetComponentsInChildren<MeshRenderer>()[bgobjIndex.groupIndex[i]].materials[bgobjIndex.materialIndex[i]];
+            }
+            else
+            {
+                this.materials[i] = bbgmrs[bgobjIndex.groupIndex[i]].materials[bgobjIndex.materialIndex[i]];
+                if (this.bbgnumber == 57) // Cleyra, Observation post
+                    this.bbgExtraAimMaterials[i] = bbgmrs[2].materials[0];
+                else if (this.bbgnumber == 71) // Fossil Roo, Underground lake
+                    this.bbgExtraAimMaterials[i] = bbgmrs[0].materials[11];
+            }
+        }
+    }
 
-	public Material[] extraTexAimMaterials;
+    public UInt16 count;
+    public UInt16 pad;
 
-	public Texture[] extraTexAnimTrTextures;
+    public GEOTEXANIMHEADER[] geotex;
+    public Material[] materials;
 
-	public Int32[] _mainTextureIndexs;
+    public Material[] bbgExtraAimMaterials;
 
-	public Int32[] _subTextureIndexs;
+    public Int32[] _mainTextureIndexs;
+    public Int32[] _subTextureIndexs;
 
-	public Dictionary<Int32, Texture> TextureMapping = new Dictionary<Int32, Texture>();
+    public Dictionary<Int32, Texture> TextureMapping = new Dictionary<Int32, Texture>();
+    public Dictionary<Int32, RenderTexture> RenderTexMapping = new Dictionary<Int32, RenderTexture>();
 
-	public Dictionary<Int32, RenderTexture> RenderTexMapping = new Dictionary<Int32, RenderTexture>();
+    public Int32 bbgnumber;
 
-	public Single RenderTexWidth;
-
-	public Single RenderTexHeight;
-
-	public Int32 bbgnumber;
-
-	public static Dictionary<Int32, BGObjIndex> bgObjMappings;
+    public static Dictionary<Int32, BGObjIndex> bgObjMappings = new Dictionary<Int32, BGObjIndex>()
+    {
+        { 4,   new BGObjIndex([0], [0]) }, // Prima Vista, Stage (Night)
+        { 7,   new BGObjIndex([1, 0, 0], [1, 0, 0]) }, // Memoria, Nova Dragon battle
+        { 9,   new BGObjIndex([0], [10]) }, // Alexandria Castle, Extraction altar
+        { 29,  new BGObjIndex([0], [0]) }, // Gizamaluke's Grotto, Hall
+        { 32,  new BGObjIndex([2], [3]) }, // Oeilvert, Grand Hall
+        { 42,  new BGObjIndex([1], [3]) }, // Oeilvert, Ark battle
+        { 51,  new BGObjIndex([0], [10]) }, // Cleyra's Trunk, Inside, Platform with less sand
+        { 52,  new BGObjIndex([0], [6]) }, // Cleyra's Trunk, Inside, Sandfall
+        { 56,  new BGObjIndex([1], [0]) }, // Cleyra, Antlion battle
+        { 57,  new BGObjIndex([0], [2]) }, // Cleyra, Observation post
+        { 66,  new BGObjIndex([0], [1]) }, // Alexandria Castle, Queen's Chamber
+        { 67,  new BGObjIndex([0], [10]) }, // Fossil Roo, Upper level
+        { 69,  new BGObjIndex([2, 3, 0, 0], [5, 0, 5, 4]) }, // Fossil Roo, Road accross water
+        { 71,  new BGObjIndex([0, 0, 2], [10, 9, 4]) }, // Fossil Roo, Underground lake
+        { 82,  new BGObjIndex([2], [0]) }, // Iifa Tree, Inside, Leaf elevator
+        { 92,  new BGObjIndex([2], [3]) }, // Desert Palace, Dock
+        { 108, new BGObjIndex([0], [11]) }, // Ipsen's Castle, Mirrors' room
+        { 118, new BGObjIndex([0], [4]) }, // Memoria, Portal
+        { 128, new BGObjIndex([0, 0], [2, 3]) }, // World Map, Mist Continent, Beach + Mist
+        { 137, new BGObjIndex([0, 0], [2, 3]) }, // World Map, Mist Continent, Beach
+        { 143, new BGObjIndex([0], [0]) }, // World Map, Lost Continent, Beach
+        { 147, new BGObjIndex([0], [0]) }, // World Map, Outer Continent, Beach
+        { 155, new BGObjIndex([0], [0]) }, // World Map, Outer Continent, Beach + Mist
+        { 164, new BGObjIndex([0], [0]) }, // World Map, Lost Continent, Beach + Mist
+        { 172, new BGObjIndex([0], [5]) }, // Crystal World, Necron battle
+    };
 }

--- a/Assembly-CSharp/Global/Geo/GeoTexAnim.cs
+++ b/Assembly-CSharp/Global/Geo/GeoTexAnim.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.IO;
+using System.Linq;
 using Assets.Scripts.Common;
 using UnityEngine;
 
@@ -9,7 +8,7 @@ public class GeoTexAnim : HonoBehavior
 {
 	public override void HonoAwake()
 	{
-		this.Count = 0;
+		this._renderTexuresCreated = false;
 		this._isLoaded = false;
 		this._cFrameCounter = 0;
 	}
@@ -17,142 +16,52 @@ public class GeoTexAnim : HonoBehavior
 	public override void HonoOnDestroy()
 	{
 		base.HonoOnDestroy();
-		if (this.RenderTex != (UnityEngine.Object)null)
+		if (this.TextureAnim != null)
 		{
-			this.RenderTex.Release();
-			this.RenderTex = (RenderTexture)null;
+			foreach (RenderTexture rt in this.TextureAnim.RenderTexMapping.Values)
+				rt.Release();
+			this.TextureAnim = null;
 		}
 	}
 
-	public void Load(String modelName, Int32 mainTextureIndex, Int32 subTextureIndex, Int32 scale = 1)
+	public void Load(String modelName, Int32[] mainTextureIndex, Int32[] subTextureIndex)
 	{
-		this._mainTextureIndex = mainTextureIndex;
-		this._subTextureIndex = subTextureIndex;
-		Byte[] binAsset = AssetManager.LoadBytes(modelName + ".tab", true);
-		if (binAsset == null)
+		this.TextureAnim = new GEOTEXHEADER();
+		this.TextureAnim.ReadTextureAnim(modelName + ".tab");
+		if (this.TextureAnim.geotex == null)
 			return;
-		using (BinaryReader binaryReader = new BinaryReader(new MemoryStream(binAsset)))
-		{
-			this.Count = binaryReader.ReadUInt16();
-			Int32 num = binaryReader.ReadUInt16();
-			this.Anims = new GEOTEXANIMHEADER[this.Count];
-			for (Int32 i = 0; i < this.Count; i++)
-			{
-				this.Anims[i] = new GEOTEXANIMHEADER();
-				this.Anims[i].ReadData(binaryReader);
-			}
-		}
-		this._isLoaded = true;
-		this._smrs = base.gameObject.GetComponentsInChildren<SkinnedMeshRenderer>();
+		this.TextureAnim._mainTextureIndexs = mainTextureIndex;
+		this.TextureAnim._subTextureIndexs = subTextureIndex;
+		SkinnedMeshRenderer[] skmrs = base.gameObject.GetComponentsInChildren<SkinnedMeshRenderer>();
 		if (modelName.Contains("GEO_SUB_F0_KUW"))
-		{
-			this._mainTexture = this._smrs[0].materials[this._mainTextureIndex].mainTexture;
-			this._subTexture = this._smrs[0].materials[this._subTextureIndex].mainTexture;
-		}
+			this.TextureAnim.materials = skmrs[0].materials;
 		else
-		{
-			this._mainTexture = this._smrs[this._mainTextureIndex].material.mainTexture;
-			this._subTexture = this._smrs[this._subTextureIndex].material.mainTexture;
-		}
-		this.RenderTex = new RenderTexture(this._mainTexture.width, this._mainTexture.height, 24);
-		this.RenderTex.filterMode = FilterMode.Bilinear;
-		this.RenderTex.wrapMode = TextureWrapMode.Repeat;
-		this.RenderTex.name = modelName + "_RT";
-		this.RenderTexWidth = this._mainTexture.width;
-		this.RenderTexHeight = this._mainTexture.height;
-		this._smrs[this._mainTextureIndex].material.mainTexture = this.RenderTex;
-		Single w = this._subTexture.width;
-		Single h = this._subTexture.height;
-		for (Int32 i = 0; i < this.Count; i++)
-		{
-			Rect rect = this.Anims[i].targetuv;
-			rect.x *= scale;
-			rect.y *= scale;
-			rect.width *= scale;
-			rect.height *= scale;
-			this.Anims[i].targetuv = rect;
-			for (Int32 j = 0; j < this.Anims[i].numframes; j++)
-			{
-				rect = this.Anims[i].rectuvs[j];
-				rect.x *= scale;
-				rect.y *= scale;
-				rect.width *= scale;
-				rect.height *= scale;
-				rect.y = h - rect.y - rect.height;
-				rect.x += 0.5f;
-				rect.y += 0.5f;
-				rect.width -= 1f;
-				rect.height -= 1f;
-				rect.x /= w;
-				rect.y /= h;
-				rect.width /= w;
-				rect.height /= h;
-				this.Anims[i].rectuvs[j] = rect;
-			}
-		}
-		RenderTexture active = RenderTexture.active;
-		RenderTexture.active = this.RenderTex;
-		GL.PushMatrix();
-		GL.Clear(true, true, Color.clear);
-		GL.LoadPixelMatrix(0f, this.RenderTexWidth, this.RenderTexHeight, 0f);
-		Graphics.DrawTexture(new Rect(0f, 0f, this.RenderTexWidth, this.RenderTexHeight), this._mainTexture);
-		GL.PopMatrix();
-		RenderTexture.active = active;
-	}
-
-	private IEnumerator WaitToRecreateTexAnim(RenderTexture reRenderTex, Texture reMainTex)
-	{
-		this._smrs[this._mainTextureIndex].material.mainTexture = this._mainTexture;
-		this._smrs[this._subTextureIndex].material.mainTexture = this._subTexture;
-		yield return new WaitForEndOfFrame();
-		this._smrs[this._mainTextureIndex].material.mainTexture = this.RenderTex;
-		this.RecreateTexAnim(reRenderTex, reMainTex);
-		yield break;
-	}
-
-	private void RecreateTexAnim(RenderTexture reRenderTex, Texture reMainTex)
-	{
-		RenderTexture active = RenderTexture.active;
-		RenderTexture.active = reRenderTex;
-		GL.PushMatrix();
-		GL.Clear(true, true, Color.clear);
-		GL.LoadPixelMatrix(0f, this.RenderTexWidth, this.RenderTexHeight, 0f);
-		Graphics.DrawTexture(new Rect(0f, 0f, this.RenderTexWidth, this.RenderTexHeight), reMainTex);
-		GL.PopMatrix();
-		RenderTexture.active = active;
+			this.TextureAnim.materials = skmrs.Select(smr => smr.material).ToArray();
+		this.TextureAnim.InitMultiTexAnim(modelName + ".tab");
+		this._isLoaded = true;
 	}
 
 	public Int32 geoTexAnimGetCount()
 	{
-		return this.Count;
+		return this.TextureAnim?.count ?? 0;
 	}
 
 	public void geoTexAnimPlay(Int32 anum)
 	{
 		if (!this._isLoaded)
-		{
 			return;
-		}
-		GEOTEXANIMHEADER geotexanimheader = this.Anims[anum];
-		geotexanimheader.flags = (Byte)(geotexanimheader.flags | 1);
-		this.Anims[anum].frame = 0;
-		this.Anims[anum].lastframe = 4096;
+		this.TextureAnim.geotex[anum].flags |= 1;
+		this.TextureAnim.geotex[anum].frame = 0;
+		this.TextureAnim.geotex[anum].lastframe = 4096;
 		if (anum == 0)
-		{
-			Byte b = 3;
-			GEOTEXANIMHEADER geotexanimheader2 = this.Anims[2];
-			geotexanimheader2.flags = (Byte)(geotexanimheader2.flags & (Byte)(~b));
-		}
+			this.TextureAnim.geotex[2].flags &= unchecked((Byte)~3);
 	}
 
 	public static void geoTexAnimPlay(GEOTEXHEADER tab, Int32 anum)
 	{
 		if (tab == null || tab.geotex == null)
-		{
 			return;
-		}
-		GEOTEXANIMHEADER geotexanimheader = tab.geotex[anum];
-		geotexanimheader.flags = (Byte)(geotexanimheader.flags | 1);
+		tab.geotex[anum].flags |= 1;
 		tab.geotex[anum].frame = 0;
 		tab.geotex[anum].lastframe = 4096;
 	}
@@ -160,23 +69,17 @@ public class GeoTexAnim : HonoBehavior
 	public void geoTexAnimPlayOnce(Int32 anum)
 	{
 		if (!this._isLoaded)
-		{
 			return;
-		}
-		GEOTEXANIMHEADER geotexanimheader = this.Anims[anum];
-		geotexanimheader.flags = (Byte)(geotexanimheader.flags | 3);
-		this.Anims[anum].frame = 0;
-		this.Anims[anum].lastframe = 4096;
+		this.TextureAnim.geotex[anum].flags |= 3;
+		this.TextureAnim.geotex[anum].frame = 0;
+		this.TextureAnim.geotex[anum].lastframe = 4096;
 	}
 
 	public static void geoTexAnimPlayOnce(GEOTEXHEADER tab, Int32 anum)
 	{
 		if (tab == null || tab.geotex == null)
-		{
 			return;
-		}
-		GEOTEXANIMHEADER geotexanimheader = tab.geotex[anum];
-		geotexanimheader.flags = (Byte)(geotexanimheader.flags | 3);
+		tab.geotex[anum].flags |= 3;
 		tab.geotex[anum].frame = 0;
 		tab.geotex[anum].lastframe = 4096;
 	}
@@ -184,46 +87,36 @@ public class GeoTexAnim : HonoBehavior
 	public void geoTexAnimStop(Int32 anum)
 	{
 		if (!this._isLoaded)
-		{
 			return;
-		}
-		Byte b = 3;
-		GEOTEXANIMHEADER geotexanimheader = this.Anims[anum];
-		geotexanimheader.flags = (Byte)(geotexanimheader.flags & (Byte)(~b));
+		this.TextureAnim.geotex[anum].flags &= unchecked((Byte)~3);
 	}
 
 	public static void geoTexAnimStop(GEOTEXHEADER tab, Int32 anum)
 	{
 		if (tab == null || tab.geotex == null)
-		{
 			return;
-		}
-		Byte b = 3;
-		GEOTEXANIMHEADER geotexanimheader = tab.geotex[anum];
-		geotexanimheader.flags = (Byte)(geotexanimheader.flags & (Byte)(~b));
+		tab.geotex[anum].flags &= unchecked((Byte)~3);
 	}
 
 	public static void geoTexAnimFreezeState(BTL_DATA btl)
 	{
 		if (btl.backupGeotex != null || btl.texanimptr == null || btl.texanimptr.geotex == null)
-		{
 			return;
-		}
-		Int32 num = (Int32)btl.texanimptr.geotex.Length;
-		btl.backupGeotex = new Byte[num];
-		for (Int32 i = 0; i < num; i++)
+		Int32 animCount = btl.texanimptr.geotex.Length;
+		btl.backupGeotex = new Byte[animCount];
+		for (Int32 i = 0; i < animCount; i++)
 		{
 			btl.backupGeotex[i] = btl.texanimptr.geotex[i].flags;
 			GeoTexAnim.geoTexAnimStop(btl.texanimptr, i);
 		}
 		if (btl.bi.player != 0 && btl.tranceTexanimptr != null && btl.tranceTexanimptr.geotex != null)
 		{
-			num = (Int32)btl.tranceTexanimptr.geotex.Length;
-			btl.backupGeoTrancetex = new Byte[num];
-			for (Int32 j = 0; j < num; j++)
+			animCount = btl.tranceTexanimptr.geotex.Length;
+			btl.backupGeoTrancetex = new Byte[animCount];
+			for (Int32 i = 0; i < animCount; i++)
 			{
-				btl.backupGeoTrancetex[j] = btl.tranceTexanimptr.geotex[j].flags;
-				GeoTexAnim.geoTexAnimStop(btl.tranceTexanimptr, j);
+				btl.backupGeoTrancetex[i] = btl.tranceTexanimptr.geotex[i].flags;
+				GeoTexAnim.geoTexAnimStop(btl.tranceTexanimptr, i);
 			}
 		}
 	}
@@ -231,25 +124,17 @@ public class GeoTexAnim : HonoBehavior
 	public static void geoTexAnimReturnState(BTL_DATA btl)
 	{
 		if (btl.texanimptr == null || btl.texanimptr.geotex == null)
-		{
 			return;
-		}
-		Int32 num = (Int32)btl.texanimptr.geotex.Length;
-		Int32 num2 = 0;
-		while (num2 < num && btl.backupGeotex != null)
-		{
-			btl.texanimptr.geotex[num2].flags = btl.backupGeotex[num2];
-			num2++;
-		}
+		Int32 animCount = btl.texanimptr.geotex.Length;
+		if (btl.backupGeotex != null)
+			for (Int32 i = 0; i < animCount; i++)
+				btl.texanimptr.geotex[i].flags = btl.backupGeotex[i];
 		if (btl.bi.player != 0 && btl.tranceTexanimptr != null && btl.tranceTexanimptr.geotex != null)
 		{
-			num = (Int32)btl.tranceTexanimptr.geotex.Length;
-			Int32 num3 = 0;
-			while (num3 < num && btl.backupGeoTrancetex != null)
-			{
-				btl.tranceTexanimptr.geotex[num3].flags = btl.backupGeoTrancetex[num3];
-				num3++;
-			}
+			animCount = btl.tranceTexanimptr.geotex.Length;
+			if (btl.backupGeoTrancetex != null)
+				for (Int32 i = 0; i < animCount; i++)
+					btl.tranceTexanimptr.geotex[i].flags = btl.backupGeoTrancetex[i];
 		}
 		btl.backupGeotex = null;
 		btl.backupGeoTrancetex = null;
@@ -258,26 +143,19 @@ public class GeoTexAnim : HonoBehavior
 	public Boolean ff9fieldCharIsTexAnimActive()
 	{
 		if (!this._isLoaded)
-		{
 			return false;
-		}
-		Int32 num = this.geoTexAnimGetCount();
-		for (Int32 i = num - 1; i >= 0; i--)
-		{
-			if ((this.Anims[i].flags & 1) != 0)
-			{
+		for (Int32 i = this.geoTexAnimGetCount() - 1; i >= 0; i--)
+			if ((this.TextureAnim.geotex[i].flags & 1) != 0)
 				return true;
-			}
-		}
 		return false;
 	}
 
 	private void Update()
 	{
-		if (!this._isLoaded)
+		if (!this._isLoaded || this._renderTexuresCreated)
 			return;
-		if (!this.RenderTex.IsCreated())
-			base.StartCoroutine(this.WaitToRecreateTexAnim(this.RenderTex, this._mainTexture));
+		this.TextureAnim.CheckRenderTextures(this);
+		this._renderTexuresCreated = true;
 	}
 
 	public override void HonoUpdate()
@@ -288,118 +166,54 @@ public class GeoTexAnim : HonoBehavior
 		if (this._cFrameCounter >= (SceneDirector.IsBattleScene() ? 2 : 1))
 		{
 			this._cFrameCounter = 0;
-			for (Int32 i = 0; i < this.Count; i++)
-			{
-				GEOTEXANIMHEADER geotexanimheader = this.Anims[i];
-				if ((geotexanimheader.flags & 1) != 0)
-				{
-					Int32 num = geotexanimheader.frame;
-					Int32 lastframe = (Int32)geotexanimheader.lastframe;
-					Int16 num2 = (Int16)(num >> 12);
-					if (num2 >= 0)
-					{
-						if ((Int32)num2 != lastframe)
-						{
-							for (Int32 j = 0; j < (Int32)geotexanimheader.count; j++)
-							{
-								RenderTexture active = RenderTexture.active;
-								RenderTexture.active = this.RenderTex;
-								GL.PushMatrix();
-								GL.LoadPixelMatrix(0f, this.RenderTexWidth, this.RenderTexHeight, 0f);
-								Graphics.DrawTexture(new Rect(0f, 0f, this.RenderTexWidth, this.RenderTexHeight), this._mainTexture);
-								Graphics.DrawTexture(geotexanimheader.targetuv, this._subTexture, geotexanimheader.rectuvs[(Int32)num2], 0, 0, 0, 0);
-								GL.PopMatrix();
-								RenderTexture.active = active;
-							}
-							geotexanimheader.lastframe = num2;
-						}
-						Int16 rate = geotexanimheader.rate;
-						num += (Int32)rate;
-					}
-					else
-					{
-						num += 4096;
-					}
-					if (num >> 12 < (Int32)geotexanimheader.numframes)
-					{
-						geotexanimheader.frame = num;
-					}
-					else if (geotexanimheader.randrange > 0)
-					{
-						UInt32 num3 = this.geoTexAnimRandom((UInt32)geotexanimheader.randmin, (UInt32)geotexanimheader.randrange);
-						geotexanimheader.frame = (Int32)(-(Int32)((UInt64)((UInt64)num3 << 12)));
-					}
-					else if ((geotexanimheader.flags & 2) != 0)
-					{
-						Byte b = 3;
-						GEOTEXANIMHEADER geotexanimheader2 = geotexanimheader;
-						geotexanimheader2.flags = (Byte)(geotexanimheader2.flags & (Byte)(~b));
-					}
-					else
-					{
-						geotexanimheader.frame = 0;
-					}
-				}
-			}
-			return;
+			geoTexAnimService(this.TextureAnim);
 		}
 	}
 
-	private UInt32 geoTexAnimRandom(UInt32 randmin, UInt32 randrange)
+	private static Int32 geoTexAnimRandom(Int32 randmin, Int32 randrange)
 	{
-		return (UInt32)UnityEngine.Random.Range((Int32)randmin, (Int32)(randrange + 1u));
+		return UnityEngine.Random.Range(randmin, randrange + 1);
 	}
 
 	public static void geoTexAnimService(GEOTEXHEADER texHeader)
 	{
 		if (texHeader == null)
-		{
 			return;
-		}
-		for (Int32 i = 0; i < (Int32)texHeader.count; i++)
+		for (Int32 i = 0; i < texHeader.count; i++)
 		{
 			GEOTEXANIMHEADER geotexanimheader = texHeader.geotex[i];
 			if ((geotexanimheader.flags & 1) != 0)
 			{
 				if (geotexanimheader.numframes != 0)
 				{
-					Int32 num = geotexanimheader.frame;
+					Int32 frameLong = geotexanimheader.frame;
 					Int16 lastframe = geotexanimheader.lastframe;
-					Int16 num2 = (Int16)(num >> 12);
-					if (num2 >= 0)
+					Int16 frameShort = (Int16)(frameLong >> 12);
+					if (frameShort >= 0)
 					{
-						if (num2 != lastframe)
+						if (frameShort != lastframe)
 						{
-							for (Int32 j = 0; j < (Int32)geotexanimheader.count; j++)
-							{
-								if (texHeader.geotex != null)
-								{
-									GeoTexAnim.MultiTexAnimService(geotexanimheader, texHeader, i, num2);
-								}
-							}
-							geotexanimheader.lastframe = num2;
+							//for (Int32 j = 0; j < geotexanimheader.count; j++)
+							texHeader.MultiTexAnimService(i, frameShort);
+							geotexanimheader.lastframe = frameShort;
 						}
-						Int16 rate = geotexanimheader.rate;
-						num += (Int32)rate;
+						frameLong += geotexanimheader.rate;
 					}
 					else
 					{
-						num += 4096;
+						frameLong += 4096;
 					}
-					if (num >> 12 < (Int32)geotexanimheader.numframes)
+					if (frameLong >> 12 < geotexanimheader.numframes)
 					{
-						geotexanimheader.frame = num;
+						geotexanimheader.frame = frameLong;
 					}
 					else if (geotexanimheader.randrange > 0)
 					{
-						UInt32 num3 = (UInt32)UnityEngine.Random.Range((Int32)geotexanimheader.randmin, (Int32)(geotexanimheader.randrange + 1));
-						geotexanimheader.frame = (Int32)(-(Int32)((UInt64)((UInt64)num3 << 12)));
+						geotexanimheader.frame = -(geoTexAnimRandom(geotexanimheader.randmin, geotexanimheader.randrange) << 12);
 					}
 					else if ((geotexanimheader.flags & 2) != 0)
 					{
-						Byte b = 3;
-						GEOTEXANIMHEADER geotexanimheader2 = geotexanimheader;
-						geotexanimheader2.flags = (Byte)(geotexanimheader2.flags & (Byte)(~b));
+						geotexanimheader.flags &= unchecked((Byte)~3);
 					}
 					else
 					{
@@ -414,52 +228,14 @@ public class GeoTexAnim : HonoBehavior
 		}
 	}
 
-	private static void MultiTexAnimService(GEOTEXANIMHEADER texAnimHeader, GEOTEXHEADER texHeader, Int32 i, Int16 framenum)
-	{
-		RenderTexture active = RenderTexture.active;
-		RenderTexture.active = texHeader.RenderTexMapping[texHeader._mainTextureIndexs[i]];
-		GL.PushMatrix();
-		GL.LoadPixelMatrix(0f, texHeader.RenderTexWidth, texHeader.RenderTexHeight, 0f);
-		Graphics.DrawTexture(new Rect(0f, 0f, texHeader.RenderTexWidth, texHeader.RenderTexHeight), texHeader.TextureMapping[texHeader._mainTextureIndexs[i]], GEOTEXANIMHEADER.texAnimMat);
-		Graphics.DrawTexture(texAnimHeader.targetuv, texHeader.TextureMapping[texHeader._subTextureIndexs[i]], texAnimHeader.rectuvs[(Int32)framenum], 0, 0, 0, 0);
-		GL.PopMatrix();
-		RenderTexture.active = active;
-	}
-
-	public static void RecreateMultiTexAnim(GEOTEXANIMHEADER texAnimHeader, GEOTEXHEADER texHeader, Int32 i)
-	{
-		RenderTexture active = RenderTexture.active;
-		RenderTexture.active = texHeader.RenderTexMapping[texHeader._mainTextureIndexs[i]];
-		GL.PushMatrix();
-		GL.Clear(true, true, Color.clear);
-		GL.LoadPixelMatrix(0f, texHeader.RenderTexWidth, texHeader.RenderTexHeight, 0f);
-		Graphics.DrawTexture(new Rect(0f, 0f, texHeader.RenderTexWidth, texHeader.RenderTexHeight), texHeader.TextureMapping[texHeader._mainTextureIndexs[i]]);
-		GL.PopMatrix();
-		RenderTexture.active = active;
-	}
-
 	public static void addTexAnim(GameObject go, String geoName)
 	{
 		GeoTexAnim geoTexAnim = go.AddComponent<GeoTexAnim>();
-		Int32 scale = ModelFactory.HaveUpScaleModel(geoName) ? 4 : 1;
 		Boolean garnetShortHair = FF9StateSystem.EventState.ScenarioCounter >= 10300;
 		if (geoName.Equals("GEO_MAIN_F0_GRN") && garnetShortHair)
 			geoName = "GEO_MAIN_F1_GRN";
-		GeoTexAnim.SetTexAnimIndex(geoName, out Int32 mainTextureIndex, out Int32 subTextureIndex);
-		geoTexAnim.Load("Models/GeoTexAnim/" + geoName, mainTextureIndex, subTextureIndex, scale);
-	}
-
-	public static void SetTexAnimIndex(String geoName, out Int32 mainTextureIndex, out Int32 subTextureIndex)
-	{
-		mainTextureIndex = 0;
-		subTextureIndex = 0;
-		String csvAsset = AssetManager.LoadString($"EmbeddedAsset/GeoTexAnimIndex/{geoName}.csv", true);
-		if (csvAsset == null)
-			return;
-		String[] entries = csvAsset.Split('\n');
-        String[] firstEntry = entries[1].Split(',');
-		mainTextureIndex = Int32.Parse(firstEntry[0]);
-		subTextureIndex = Int32.Parse(firstEntry[1]);
+		GeoTexAnim.SetTexAnimIndexs(geoName, out Int32[] mainTextureIndex, out Int32[] subTextureIndex);
+		geoTexAnim.Load("Models/GeoTexAnim/" + geoName, mainTextureIndex, subTextureIndex);
 	}
 
 	public static void SetTexAnimIndexs(String geoName, out Int32[] mainTextureIndexs, out Int32[] subTextureIndexs)
@@ -470,9 +246,9 @@ public class GeoTexAnim : HonoBehavior
 			mainTextureIndexs = null;
 			subTextureIndexs = null;
 			return;
-        }
-        String[] entries = csvAsset.Split('\n');
-        Int32 cnt = entries.Length;
+		}
+		String[] entries = csvAsset.Split('\n');
+		Int32 cnt = entries.Length;
 		mainTextureIndexs = new Int32[cnt - 1];
 		subTextureIndexs = new Int32[cnt - 1];
 		for (Int32 i = 1; i < cnt; i++)
@@ -483,56 +259,9 @@ public class GeoTexAnim : HonoBehavior
 		}
 	}
 
-	public static void MapTextureToTexAnimIndex(Int32 texAnimIndex, Texture texture, Dictionary<Int32, Texture> textureMapping)
-	{
-		if (!textureMapping.ContainsKey(texAnimIndex))
-		{
-			textureMapping.Add(texAnimIndex, texture);
-		}
-	}
+	public GEOTEXHEADER TextureAnim;
 
-	public static void MapRenderTexToTexAnimIndex(Int32 texAnimIndex, Single textureWidth, Single textureHeight, SkinnedMeshRenderer skinnedMeshRenderer, Texture mainTexture, Dictionary<Int32, RenderTexture> renderTexMapping)
-	{
-		if (!renderTexMapping.ContainsKey(texAnimIndex))
-		{
-			RenderTexture renderTexture = new RenderTexture((Int32)textureWidth, (Int32)textureHeight, 24);
-			renderTexture.filterMode = FilterMode.Bilinear;
-			renderTexture.wrapMode = TextureWrapMode.Repeat;
-			renderTexture.name = skinnedMeshRenderer.transform.parent.name + "_" + skinnedMeshRenderer.name + "_RT";
-			skinnedMeshRenderer.material.mainTexture = renderTexture;
-			renderTexMapping.Add(texAnimIndex, renderTexture);
-			RenderTexture active = RenderTexture.active;
-			RenderTexture.active = renderTexture;
-			GL.PushMatrix();
-			GL.Clear(true, true, Color.clear);
-			GL.LoadPixelMatrix(0f, textureWidth, textureHeight, 0f);
-			Graphics.DrawTexture(new Rect(0f, 0f, textureWidth, textureHeight), mainTexture);
-			GL.PopMatrix();
-			RenderTexture.active = active;
-		}
-	}
-
-	public Int32 Count;
-
-	public GEOTEXANIMHEADER[] Anims;
-
-	public RenderTexture RenderTex;
-
-	public Single RenderTexWidth;
-
-	public Single RenderTexHeight;
-
+	private Boolean _renderTexuresCreated;
 	private Boolean _isLoaded;
-
 	private Int32 _cFrameCounter;
-
-	private SkinnedMeshRenderer[] _smrs;
-
-	private Int32 _mainTextureIndex;
-
-	private Int32 _subTextureIndex;
-
-	private Texture _mainTexture;
-
-	private Texture _subTexture;
 }

--- a/Assembly-CSharp/Global/Geo/GeoTexAnim.cs
+++ b/Assembly-CSharp/Global/Geo/GeoTexAnim.cs
@@ -453,60 +453,33 @@ public class GeoTexAnim : HonoBehavior
 	{
 		mainTextureIndex = 0;
 		subTextureIndex = 0;
-		String textAsset = AssetManager.LoadString("EmbeddedAsset/GeoTexAnimIndex/" + geoName + ".csv");
-		if (textAsset == null)
+		String csvAsset = AssetManager.LoadString($"EmbeddedAsset/GeoTexAnimIndex/{geoName}.csv", true);
+		if (csvAsset == null)
 			return;
-		String[] array = textAsset.Split(new Char[]
-		{
-			'\n'
-		});
-		Int32 num = (Int32)array.Length;
-		Int32[,] array2 = new Int32[num - 1, num - 1];
-		for (Int32 i = 1; i < num; i++)
-		{
-			String[] array3 = array[i].Split(new Char[]
-			{
-				','
-			});
-			String s = array3[0];
-			String s2 = array3[1];
-			Int32 num2 = Int32.Parse(s);
-			Int32 num3 = Int32.Parse(s2);
-			array2[i - 1, 0] = num2;
-			array2[i - 1, 1] = num3;
-		}
-		mainTextureIndex = array2[0, 0];
-		subTextureIndex = array2[0, 1];
+		String[] entries = csvAsset.Split('\n');
+        String[] firstEntry = entries[1].Split(',');
+		mainTextureIndex = Int32.Parse(firstEntry[0]);
+		subTextureIndex = Int32.Parse(firstEntry[1]);
 	}
 
 	public static void SetTexAnimIndexs(String geoName, out Int32[] mainTextureIndexs, out Int32[] subTextureIndexs)
 	{
-		String textAsset = AssetManager.LoadString("EmbeddedAsset/GeoTexAnimIndex/" + geoName + ".csv");
-		if (textAsset == null)
+		String csvAsset = AssetManager.LoadString($"EmbeddedAsset/GeoTexAnimIndex/{geoName}.csv", true);
+		if (csvAsset == null)
 		{
 			mainTextureIndexs = null;
 			subTextureIndexs = null;
 			return;
-		}
-		String[] array = textAsset.Split(new Char[]
+        }
+        String[] entries = csvAsset.Split('\n');
+        Int32 cnt = entries.Length;
+		mainTextureIndexs = new Int32[cnt - 1];
+		subTextureIndexs = new Int32[cnt - 1];
+		for (Int32 i = 1; i < cnt; i++)
 		{
-			'\n'
-		});
-		Int32 num = (Int32)array.Length;
-		mainTextureIndexs = new Int32[num - 1];
-		subTextureIndexs = new Int32[num - 1];
-		for (Int32 i = 1; i < num; i++)
-		{
-			String[] array2 = array[i].Split(new Char[]
-			{
-				','
-			});
-			String s = array2[0];
-			String s2 = array2[1];
-			Int32 num2 = Int32.Parse(s);
-			Int32 num3 = Int32.Parse(s2);
-			mainTextureIndexs[i - 1] = num2;
-			subTextureIndexs[i - 1] = num3;
+			String[] entry = entries[i].Split(',');
+			mainTextureIndexs[i - 1] = Int32.Parse(entry[0]);
+			subTextureIndexs[i - 1] = Int32.Parse(entry[1]);
 		}
 	}
 

--- a/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
+++ b/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
@@ -734,6 +734,7 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
         UpdateAttachModel();
         UIManager.Battle.modelButtonManager.UpdateModelButtonPosition();
         Singleton<HUDMessage>.Instance.UpdateChildPosition();
+        btl_eqp.ProcessBuiltInWeapon();
     }
 
     public Int32 GetWeaponID(Int32 battlePlayerPosID)

--- a/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
+++ b/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
@@ -570,7 +570,7 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
         }
         catch (Exception err)
         {
-            Memoria.Prime.Log.Error(err);
+            Log.Error(err);
         }
     }
 

--- a/Assembly-CSharp/Global/Model/ModelFactory.cs
+++ b/Assembly-CSharp/Global/Model/ModelFactory.cs
@@ -79,6 +79,7 @@ public static class ModelFactory
                 String textureFileName = geoId + "_" + textureId;
                 String texturePath = "Models/2/" + geoId + "/" + textureFileName;
                 Texture texture = AssetManager.Load<Texture>(texturePath, false);
+                texture.name = name;
                 renderer.material.SetTexture("_MainTex", texture);
                 checkTextureOnDisc = false;
             }
@@ -98,7 +99,11 @@ public static class ModelFactory
             {
                 String externalPath = AssetManager.SearchAssetOnDisc(texturePath.Replace("%", renderer.material.mainTexture.name), true, false);
                 if (!String.IsNullOrEmpty(externalPath))
-                    renderer.material.mainTexture = AssetManager.LoadFromDisc<Texture2D>(externalPath, "");
+                {
+                    Texture texture = AssetManager.LoadFromDisc<Texture2D>(externalPath, "");
+                    texture.name = renderer.material.mainTexture.name;
+                    renderer.material.mainTexture = texture;
+                }
             }
         }
         Shader shader;

--- a/Assembly-CSharp/Global/Model/ModelFactory.cs
+++ b/Assembly-CSharp/Global/Model/ModelFactory.cs
@@ -165,14 +165,6 @@ public static class ModelFactory
                 for (Int32 i = 0; i < renderers.Length; i++)
                     renderers[i].enabled = false;
             }
-            // TODO: Handle weapons that are parts of models
-            //Int32 weaponBoneID;
-            //if (removableWeaponBoneTable.TryGetValue(text, out weaponBoneID))
-            //{
-            //	Transform weaponBone = gameObject.transform.GetChildByName($"bone{weaponBoneID:D3}");
-            //	if (weaponBone != null)
-            //		UnityEngine.Object.Destroy(weaponBone);
-            //}
         }
         else
         {
@@ -1674,12 +1666,6 @@ public static class ModelFactory
 			"GEO_MON_B3_155",
 			16
 		}
-	};
-
-	private static Dictionary<String, Int32> removableWeaponBoneTable = new Dictionary<String, Int32>
-	{
-		{ "GEO_SUB_F0_FLT", 21 }, // Fratley
-		{ "GEO_MON_B3_122", 31 }  // Lani
 	};
 
 	public static List<String> garnetShortHairTable = new List<String>

--- a/Assembly-CSharp/Global/PillarBoxOverrideManager.cs
+++ b/Assembly-CSharp/Global/PillarBoxOverrideManager.cs
@@ -4,59 +4,47 @@ using UnityEngine.UI;
 
 public class PillarBoxOverrideManager : MonoBehaviour
 {
-	private void Start()
-	{
-		this.topRect = base.gameObject.FindChild("Top").GetComponent<RectTransform>();
-		this.bottomRect = base.gameObject.FindChild("Bottom").GetComponent<RectTransform>();
-		this.leftRect = base.gameObject.FindChild("Left").GetComponent<RectTransform>();
-		this.rightRect = base.gameObject.FindChild("Right").GetComponent<RectTransform>();
-		this.leftImage = base.gameObject.FindChild("Left").GetComponent<Image>();
-		this.rightImage = base.gameObject.FindChild("Right").GetChild(0).GetComponent<Image>();
-		this.UpdatePillarSize();
-	}
+    private void Start()
+    {
+        this.topRect = base.gameObject.FindChild("Top").GetComponent<RectTransform>();
+        this.bottomRect = base.gameObject.FindChild("Bottom").GetComponent<RectTransform>();
+        this.leftRect = base.gameObject.FindChild("Left").GetComponent<RectTransform>();
+        this.rightRect = base.gameObject.FindChild("Right").GetComponent<RectTransform>();
+        this.leftImage = base.gameObject.FindChild("Left").GetComponent<Image>();
+        this.rightImage = base.gameObject.FindChild("Right").GetChild(0).GetComponent<Image>();
+        if (AssetManager.HasAssetOnDisc("embeddedasset/ui/sprites/overlay canvas/letterbox_verticle", true, false))
+        {
+            // TODO: for now, the existence of a custom texture replaces the pillars by black bars, without loading the texture itself
+            this.leftImage.gameObject.active = false;
+            this.rightImage.gameObject.active = false;
+        }
+        this.UpdatePillarSize();
+    }
 
-	public void Restart()
-	{
-		this.UpdatePillarSize();
-	}
+    public void Restart()
+    {
+        this.UpdatePillarSize();
+    }
 
-	private void LateUpdate()
-	{
-	}
+    private void LateUpdate()
+    {
+    }
 
-	private void UpdatePillarSize()
-	{
-		this.topRect.sizeDelta = new Vector2(0f, Mathf.Max(UIManager.UIPillarBoxSize.y, 1f));
-		this.bottomRect.sizeDelta = new Vector2(0f, Mathf.Max(UIManager.UIPillarBoxSize.y, 1f));
-		this.leftRect.sizeDelta = new Vector2(Mathf.Max(UIManager.UIPillarBoxSize.x, 1f), 0f);
-		this.rightRect.sizeDelta = new Vector2(Mathf.Max(UIManager.UIPillarBoxSize.x, 1f), 0f);
-		if (this.leftRect.sizeDelta.x <= 1f)
-		{
-			this.leftImage.color = Color.black;
-		}
-		else
-		{
-			this.leftImage.color = Color.white;
-		}
-		if (this.rightRect.sizeDelta.x <= 1f)
-		{
-			this.rightImage.color = Color.black;
-		}
-		else
-		{
-			this.rightImage.color = Color.white;
-		}
-	}
+    private void UpdatePillarSize()
+    {
+        this.topRect.sizeDelta = new Vector2(0f, Mathf.Max(UIManager.UIPillarBoxSize.y, 1f));
+        this.bottomRect.sizeDelta = new Vector2(0f, Mathf.Max(UIManager.UIPillarBoxSize.y, 1f));
+        this.leftRect.sizeDelta = new Vector2(Mathf.Max(UIManager.UIPillarBoxSize.x, 1f), 0f);
+        this.rightRect.sizeDelta = new Vector2(Mathf.Max(UIManager.UIPillarBoxSize.x, 1f), 0f);
+        this.leftImage.color = this.leftRect.sizeDelta.x <= 1f ? Color.black : Color.white;
+        this.rightImage.color = this.rightRect.sizeDelta.x <= 1f ? Color.black : Color.white;
+    }
 
-	private RectTransform topRect;
+    private RectTransform topRect;
+    private RectTransform bottomRect;
+    private RectTransform leftRect;
+    private RectTransform rightRect;
 
-	private RectTransform bottomRect;
-
-	private RectTransform leftRect;
-
-	private RectTransform rightRect;
-
-	private Image leftImage;
-
-	private Image rightImage;
+    private Image leftImage;
+    private Image rightImage;
 }

--- a/Assembly-CSharp/Global/SFX/SFX.cs
+++ b/Assembly-CSharp/Global/SFX/SFX.cs
@@ -2070,7 +2070,8 @@ public static class SFX
 
     public static Int32 GetEffectJTexUsed()
     {
-        return SFX.SFX_SendIntData(12, 0, 0, 0);
+        SmoothFrameUpdater_Battle.LastSFXEffectJTex = SFX.SFX_SendIntData(12, 0, 0, 0);
+        return SmoothFrameUpdater_Battle.LastSFXEffectJTex;
     }
 
     public static void SoundClear()

--- a/Assembly-CSharp/Global/SPS/SPSEffect.cs
+++ b/Assembly-CSharp/Global/SPS/SPSEffect.cs
@@ -524,14 +524,6 @@ public class SPSEffect : MonoBehaviour
     private Boolean tcbAreaComputed;
     private Rect tcbArea;
 
-    public Boolean _smoothUpdateRegistered = false;
-    public Vector3 _smoothUpdatePosPrevious;
-    public Vector3 _smoothUpdatePosActual;
-    public Quaternion _smoothUpdateRotPrevious;
-    public Quaternion _smoothUpdateRotActual;
-    public Int32 _smoothUpdateScalePrevious;
-    public Int32 _smoothUpdateScaleActual;
-
     public class FieldSPSWork
     {
         public Int32 pt;

--- a/Assembly-CSharp/Global/SPS/WorldSPSSystem.cs
+++ b/Assembly-CSharp/Global/SPS/WorldSPSSystem.cs
@@ -269,11 +269,11 @@ public class WorldSPSSystem : MonoBehaviour
     }
 
     public Int32 EffectRegist(Single x, Single y, Single z, SPSConst.WorldSPSEffect no, Int32 size)
-	{
+    {
         Int32 slot = this._FindFreeEffectSlot();
         SPSEffect sps = Utility.SpsList[slot];
         if (!Utility.SetupSPSBinary(sps, new KeyValuePair<String, Int32>("WorldMap", (Int32)no), false))
-			return -1;
+            return -1;
         switch (no)
         {
             case SPSConst.WorldSPSEffect.SMOKE_SOUTH_GATE:
@@ -287,15 +287,16 @@ public class WorldSPSSystem : MonoBehaviour
                 sps.abr = SPSConst.ABR_ADD;
                 break;
         }
+        sps.attr |= SPSConst.ATTR_UPDATE_ANY_FRAME;
         if (no != SPSConst.WorldSPSEffect.MEMORIA)
             sps.attr |= SPSConst.ATTR_UNLOAD_ON_FINISH;
         sps.pos.x = x;
-		sps.pos.y = y;
-		sps.pos.z = z;
+        sps.pos.y = y;
+        sps.pos.z = z;
         sps.rot = Vector3.zero;
-		sps.scale = size;
-		sps.prm0 = 0;
-		sps.meshRenderer.enabled = true;
+        sps.scale = size;
+        sps.prm0 = 0;
+        sps.meshRenderer.enabled = true;
         if (no == SPSConst.WorldSPSEffect.SMOKE_SOUTH_GATE)
             sps.frameRate = 4;
         else if (no == SPSConst.WorldSPSEffect.SMOKE_FIRE_SHRINE)
@@ -303,76 +304,76 @@ public class WorldSPSSystem : MonoBehaviour
         else if (no == SPSConst.WorldSPSEffect.MEMORIA)
             sps.frameRate = 0;
         return slot;
-	}
+    }
 
     public void ShiftRight()
     {
         foreach (SPSEffect sps in Utility.SpsList)
         {
             if (sps.spsId != -1)
-			{
-				Vector3 position = sps.transform.position;
-				position.x += 64f;
-				if (position.x >= 1536f)
-					position.x -= 1536f;
-				sps.pos = position;
-				sps.transform.position = position;
-			}
-		}
-	}
+            {
+                Vector3 position = sps.transform.position;
+                position.x += 64f;
+                if (position.x >= 1536f)
+                    position.x -= 1536f;
+                sps.pos = position;
+                sps.transform.position = position;
+            }
+        }
+    }
 
-	public void ShiftLeft()
+    public void ShiftLeft()
     {
         foreach (SPSEffect sps in Utility.SpsList)
         {
             if (sps.spsId != -1)
-			{
-				Vector3 position = sps.transform.position;
-				position.x -= 64f;
-				if (position.x < 0f)
-					position.x += 1536f;
-				sps.pos = position;
-				sps.transform.position = position;
-			}
-		}
-	}
+            {
+                Vector3 position = sps.transform.position;
+                position.x -= 64f;
+                if (position.x < 0f)
+                    position.x += 1536f;
+                sps.pos = position;
+                sps.transform.position = position;
+            }
+        }
+    }
 
-	public void ShiftDown()
+    public void ShiftDown()
     {
         foreach (SPSEffect sps in Utility.SpsList)
         {
             if (sps.spsId != -1)
-			{
-				Vector3 position = sps.transform.position;
-				position.z -= 64f;
-				if (position.z <= -1280f)
-					position.z += 1280f;
-				sps.pos = position;
-				sps.transform.position = position;
-			}
-		}
-	}
+            {
+                Vector3 position = sps.transform.position;
+                position.z -= 64f;
+                if (position.z <= -1280f)
+                    position.z += 1280f;
+                sps.pos = position;
+                sps.transform.position = position;
+            }
+        }
+    }
 
-	public void ShiftUp()
-	{
-		foreach (SPSEffect sps in Utility.SpsList)
-		{
-			if (sps.spsId != -1)
-			{
-				Vector3 position = sps.transform.position;
-				position.z += 64f;
-				if (position.z > 0f)
-					position.z -= 1280f;
-				sps.pos = position;
-				sps.transform.position = position;
-			}
-		}
-	}
+    public void ShiftUp()
+    {
+        foreach (SPSEffect sps in Utility.SpsList)
+        {
+            if (sps.spsId != -1)
+            {
+                Vector3 position = sps.transform.position;
+                position.z += 64f;
+                if (position.z > 0f)
+                    position.z -= 1280f;
+                sps.pos = position;
+                sps.transform.position = position;
+            }
+        }
+    }
 
-	public void EffectRelease(SPSEffect sps)
-	{
+    public void EffectRelease(SPSEffect sps)
+    {
         sps.Unload();
-		sps.spsId = -1;
+        sps.spsId = -1;
     }
 
     public void SetObjParm(Int32 ObjNo, Int32 ParmType, Int32 Arg0, Int32 Arg1, Int32 Arg2)
@@ -400,19 +401,19 @@ public class WorldSPSSystem : MonoBehaviour
     }
 
     private Boolean _IsSlotAvailable(Int32 index)
-	{
-		return Utility.SpsList[index].spsId == -1;
-	}
+    {
+        return Utility.SpsList[index].spsId == -1;
+    }
 
-	private Int32 _FindFreeEffectSlot()
-	{
-		for (Int32 i = 0; i < Utility.SpsList.Count; i++)
-			if (this._IsSlotAvailable(i))
-				return i;
+    private Int32 _FindFreeEffectSlot()
+    {
+        for (Int32 i = 0; i < Utility.SpsList.Count; i++)
+            if (this._IsSlotAvailable(i))
+                return i;
         Int32 slot = Utility.SpsList.Count;
         this.InitSPSInstance(slot);
         return slot;
-	}
+    }
 
     [NonSerialized]
     private CommonSPSSystem Utility;

--- a/Assembly-CSharp/Global/WM/WMRenderTextureBank.cs
+++ b/Assembly-CSharp/Global/WM/WMRenderTextureBank.cs
@@ -12,73 +12,58 @@ public class WMRenderTextureBank : Singleton<WMRenderTextureBank>
 	private void Initialize()
 	{
 		if (this.initialized)
-		{
 			return;
-		}
+		WMBlock.LoadMaterialsFromDisc();
 		this.VolcanoCrater1 = AssetManager.Load<RenderTexture>("WorldMap/RenderTextures/VolcanoCrater1", false);
-		this.VolcanoCrater1Material = AssetManager.Load<Material>("WorldMap/Materials/0_4_0_128_mat", false);
+		if (!WMBlock.MaterialDatabase.TryGetValue("VolcanoCrater1", out this.VolcanoCrater1Material))
+			this.VolcanoCrater1Material = AssetManager.Load<Material>("WorldMap/Materials/0_4_0_128_mat", false);
 		this.VolcanoCrater1Texture = (Texture2D)this.VolcanoCrater1Material.mainTexture;
 		this.VolcanoLava1 = AssetManager.Load<RenderTexture>("WorldMap/RenderTextures/VolcanoLava1", false);
-		this.VolcanoLava1Material = AssetManager.Load<Material>("WorldMap/Materials/0_4_0_192_mat", false);
+		if (!WMBlock.MaterialDatabase.TryGetValue("VolcanoLava1", out this.VolcanoLava1Material))
+			this.VolcanoLava1Material = AssetManager.Load<Material>("WorldMap/Materials/0_4_0_192_mat", false);
 		this.VolcanoLava1Texture = (Texture2D)this.VolcanoLava1Material.mainTexture;
 		this.VolcanoCrater2 = AssetManager.Load<RenderTexture>("WorldMap/RenderTextures/VolcanoCrater2", false);
-		this.VolcanoCrater2Material = AssetManager.Load<Material>("WorldMap/Materials/1_4_0_128_mat", false);
+		if (!WMBlock.MaterialDatabase.TryGetValue("VolcanoCrater2", out this.VolcanoCrater2Material))
+			this.VolcanoCrater2Material = AssetManager.Load<Material>("WorldMap/Materials/1_4_0_128_mat", false);
 		this.VolcanoCrater2Texture = (Texture2D)this.VolcanoCrater2Material.mainTexture;
 		this.VolcanoLava2 = AssetManager.Load<RenderTexture>("WorldMap/RenderTextures/VolcanoLava2", false);
-		this.VolcanoLava2Material = AssetManager.Load<Material>("WorldMap/Materials/1_4_0_192_mat", false);
+		if (!WMBlock.MaterialDatabase.TryGetValue("VolcanoLava2", out this.VolcanoLava2Material))
+			this.VolcanoLava2Material = AssetManager.Load<Material>("WorldMap/Materials/1_4_0_192_mat", false);
 		this.VolcanoLava2Texture = (Texture2D)this.VolcanoLava2Material.mainTexture;
 		this.Beach1Material = AssetManager.Load<Material>("WorldMap/Materials/Beach1", false);
 		for (Int32 i = 0; i < 4; i++)
-		{
 			this.Beach1Textures[i] = AssetManager.Load<Texture2D>("WorldMap/Textures/11_0_128_" + i, false);
-		}
 		this.Beach2Material = AssetManager.Load<Material>("WorldMap/Materials/Beach2", false);
-		for (Int32 j = 0; j < 4; j++)
-		{
-			this.Beach2Textures[j] = AssetManager.Load<Texture2D>("WorldMap/Textures/11_128_128_" + j, false);
-		}
+		for (Int32 i = 0; i < 4; i++)
+			this.Beach2Textures[i] = AssetManager.Load<Texture2D>("WorldMap/Textures/11_128_128_" + i, false);
 		this.RiverMaterial = AssetManager.Load<Material>("WorldMap/Materials/River", false);
-		for (Int32 k = 0; k < 6; k++)
-		{
-			this.RiverTextures[k] = AssetManager.Load<Texture2D>("WorldMap/Textures/11_128_0_" + k, false);
-		}
+		for (Int32 i = 0; i < 6; i++)
+			this.RiverTextures[i] = AssetManager.Load<Texture2D>("WorldMap/Textures/11_128_0_" + i, false);
 		this.RiverJointMaterial = AssetManager.Load<Material>("WorldMap/Materials/RiverJoint", false);
-		for (Int32 l = 0; l < 6; l++)
-		{
-			this.RiverJointTextures[l] = AssetManager.Load<Texture2D>("WorldMap/Textures/10_0_128_" + l, false);
-		}
+		for (Int32 i = 0; i < 6; i++)
+			this.RiverJointTextures[i] = AssetManager.Load<Texture2D>("WorldMap/Textures/10_0_128_" + i, false);
 		this.Sea_10_64_0Material = AssetManager.Load<Material>("WorldMap/Materials/Sea1", false);
-		for (Int32 m = 0; m < 6; m++)
-		{
-			this.Sea_10_64_0Textures[m] = AssetManager.Load<Texture2D>("WorldMap/Textures/10_64_0_" + m, false);
-		}
+		for (Int32 i = 0; i < 6; i++)
+			this.Sea_10_64_0Textures[i] = AssetManager.Load<Texture2D>("WorldMap/Textures/10_64_0_" + i, false);
 		this.Sea_10_128_0Material = AssetManager.Load<Material>("WorldMap/Materials/Sea2", false);
-		for (Int32 n = 0; n < 6; n++)
-		{
-			this.Sea_10_128_0Textures[n] = AssetManager.Load<Texture2D>("WorldMap/Textures/10_128_0_" + n, false);
-		}
+		for (Int32 i = 0; i < 6; i++)
+			this.Sea_10_128_0Textures[i] = AssetManager.Load<Texture2D>("WorldMap/Textures/10_128_0_" + i, false);
 		this.Sea_10_128_64Material = AssetManager.Load<Material>("WorldMap/Materials/Sea3", false);
-		for (Int32 num = 0; num < 6; num++)
-		{
-			this.Sea_10_128_64Textures[num] = AssetManager.Load<Texture2D>("WorldMap/Textures/10_128_64_" + num, false);
-		}
+		for (Int32 i = 0; i < 6; i++)
+			this.Sea_10_128_64Textures[i] = AssetManager.Load<Texture2D>("WorldMap/Textures/10_128_64_" + i, false);
 		this.Sea_10_128_128Material = AssetManager.Load<Material>("WorldMap/Materials/Sea4", false);
-		for (Int32 num2 = 0; num2 < 6; num2++)
-		{
-			this.Sea_10_128_128Textures[num2] = AssetManager.Load<Texture2D>("WorldMap/Textures/10_128_128_" + num2, false);
-		}
+		for (Int32 i = 0; i < 6; i++)
+			this.Sea_10_128_128Textures[i] = AssetManager.Load<Texture2D>("WorldMap/Textures/10_128_128_" + i, false);
 		this.Sea_11_64_0Material = AssetManager.Load<Material>("WorldMap/Materials/Sea5", false);
-		for (Int32 num3 = 0; num3 < 6; num3++)
-		{
-			this.Sea_11_64_0Textures[num3] = AssetManager.Load<Texture2D>("WorldMap/Textures/11_64_0_" + num3, false);
-		}
+		for (Int32 i = 0; i < 6; i++)
+			this.Sea_11_64_0Textures[i] = AssetManager.Load<Texture2D>("WorldMap/Textures/11_64_0_" + i, false);
 		this.Sea_11_192_64Material = AssetManager.Load<Material>("WorldMap/Materials/Sea6", false);
-		for (Int32 num4 = 0; num4 < 4; num4++)
-		{
-			this.Sea_11_192_64Textures[num4] = AssetManager.Load<Texture2D>("WorldMap/Textures/11_192_64_" + num4, false);
-		}
-		this.Falls = AssetManager.Load<Material>("WorldMap/Materials/Falls", false);
-		this.Stream = AssetManager.Load<Material>("WorldMap/Materials/Stream", false);
+		for (Int32 i = 0; i < 4; i++)
+			this.Sea_11_192_64Textures[i] = AssetManager.Load<Texture2D>("WorldMap/Textures/11_192_64_" + i, false);
+		if (!WMBlock.MaterialDatabase.TryGetValue("Falls", out this.Falls))
+			this.Falls = AssetManager.Load<Material>("WorldMap/Materials/Falls", false);
+		if (!WMBlock.MaterialDatabase.TryGetValue("Stream", out this.Stream))
+			this.Stream = AssetManager.Load<Material>("WorldMap/Materials/Stream", false);
 		this.initialized = true;
 	}
 

--- a/Assembly-CSharp/Global/WM/WMWorld/WMWorld.cs
+++ b/Assembly-CSharp/Global/WM/WMWorld/WMWorld.cs
@@ -53,7 +53,8 @@ public class WMWorld : Singleton<WMWorld>
 	}
 
 	public void Initialize()
-	{
+    {
+		WMBlock.LoadMaterialsFromDisc();
 		if (FF9StateSystem.World.IsBeeScene)
 		{
 			GameObject gameObject = GameObject.Find("WorldMapRoot");
@@ -366,7 +367,7 @@ public class WMWorld : Singleton<WMWorld>
 		Int32 peak = 0;
 		for (Int32 i = 0; i < this.WorldSPSSystem.SpsList.Count; i++)
 		{
-            SPSEffect worldSPS = this.WorldSPSSystem.SpsList[i];
+			SPSEffect worldSPS = this.WorldSPSSystem.SpsList[i];
 			if (worldSPS.spsBin != null && worldSPS.spsId != -1)
 				peak++;
 		}
@@ -493,433 +494,243 @@ public class WMWorld : Singleton<WMWorld>
 		}
 	}
 
-	private void LoadBlock(GameObject blockObjectPrefab, WMBlock block)
-	{
-		WMBlockPrefab component = blockObjectPrefab.GetComponent<WMBlockPrefab>();
-		block.Form1WalkMeshes = new List<WMMesh>();
-		block.Form2WalkMeshes = new List<WMMesh>();
-		block.Form1Transforms = new List<Transform>();
-		if (component.ObjectForm1)
-		{
-			Transform transform = UnityEngine.Object.Instantiate<Transform>(component.ObjectForm1);
-			transform.name = component.ObjectForm1.name;
-			transform.parent = block.transform;
-			transform.localPosition = Vector3.zero;
-			transform.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh = transform.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm1(sharedMesh);
-			block.AddForm1Transform(transform);
-		}
-		if (component.TerrainForm1)
-		{
-			Transform transform2 = UnityEngine.Object.Instantiate<Transform>(component.TerrainForm1);
-			transform2.name = component.TerrainForm1.name;
-			transform2.parent = block.transform;
-			transform2.localPosition = Vector3.zero;
-			transform2.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh2 = transform2.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm1(sharedMesh2);
-			block.AddForm1Transform(transform2);
-		}
-		if (component.ObjectForm2)
-		{
-			Transform transform3 = UnityEngine.Object.Instantiate<Transform>(component.ObjectForm2);
-			transform3.name = component.ObjectForm2.name;
-			transform3.parent = block.transform;
-			transform3.localPosition = Vector3.zero;
-			transform3.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh3 = transform3.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm2(sharedMesh3);
-			block.AddForm2Transform(transform3);
-		}
-		if (component.TerrainForm2)
-		{
-			Transform transform4 = UnityEngine.Object.Instantiate<Transform>(component.TerrainForm2);
-			transform4.name = component.TerrainForm2.name;
-			transform4.parent = block.transform;
-			transform4.localPosition = Vector3.zero;
-			transform4.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh4 = transform4.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm2(sharedMesh4);
-			block.AddForm2Transform(transform4);
-		}
-		if (block.Number == 219)
-		{
-			if (component.Sea3)
-			{
-				Transform transform5 = UnityEngine.Object.Instantiate<Transform>(component.Sea3);
-				transform5.name = component.Sea3.name;
-				transform5.parent = block.transform;
-				transform5.localPosition = Vector3.zero;
-				transform5.localScale = new Vector3(1f, 1f, 1f);
-				Mesh sharedMesh5 = transform5.GetComponent<MeshFilter>().sharedMesh;
-				block.AddWalkMeshForm1(sharedMesh5);
-				block.AddForm1Transform(transform5);
-				block.HasSea = true;
-			}
-			if (component.Sea4)
-			{
-				Transform transform6 = UnityEngine.Object.Instantiate<Transform>(component.Sea4);
-				transform6.name = component.Sea4.name;
-				transform6.parent = block.transform;
-				transform6.localPosition = Vector3.zero;
-				transform6.localScale = new Vector3(1f, 1f, 1f);
-				Mesh sharedMesh6 = transform6.GetComponent<MeshFilter>().sharedMesh;
-				block.AddWalkMeshForm1(sharedMesh6);
-				block.AddForm1Transform(transform6);
-				block.HasSea = true;
-			}
-			if (component.Sea5)
-			{
-				Transform transform7 = UnityEngine.Object.Instantiate<Transform>(component.Sea5);
-				transform7.name = component.Sea5.name;
-				transform7.parent = block.transform;
-				transform7.localPosition = Vector3.zero;
-				transform7.localScale = new Vector3(1f, 1f, 1f);
-				Mesh sharedMesh7 = transform7.GetComponent<MeshFilter>().sharedMesh;
-				block.AddWalkMeshForm1(sharedMesh7);
-				block.AddForm1Transform(transform7);
-				block.HasSea = true;
-			}
-			if (component.Sea3_2)
-			{
-				Transform transform8 = UnityEngine.Object.Instantiate<Transform>(component.Sea3_2);
-				transform8.name = component.Sea3_2.name;
-				transform8.parent = block.transform;
-				transform8.localPosition = Vector3.zero;
-				transform8.localScale = new Vector3(1f, 1f, 1f);
-				Mesh sharedMesh8 = transform8.GetComponent<MeshFilter>().sharedMesh;
-				block.AddWalkMeshForm2(sharedMesh8);
-				block.AddForm2Transform(transform8);
-			}
-			if (component.Sea4_2)
-			{
-				Transform transform9 = UnityEngine.Object.Instantiate<Transform>(component.Sea4_2);
-				transform9.name = component.Sea4_2.name;
-				transform9.parent = block.transform;
-				transform9.localPosition = Vector3.zero;
-				transform9.localScale = new Vector3(1f, 1f, 1f);
-				Mesh sharedMesh9 = transform9.GetComponent<MeshFilter>().sharedMesh;
-				block.AddWalkMeshForm2(sharedMesh9);
-				block.AddForm2Transform(transform9);
-			}
-			if (component.Sea5_2)
-			{
-				Transform transform10 = UnityEngine.Object.Instantiate<Transform>(component.Sea5_2);
-				transform10.name = component.Sea5_2.name;
-				transform10.parent = block.transform;
-				transform10.localPosition = Vector3.zero;
-				transform10.localScale = new Vector3(1f, 1f, 1f);
-				Mesh sharedMesh10 = transform10.GetComponent<MeshFilter>().sharedMesh;
-				block.AddWalkMeshForm2(sharedMesh10);
-				block.AddForm2Transform(transform10);
-			}
-			GameObject gameObject = AssetManager.Load<GameObject>("WorldMap/Prefabs/Effects/WaterShrine", false);
-			if (gameObject)
-			{
-				GameObject gameObject2 = UnityEngine.Object.Instantiate<GameObject>(gameObject);
-				gameObject2.transform.parent = block.transform;
-				gameObject2.transform.localPosition = new Vector3(32.11f, -2.46f, -31.69f);
-				block.AddForm2Transform(gameObject2.transform);
-			}
-			block.ApplyForm();
-			return;
-		}
-		if (component.Beach1)
-		{
-			Transform transform11 = UnityEngine.Object.Instantiate<Transform>(component.Beach1);
-			transform11.name = component.Beach1.name;
-			transform11.parent = block.transform;
-			transform11.localPosition = Vector3.zero;
-			transform11.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh11 = transform11.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm1(sharedMesh11);
-			block.AddWalkMeshForm2(sharedMesh11);
-			block.AddForm1Transform(transform11);
-			block.AddForm2Transform(transform11);
-			block.HasBeach1 = true;
-		}
-		if (component.Beach2)
-		{
-			Transform transform12 = UnityEngine.Object.Instantiate<Transform>(component.Beach2);
-			transform12.name = component.Beach2.name;
-			transform12.parent = block.transform;
-			transform12.localPosition = Vector3.zero;
-			transform12.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh12 = transform12.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm1(sharedMesh12);
-			block.AddWalkMeshForm2(sharedMesh12);
-			block.AddForm1Transform(transform12);
-			block.AddForm2Transform(transform12);
-			block.HasBeach2 = true;
-		}
-		if (component.Stream)
-		{
-			Transform transform13 = UnityEngine.Object.Instantiate<Transform>(component.Stream);
-			transform13.name = component.Stream.name;
-			transform13.parent = block.transform;
-			transform13.localPosition = Vector3.zero;
-			transform13.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh13 = transform13.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm1(sharedMesh13);
-			block.AddWalkMeshForm2(sharedMesh13);
-			block.AddForm1Transform(transform13);
-			block.AddForm2Transform(transform13);
-			block.HasStream = true;
-		}
-		if (component.River)
-		{
-			Transform transform14 = UnityEngine.Object.Instantiate<Transform>(component.River);
-			transform14.name = component.River.name;
-			transform14.parent = block.transform;
-			transform14.localPosition = Vector3.zero;
-			transform14.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh14 = transform14.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm1(sharedMesh14);
-			block.AddWalkMeshForm2(sharedMesh14);
-			block.AddForm1Transform(transform14);
-			block.AddForm2Transform(transform14);
-			block.HasRiver = true;
-		}
-		if (component.RiverJoint)
-		{
-			Transform transform15 = UnityEngine.Object.Instantiate<Transform>(component.RiverJoint);
-			transform15.name = component.RiverJoint.name;
-			transform15.parent = block.transform;
-			transform15.localPosition = Vector3.zero;
-			transform15.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh15 = transform15.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm1(sharedMesh15);
-			block.AddWalkMeshForm2(sharedMesh15);
-			block.AddForm1Transform(transform15);
-			block.AddForm2Transform(transform15);
-			block.HasRiverJoint = true;
-		}
-		if (component.Falls)
-		{
-			Transform transform16 = UnityEngine.Object.Instantiate<Transform>(component.Falls);
-			transform16.name = component.Falls.name;
-			transform16.parent = block.transform;
-			transform16.localPosition = Vector3.zero;
-			transform16.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh16 = transform16.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm1(sharedMesh16);
-			block.AddWalkMeshForm2(sharedMesh16);
-			block.AddForm1Transform(transform16);
-			block.AddForm2Transform(transform16);
-			block.HasFalls = true;
-		}
-		if (component.Sea1)
-		{
-			Transform transform17 = UnityEngine.Object.Instantiate<Transform>(component.Sea1);
-			transform17.name = component.Sea1.name;
-			transform17.parent = block.transform;
-			transform17.localPosition = Vector3.zero;
-			transform17.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh17 = transform17.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm1(sharedMesh17);
-			block.AddWalkMeshForm2(sharedMesh17);
-			block.AddForm1Transform(transform17);
-			block.AddForm2Transform(transform17);
-			block.HasSea = true;
-		}
-		if (component.Sea2)
-		{
-			Transform transform18 = UnityEngine.Object.Instantiate<Transform>(component.Sea2);
-			transform18.name = component.Sea2.name;
-			transform18.parent = block.transform;
-			transform18.localPosition = Vector3.zero;
-			transform18.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh18 = transform18.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm1(sharedMesh18);
-			block.AddWalkMeshForm2(sharedMesh18);
-			block.AddForm1Transform(transform18);
-			block.AddForm2Transform(transform18);
-			block.HasSea = true;
-		}
-		if (component.Sea3)
-		{
-			Transform transform19 = UnityEngine.Object.Instantiate<Transform>(component.Sea3);
-			transform19.name = component.Sea3.name;
-			transform19.parent = block.transform;
-			transform19.localPosition = Vector3.zero;
-			transform19.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh19 = transform19.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm1(sharedMesh19);
-			block.AddWalkMeshForm2(sharedMesh19);
-			block.AddForm1Transform(transform19);
-			block.AddForm2Transform(transform19);
-			block.HasSea = true;
-		}
-		if (component.Sea4)
-		{
-			Transform transform20 = UnityEngine.Object.Instantiate<Transform>(component.Sea4);
-			transform20.name = component.Sea4.name;
-			transform20.parent = block.transform;
-			transform20.localPosition = Vector3.zero;
-			transform20.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh20 = transform20.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm1(sharedMesh20);
-			block.AddWalkMeshForm2(sharedMesh20);
-			block.AddForm1Transform(transform20);
-			block.AddForm2Transform(transform20);
-			block.HasSea = true;
-		}
-		if (component.Sea5)
-		{
-			Transform transform21 = UnityEngine.Object.Instantiate<Transform>(component.Sea5);
-			transform21.name = component.Sea5.name;
-			transform21.parent = block.transform;
-			transform21.localPosition = Vector3.zero;
-			transform21.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh21 = transform21.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm1(sharedMesh21);
-			block.AddWalkMeshForm2(sharedMesh21);
-			block.AddForm1Transform(transform21);
-			block.AddForm2Transform(transform21);
-			block.HasSea = true;
-		}
-		if (component.Sea6)
-		{
-			Transform transform22 = UnityEngine.Object.Instantiate<Transform>(component.Sea6);
-			transform22.name = component.Sea6.name;
-			transform22.parent = block.transform;
-			transform22.localPosition = Vector3.zero;
-			transform22.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh22 = transform22.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm1(sharedMesh22);
-			block.AddWalkMeshForm2(sharedMesh22);
-			block.AddForm1Transform(transform22);
-			block.AddForm2Transform(transform22);
-			block.HasSea = true;
-		}
-		if (component.VolcanoCrater1)
-		{
-			Transform transform23 = UnityEngine.Object.Instantiate<Transform>(component.VolcanoCrater1);
-			transform23.name = component.VolcanoCrater1.name;
-			transform23.parent = block.transform;
-			transform23.localPosition = Vector3.zero;
-			transform23.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh23 = transform23.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm1(sharedMesh23);
-			block.AddForm1Transform(transform23);
-			block.HasVolcanoCrater = true;
-		}
-		if (component.VolcanoLava1)
-		{
-			Transform transform24 = UnityEngine.Object.Instantiate<Transform>(component.VolcanoLava1);
-			transform24.name = component.VolcanoLava1.name;
-			transform24.parent = block.transform;
-			transform24.localPosition = Vector3.zero;
-			transform24.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh24 = transform24.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm1(sharedMesh24);
-			block.AddForm1Transform(transform24);
-			block.HasVolcanoLava = true;
-		}
-		if (component.VolcanoCrater2)
-		{
-			Transform transform25 = UnityEngine.Object.Instantiate<Transform>(component.VolcanoCrater2);
-			transform25.name = component.VolcanoCrater2.name;
-			transform25.parent = block.transform;
-			transform25.localPosition = Vector3.zero;
-			transform25.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh25 = transform25.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm2(sharedMesh25);
-			block.AddForm2Transform(transform25);
-			block.HasVolcanoCrater = true;
-		}
-		if (component.VolcanoLava2)
-		{
-			Transform transform26 = UnityEngine.Object.Instantiate<Transform>(component.VolcanoLava2);
-			transform26.name = component.VolcanoLava2.name;
-			transform26.parent = block.transform;
-			transform26.localPosition = Vector3.zero;
-			transform26.localScale = new Vector3(1f, 1f, 1f);
-			Mesh sharedMesh26 = transform26.GetComponent<MeshFilter>().sharedMesh;
-			block.AddWalkMeshForm2(sharedMesh26);
-			block.AddForm2Transform(transform26);
-			block.HasVolcanoLava = true;
-		}
-		if (block.Number == 91)
-		{
-			GameObject gameObject3 = AssetManager.Load<GameObject>("WorldMap/Prefabs/Effects/Quicksand", false);
-			if (gameObject3)
-			{
-				GameObject gameObject4 = UnityEngine.Object.Instantiate<GameObject>(gameObject3);
-				gameObject4.transform.parent = block.transform;
-				gameObject4.transform.localPosition = new Vector3(8f, 1.66f, -60f);
-			}
-		}
-		if (block.Number == 115)
-		{
-			GameObject gameObject5 = AssetManager.Load<GameObject>("WorldMap/Prefabs/Effects/Quicksand", false);
-			if (gameObject5)
-			{
-				GameObject gameObject6 = UnityEngine.Object.Instantiate<GameObject>(gameObject5);
-				gameObject6.transform.parent = block.transform;
-				gameObject6.transform.localPosition = new Vector3(23.68f, 1.18f, -23.98f);
-				gameObject6 = UnityEngine.Object.Instantiate<GameObject>(gameObject5);
-				gameObject6.transform.parent = block.transform;
-				gameObject6.transform.localPosition = new Vector3(4f, 1.18f, -16f);
-				gameObject6 = UnityEngine.Object.Instantiate<GameObject>(gameObject5);
-				gameObject6.transform.parent = block.transform;
-				gameObject6.transform.localPosition = new Vector3(28f, 1.18f, -4f);
-			}
-		}
-		if (block.Number == 158 && ff9.w_frameDisc == 4)
-		{
-			GameObject gameObject7 = AssetManager.Load<GameObject>("EmbeddedAsset/WorldMap_Local/Prefabs/Block[14][6] Object", false);
-			if (gameObject7)
-			{
-				Transform transform27 = block.transform.Find("Object");
-				if (transform27)
-					transform27.GetComponent<Renderer>().enabled = false;
-				GameObject gameObject8 = UnityEngine.Object.Instantiate<GameObject>(gameObject7);
-				gameObject8.transform.parent = block.transform;
-				gameObject8.transform.localPosition = new Vector3(0f, 0f, 0f);
-			}
-			gameObject7 = AssetManager.Load<GameObject>("EmbeddedAsset/WorldMap_Local/Prefabs/Block[14][6] Object_tree", false);
-			if (gameObject7)
-			{
-				GameObject gameObject9 = UnityEngine.Object.Instantiate<GameObject>(gameObject7);
-				gameObject9.transform.parent = block.transform;
-				gameObject9.transform.localPosition = new Vector3(0f, 0f, 0f);
-			}
-		}
-		if (block.Number == 219)
-		{
-		}
-		if (block.Number == 31)
-		{
-		}
-		if (block.Number == 115)
-		{
-		}
-		if (block.Number == 283)
-		{
-		}
-		if (block.Number == 219)
-		{
-		}
-		if (block.Number == 397)
-		{
-		}
-		if (block.Number == 389)
-		{
-			GameObject gameObject10 = AssetManager.Load<GameObject>("EmbeddedAsset/WorldMap_Local/Prefabs/Block[5][16] Object", false);
-			if (gameObject10)
-			{
-				Transform transform28 = block.transform.Find("Object");
-				if (transform28)
-					transform28.GetComponent<Renderer>().enabled = false;
-				GameObject gameObject11 = UnityEngine.Object.Instantiate<GameObject>(gameObject10);
-				gameObject11.transform.parent = block.transform;
-				gameObject11.transform.localPosition = new Vector3(0f, 0f, 0f);
-			}
-		}
-		block.ApplyForm();
-	}
+    private void LoadBlock(GameObject blockObjectPrefab, WMBlock block)
+    {
+        WMBlockPrefab prefab = blockObjectPrefab.GetComponent<WMBlockPrefab>();
+        block.Form1WalkMeshes = new List<WMMesh>();
+        block.Form2WalkMeshes = new List<WMMesh>();
+        block.Form1Transforms = new List<Transform>();
+        if (prefab.ObjectForm1)
+            RegisterBlockComponent(block, prefab.ObjectForm1, true, false);
+        if (prefab.TerrainForm1)
+            RegisterBlockComponent(block, prefab.TerrainForm1, true, false);
+        if (prefab.ObjectForm2)
+            RegisterBlockComponent(block, prefab.ObjectForm2, false, true);
+        if (prefab.TerrainForm2)
+            RegisterBlockComponent(block, prefab.TerrainForm2, false, true);
+        if (block.Number == 219)
+        {
+            if (prefab.Sea3)
+            {
+                RegisterBlockComponent(block, prefab.Sea3, true, false);
+                block.HasSea = true;
+            }
+            if (prefab.Sea4)
+            {
+                RegisterBlockComponent(block, prefab.Sea4, true, false);
+                block.HasSea = true;
+            }
+            if (prefab.Sea5)
+            {
+                RegisterBlockComponent(block, prefab.Sea5, true, false);
+                block.HasSea = true;
+            }
+            if (prefab.Sea3_2)
+                RegisterBlockComponent(block, prefab.Sea3_2, false, true);
+            if (prefab.Sea4_2)
+                RegisterBlockComponent(block, prefab.Sea4_2, false, true);
+            if (prefab.Sea5_2)
+                RegisterBlockComponent(block, prefab.Sea5_2, false, true);
+            GameObject waterShrineGo = AssetManager.Load<GameObject>("WorldMap/Prefabs/Effects/WaterShrine", false);
+            if (waterShrineGo)
+            {
+                GameObject waterShrineCopy = UnityEngine.Object.Instantiate<GameObject>(waterShrineGo);
+                waterShrineCopy.transform.name = waterShrineGo.transform.name;
+                waterShrineCopy.transform.parent = block.transform;
+                waterShrineCopy.transform.localPosition = new Vector3(32.11f, -2.46f, -31.69f);
+                block.AddForm2Transform(waterShrineCopy.transform);
+            }
+            block.SetupPreloadedMaterials();
+            block.ApplyForm();
+            return;
+        }
+        if (prefab.Beach1)
+        {
+            RegisterBlockComponent(block, prefab.Beach1, true, true);
+            block.HasBeach1 = true;
+        }
+        if (prefab.Beach2)
+        {
+            RegisterBlockComponent(block, prefab.Beach2, true, true);
+            block.HasBeach2 = true;
+        }
+        if (prefab.Stream)
+        {
+            RegisterBlockComponent(block, prefab.Stream, true, true);
+            block.HasStream = true;
+        }
+        if (prefab.River)
+        {
+            RegisterBlockComponent(block, prefab.River, true, true);
+            block.HasRiver = true;
+        }
+        if (prefab.RiverJoint)
+        {
+            RegisterBlockComponent(block, prefab.RiverJoint, true, true);
+            block.HasRiverJoint = true;
+        }
+        if (prefab.Falls)
+        {
+            RegisterBlockComponent(block, prefab.Falls, true, true);
+            block.HasFalls = true;
+        }
+        if (prefab.Sea1)
+        {
+            RegisterBlockComponent(block, prefab.Sea1, true, true);
+            block.HasSea = true;
+        }
+        if (prefab.Sea2)
+        {
+            RegisterBlockComponent(block, prefab.Sea2, true, true);
+            block.HasSea = true;
+        }
+        if (prefab.Sea3)
+        {
+            RegisterBlockComponent(block, prefab.Sea3, true, true);
+            block.HasSea = true;
+        }
+        if (prefab.Sea4)
+        {
+            RegisterBlockComponent(block, prefab.Sea4, true, true);
+            block.HasSea = true;
+        }
+        if (prefab.Sea5)
+        {
+            RegisterBlockComponent(block, prefab.Sea5, true, true);
+            block.HasSea = true;
+        }
+        if (prefab.Sea6)
+        {
+            RegisterBlockComponent(block, prefab.Sea6, true, true);
+            block.HasSea = true;
+        }
+        if (prefab.VolcanoCrater1)
+        {
+            RegisterBlockComponent(block, prefab.VolcanoCrater1, true, false);
+            block.HasVolcanoCrater = true;
+        }
+        if (prefab.VolcanoLava1)
+        {
+            RegisterBlockComponent(block, prefab.VolcanoLava1, true, false);
+            block.HasVolcanoLava = true;
+        }
+        if (prefab.VolcanoCrater2)
+        {
+            RegisterBlockComponent(block, prefab.VolcanoCrater2, false, true);
+            block.HasVolcanoCrater = true;
+        }
+        if (prefab.VolcanoLava2)
+        {
+            RegisterBlockComponent(block, prefab.VolcanoLava2, false, true);
+            block.HasVolcanoLava = true;
+        }
+        if (block.Number == 91)
+        {
+            GameObject quicksandGo = AssetManager.Load<GameObject>("WorldMap/Prefabs/Effects/Quicksand", false);
+            if (quicksandGo)
+            {
+                GameObject quicksandCopy = UnityEngine.Object.Instantiate<GameObject>(quicksandGo);
+                quicksandCopy.transform.name = quicksandGo.transform.name;
+                quicksandCopy.transform.parent = block.transform;
+                quicksandCopy.transform.localPosition = new Vector3(8f, 1.66f, -60f);
+            }
+        }
+        if (block.Number == 115)
+        {
+            GameObject quicksandGo = AssetManager.Load<GameObject>("WorldMap/Prefabs/Effects/Quicksand", false);
+            if (quicksandGo)
+            {
+                GameObject quicksandCopy = UnityEngine.Object.Instantiate<GameObject>(quicksandGo);
+                quicksandCopy.transform.name = quicksandGo.transform.name;
+                quicksandCopy.transform.parent = block.transform;
+                quicksandCopy.transform.localPosition = new Vector3(23.68f, 1.18f, -23.98f);
+                quicksandCopy = UnityEngine.Object.Instantiate<GameObject>(quicksandGo);
+                quicksandCopy.transform.name = quicksandGo.transform.name;
+                quicksandCopy.transform.parent = block.transform;
+                quicksandCopy.transform.localPosition = new Vector3(4f, 1.18f, -16f);
+                quicksandCopy = UnityEngine.Object.Instantiate<GameObject>(quicksandGo);
+                quicksandCopy.transform.name = quicksandGo.transform.name;
+                quicksandCopy.transform.parent = block.transform;
+                quicksandCopy.transform.localPosition = new Vector3(28f, 1.18f, -4f);
+            }
+        }
+        if (block.Number == 158 && ff9.w_frameDisc == 4)
+        {
+            GameObject block146Go = AssetManager.Load<GameObject>("EmbeddedAsset/WorldMap_Local/Prefabs/Block[14][6] Object", false);
+            if (block146Go)
+            {
+                Transform obj = block.transform.Find("Object");
+                if (obj)
+                    obj.GetComponent<Renderer>().enabled = false;
+                GameObject block146Copy = UnityEngine.Object.Instantiate<GameObject>(block146Go);
+                block146Copy.transform.name = block146Go.transform.name;
+                block146Copy.transform.parent = block.transform;
+                block146Copy.transform.localPosition = new Vector3(0f, 0f, 0f);
+            }
+            block146Go = AssetManager.Load<GameObject>("EmbeddedAsset/WorldMap_Local/Prefabs/Block[14][6] Object_tree", false);
+            if (block146Go)
+            {
+                GameObject block146Copy = UnityEngine.Object.Instantiate<GameObject>(block146Go);
+                block146Copy.transform.name = block146Go.transform.name;
+                block146Copy.transform.parent = block.transform;
+                block146Copy.transform.localPosition = new Vector3(0f, 0f, 0f);
+            }
+        }
+        if (block.Number == 219)
+        {
+        }
+        if (block.Number == 31)
+        {
+        }
+        if (block.Number == 115)
+        {
+        }
+        if (block.Number == 283)
+        {
+        }
+        if (block.Number == 219)
+        {
+        }
+        if (block.Number == 397)
+        {
+        }
+        if (block.Number == 389)
+        {
+            GameObject block516Go = AssetManager.Load<GameObject>("EmbeddedAsset/WorldMap_Local/Prefabs/Block[5][16] Object", false);
+            if (block516Go)
+            {
+                Transform obj = block.transform.Find("Object");
+                if (obj)
+                    obj.GetComponent<Renderer>().enabled = false;
+                GameObject block516Copy = UnityEngine.Object.Instantiate<GameObject>(block516Go);
+                block516Copy.transform.name = block516Go.transform.name;
+                block516Copy.transform.parent = block.transform;
+                block516Copy.transform.localPosition = new Vector3(0f, 0f, 0f);
+            }
+        }
+        block.SetupPreloadedMaterials();
+        block.ApplyForm();
+    }
+
+    private void RegisterBlockComponent(WMBlock block, Transform transform, Boolean form1, Boolean form2)
+    {
+        Transform copy = UnityEngine.Object.Instantiate<Transform>(transform);
+        copy.name = transform.name;
+        copy.parent = block.transform;
+        copy.localPosition = Vector3.zero;
+        copy.localScale = new Vector3(1f, 1f, 1f);
+        Mesh mesh = copy.GetComponent<MeshFilter>().sharedMesh;
+        if (form1)
+        {
+            block.AddWalkMeshForm1(mesh);
+            block.AddForm1Transform(copy);
+        }
+        if (form2)
+        {
+            block.AddWalkMeshForm2(mesh);
+            block.AddForm2Transform(copy);
+        }
+    }
 
 	private IEnumerator LoadBlockAsync(Int32 disc, WMBlock block)
 	{
@@ -2043,14 +1854,16 @@ public class WMWorld : Singleton<WMWorld>
 
 	public void LoadQuicksandMaterial()
 	{
-		this.QuicksandMaterial = AssetManager.Load<Material>("WorldMap/Materials/quicksand_mat", false);
-		Texture2D texture = AssetManager.Load<Texture2D>("EmbeddedAsset/WorldMap_Local/Textures/SeamlessRock", false);
-		this.QuicksandMaterial.SetTexture("_DetailTex", texture);
+		if (!WMBlock.MaterialDatabase.TryGetValue("Quicksand", out this.QuicksandMaterial))
+			this.QuicksandMaterial = AssetManager.Load<Material>("WorldMap/Materials/quicksand_mat", false);
+		Texture2D detailTexture = AssetManager.Load<Texture2D>("EmbeddedAsset/WorldMap_Local/Textures/SeamlessRock", false);
+		this.QuicksandMaterial.SetTexture("_DetailTex", detailTexture);
 	}
 
 	public void LoadWaterShrineMaterial()
 	{
-		this.WaterShrineMaterial = AssetManager.Load<Material>("WorldMap/Materials/WaterShrine_mat", false);
+		if (!WMBlock.MaterialDatabase.TryGetValue("WaterShrine", out this.WaterShrineMaterial))
+			this.WaterShrineMaterial = AssetManager.Load<Material>("WorldMap/Materials/WaterShrine_mat", false);
 	}
 
 	public void CreateProjectionMatrix()

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Public.cs
@@ -236,11 +236,13 @@ public partial class BattleHUD : UIScene
                 }
                 libraMessage += "\n";
             }
+            btl_eqp.ProcessBuiltInWeapon();
             Camera camera = Camera.main ? Camera.main : GameObject.Find("Battle Camera").GetComponent<BattleMapCameraController>().GetComponent<Camera>();
             RenderTexture photoRender = RenderTexture.GetTemporary(Screen.width, Screen.height);
             Vector2 photoSize = new Vector2(Math.Min(Screen.width, 400f), Math.Min(Screen.height, 600f));
             btl2d.GetIconPosition(pBtl.Data, out Byte[] iconBone, out _, out _);
             Vector3 btlPos = pBtl.Data.gameObject.transform.GetChildByName($"bone{iconBone[3]:D3}").position + 50f * Vector3.down;
+            Matrix4x4 cameraOldMatrix = camera.worldToCameraMatrix;
             camera.ResetWorldToCameraMatrix();
             camera.transform.position = btlPos - 1500f * pBtl.Data.gameObject.transform.forward + 500f * Vector3.up;
             camera.transform.LookAt(btlPos);
@@ -249,7 +251,10 @@ public partial class BattleHUD : UIScene
             camera.targetTexture = photoRender;
             camera.Render();
             camera.targetTexture = null;
-            SFXDataCamera.UpdateCamera();
+            camera.nearClipPlane = SFX.fxNearZ;
+            camera.farClipPlane = SFX.fxFarZ;
+            camera.worldToCameraMatrix = cameraOldMatrix;
+            camera.projectionMatrix = PsxCamera.PsxProj2UnityProj(SFX.fxNearZ, SFX.fxFarZ);
             RenderTexture.active = photoRender;
             Texture2D photo = new Texture2D((Int32)photoSize.x, (Int32)photoSize.y, TextureFormat.ARGB32, false);
             photo.ReadPixels(new Rect((Screen.width - (Int32)photoSize.x) / 2, (Screen.height - (Int32)photoSize.y) / 2, photoRender.width, photoRender.height), 0, 0);

--- a/Assembly-CSharp/Global/battle/BattlePlayerCharacter.cs
+++ b/Assembly-CSharp/Global/battle/BattlePlayerCharacter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Collections.Generic;
 using UnityEngine;
 using Memoria.Data;
@@ -78,16 +79,28 @@ public class BattlePlayerCharacter : MonoBehaviour
 		btl.originalGo = gameObject;
 	}
 
-	private static void CreateTranceModel(BTL_DATA btl, CharacterSerialNumber serial)
-	{
-		String path = btl_mot.BattleParameterList[serial].TranceModelId;
-		btl.tranceGo = ModelFactory.CreateModel(path, true);
-		BattlePlayerCharacter.CheckToHideBattleModel(btl.tranceGo, serial);
-		btl.tranceGo.transform.localPosition = new Vector3(btl.tranceGo.transform.localPosition.x, -10000f, btl.tranceGo.transform.localPosition.z);
-		btl.tranceGo.SetActive(false);
-	}
+    private static void CreateTranceModel(BTL_DATA btl, CharacterSerialNumber serial)
+    {
+        String path = btl_mot.BattleParameterList[serial].TranceModelId;
+        btl.tranceGo = ModelFactory.CreateModel(path, true);
+        BattlePlayerCharacter.CheckToHideBattleModel(btl.tranceGo, serial);
+        btl.tranceGo.transform.localPosition = new Vector3(btl.tranceGo.transform.localPosition.x, -10000f, btl.tranceGo.transform.localPosition.z);
+        // Set custom trance texture, if they exist
+        String tranceTexturePath = Path.GetDirectoryName(ModelFactory.GetRenameModelPath(ModelFactory.CheckUpscale(path))) + "/%_trance.png";
+        foreach (Renderer renderer in btl.tranceGo.GetComponentsInChildren<Renderer>())
+        {
+            String externalPath = AssetManager.SearchAssetOnDisc(tranceTexturePath.Replace("%", renderer.material.mainTexture.name), true, false);
+            if (!String.IsNullOrEmpty(externalPath))
+            {
+                Texture texture = AssetManager.LoadFromDisc<Texture2D>(externalPath, "");
+                texture.name = renderer.material.mainTexture.name;
+                renderer.material.mainTexture = texture;
+            }
+        }
+        btl.tranceGo.SetActive(false);
+    }
 
-	private static void CheckToHideBattleModel(GameObject characterGo, CharacterSerialNumber serial)
+    private static void CheckToHideBattleModel(GameObject characterGo, CharacterSerialNumber serial)
 	{
 		if (serial == CharacterSerialNumber.ZIDANE_SWORD)
 		{

--- a/Assembly-CSharp/Global/battle/BattleTexAnimWatcher.cs
+++ b/Assembly-CSharp/Global/battle/BattleTexAnimWatcher.cs
@@ -13,30 +13,17 @@ public class BattleTexAnimWatcher : MonoBehaviour
 		{
 			if (!Status.checkCurStat(next, BattleStatus.Jump))
 			{
-				this.CheckRenderTexture(next.texanimptr);
-				this.CheckRenderTexture(next.tranceTexanimptr);
+				this.CheckRenderTextures(next.texanimptr);
+				this.CheckRenderTextures(next.tranceTexanimptr);
 			}
 		}
 	}
 
-	public void CheckRenderTexture(GEOTEXHEADER texHeader)
+	public void CheckRenderTextures(GEOTEXHEADER texHeader)
 	{
 		if (texHeader == null)
-		{
 			return;
-		}
-		for (Int32 i = 0; i < (Int32)texHeader.count; i++)
-		{
-			RenderTexture renderTexture = texHeader.RenderTexMapping[texHeader._mainTextureIndexs[i]];
-			if (!renderTexture.IsCreated())
-			{
-				if (texHeader.geotex != null)
-				{
-					GEOTEXANIMHEADER texAnimHeader = texHeader.geotex[i];
-					base.StartCoroutine(this.WaitForRecreateRenderTexture(texAnimHeader, texHeader, i));
-				}
-			}
-		}
+        texHeader.CheckRenderTextures(this);
 	}
 
 	public static void ForcedNonCullingMesh(GameObject go)
@@ -61,25 +48,5 @@ public class BattleTexAnimWatcher : MonoBehaviour
 			MeshFilter meshFilter = array2[j];
 			meshFilter.sharedMesh.bounds = new Bounds(center, Vector3.one * Single.MaxValue * 0.01f);
 		}
-	}
-
-	private void SetDefaultTextures(GEOTEXHEADER texHeader, Int32 i)
-	{
-		texHeader._smrs[texHeader._mainTextureIndexs[i]].material.mainTexture = texHeader.TextureMapping[texHeader._mainTextureIndexs[i]];
-		texHeader._smrs[texHeader._subTextureIndexs[i]].material.mainTexture = texHeader.TextureMapping[texHeader._subTextureIndexs[i]];
-	}
-
-	private void SetBackRenderTexture(GEOTEXHEADER texHeader, Int32 i)
-	{
-		texHeader._smrs[texHeader._mainTextureIndexs[i]].material.mainTexture = texHeader.RenderTexMapping[texHeader._mainTextureIndexs[i]];
-	}
-
-	private IEnumerator WaitForRecreateRenderTexture(GEOTEXANIMHEADER texAnimHeader, GEOTEXHEADER texHeader, Int32 i)
-	{
-		this.SetDefaultTextures(texHeader, i);
-		yield return new WaitForEndOfFrame();
-		this.SetBackRenderTexture(texHeader, i);
-		GeoTexAnim.RecreateMultiTexAnim(texAnimHeader, texHeader, i);
-		yield break;
 	}
 }

--- a/Assembly-CSharp/Global/battlebg.cs
+++ b/Assembly-CSharp/Global/battlebg.cs
@@ -43,7 +43,7 @@ public class battlebg
 			}
 		}
 		FF9StateSystem.Battle.FF9Battle.map.btlBGObjAnim = battlebg.objAnimModel;
-		battlebg.nf_BbgTabAddress.InitTextureAnim();
+		battlebg.nf_BbgTabAddress.InitBBGTextureAnim();
 		if (battlebg.nf_BbgTexAnm != 0)
 		{
 			for (Int32 j = 0; j < battlebg.nf_BbgTexAnm; j++)
@@ -383,14 +383,11 @@ public class battlebg
 	{
 		if (tab.geotex[anum].numframes == 0)
 		{
-			tab.TexAnimTextures[anum].wrapMode = TextureWrapMode.Repeat;
-			if (battlebg.nf_BbgNumber == 57)
-			{
-				tab.extraTexAnimTrTextures[anum].wrapMode = TextureWrapMode.Repeat;
-			}
+			tab.materials[anum].mainTexture.wrapMode = TextureWrapMode.Repeat;
+			if (battlebg.nf_BbgNumber == 57) // Cleyra, Observation post
+				tab.bbgExtraAimMaterials[anum].mainTexture.wrapMode = TextureWrapMode.Repeat;
 		}
-		GEOTEXANIMHEADER geotexanimheader = tab.geotex[anum];
-		geotexanimheader.flags = (Byte)(geotexanimheader.flags | 1);
+		tab.geotex[anum].flags |= 1;
 		tab.geotex[anum].frame = 0;
 		tab.geotex[anum].lastframe = 4096;
 	}
@@ -413,15 +410,15 @@ public class battlebg
 					{
 						if (geotexanimheader.numframes <= 0)
 						{
-							goto IL_2C3;
+							continue;
 						}
 						if (num2 != lastframe)
 						{
 							for (Int32 j = 0; j < (Int32)geotexanimheader.count; j++)
 							{
-								Single x = (geotexanimheader.coords[(Int32)num2].x - geotexanimheader.target.x) / (Single)texheaderptr.TexAnimTextures[j].width;
-								Single num3 = (geotexanimheader.coords[(Int32)num2].y - geotexanimheader.target.y) / (Single)texheaderptr.TexAnimTextures[j].height;
-								texheaderptr.texAnimMaterials[i].SetTextureOffset("_MainTex", new Vector2(x, -num3));
+								Single x = (geotexanimheader.coords[num2].x - geotexanimheader.target.x) / texheaderptr.materials[j].mainTexture.width;
+								Single num3 = (geotexanimheader.coords[num2].y - geotexanimheader.target.y) / texheaderptr.materials[j].mainTexture.height;
+								texheaderptr.materials[i].SetTextureOffset("_MainTex", new Vector2(x, -num3));
 							}
 							geotexanimheader.lastframe = num2;
 						}
@@ -459,27 +456,20 @@ public class battlebg
 					for (Int32 k = 0; k < (Int32)geotexanimheader.count; k++)
 					{
 						Int32 num5 = 0;
-						Int32 height = texheaderptr.TexAnimTextures[k].height;
+						Int32 height = texheaderptr.materials[k].mainTexture.height;
 						Single num6 = (Single)num2 / (Single)height;
-						if (battlebg.nf_BbgNumber == 69 && i == 3)
-						{
+						if (battlebg.nf_BbgNumber == 69 && i == 3) // 
 							num6 *= -1f;
-						}
-						texheaderptr.texAnimMaterials[i].SetTextureOffset("_MainTex", new Vector2((Single)num5, -num6));
+						texheaderptr.materials[i].SetTextureOffset("_MainTex", new Vector2(num5, -num6));
 						if (battlebg.nf_BbgNumber == 57)
-						{
-							texheaderptr.extraTexAimMaterials[i].SetTextureOffset("_MainTex", new Vector2((Single)num5, -num6));
-						}
+							texheaderptr.bbgExtraAimMaterials[i].SetTextureOffset("_MainTex", new Vector2(num5, -num6));
 						else if (battlebg.nf_BbgNumber == 71 && k == 0)
-						{
-							texheaderptr.extraTexAimMaterials[i].SetTextureOffset("_MainTex", new Vector2((Single)num5, -num6));
-						}
+							texheaderptr.bbgExtraAimMaterials[i].SetTextureOffset("_MainTex", new Vector2(num5, -num6));
 					}
 					Int16 rate = geotexanimheader.rate;
 					geotexanimheader.frame += (Int32)rate;
 				}
 			}
-			IL_2C3:;
 		}
 	}
 
@@ -490,12 +480,12 @@ public class battlebg
 
 	public static Int32 rand()
 	{
-		return UnityEngine.Random.Range(0, 32767);
+		return UnityEngine.Random.Range(0, 0x7FFF);
 	}
 
 	public static Int32 nf_GetBbgIntensity()
 	{
-		return (Int32)battlebg.nf_BbgBrite;
+		return battlebg.nf_BbgBrite;
 	}
 
 	public static void nf_SetBbgIntensity(Byte fade)
@@ -505,23 +495,18 @@ public class battlebg
 
 	private static void setBGColor(GameObject go)
 	{
-		Single num = (Single)battlebg.nf_BbgBrite;
-		MeshRenderer[] componentsInChildren = go.GetComponentsInChildren<MeshRenderer>();
-		for (Int32 i = 0; i < (Int32)componentsInChildren.Length; i++)
+		Single intensity = battlebg.nf_BbgBrite;
+		foreach (MeshRenderer renderer in go.GetComponentsInChildren<MeshRenderer>())
 		{
-			if (num == 0f)
+			if (intensity == 0f)
 			{
-				componentsInChildren[i].enabled = false;
+				renderer.enabled = false;
 			}
 			else
 			{
-				componentsInChildren[i].enabled = true;
-				Material[] materials = componentsInChildren[i].materials;
-				for (Int32 j = 0; j < (Int32)materials.Length; j++)
-				{
-					Material material = materials[j];
-					material.SetFloat("_Intensity", num);
-				}
+				renderer.enabled = true;
+				foreach (Material mat in renderer.materials)
+					mat.SetFloat("_Intensity", intensity);
 			}
 		}
 	}

--- a/Assembly-CSharp/Global/btl2d.cs
+++ b/Assembly-CSharp/Global/btl2d.cs
@@ -310,7 +310,7 @@ public static class btl2d
         workSet.OldDisappear = oldDisappear;
     }
 
-    private static void Btl2dStatIcon()
+    public static void Btl2dStatIcon()
     {
         BTL2D_WORK btl2d_work_set = FF9StateSystem.Battle.FF9Battle.btl2d_work_set;
         for (BTL_DATA btl = FF9StateSystem.Battle.FF9Battle.btl_list.next; btl != null; btl = btl.next)
@@ -346,7 +346,7 @@ public static class btl2d
         }
     }
 
-    private static void Btl2dStatCount()
+    public static void Btl2dStatCount()
     {
         btl2d.STAT_CNT_TBL[] statusTableList = new btl2d.STAT_CNT_TBL[]
         {

--- a/Assembly-CSharp/Global/btl_eqp.cs
+++ b/Assembly-CSharp/Global/btl_eqp.cs
@@ -1,49 +1,90 @@
 ﻿using System;
+using System.Collections.Generic;
 using FF9;
 using UnityEngine;
 using Memoria.Data;
 
-public class btl_eqp
+public static class btl_eqp
 {
-	public static void InitWeapon(PLAYER p, BTL_DATA btl)
-	{
-		btl.weapon = ff9item.GetItemWeapon(p.equip[0]);
-		p.wep_bone = btl_mot.BattleParameterList[p.info.serial_no].WeaponBone;
-		if (btl.weapon.ModelId != UInt16.MaxValue)
-		{
-			String modelName = FF9BattleDB.GEO.GetValue(btl.weapon.ModelId);
-			btl.weapon_geo = ModelFactory.CreateModel("BattleMap/BattleModel/battle_weapon/" + modelName + "/" + modelName, true);
-		}
-		else
-		{
-			btl.weapon_geo = new GameObject("Dummy weapon");
-		}
-		MeshRenderer[] componentsInChildren = btl.weapon_geo.GetComponentsInChildren<MeshRenderer>();
-		btl.weaponMeshCount = componentsInChildren.Length;
-		btl.weaponRenderer = new Renderer[btl.weaponMeshCount];
-		for (Int32 i = 0; i < btl.weaponMeshCount; i++)
-		{
-			btl.weaponRenderer[i] = componentsInChildren[i].GetComponent<Renderer>();
-			if (btl.weapon.CustomTexture != null && btl.weapon.CustomTexture.Length > i && !String.IsNullOrEmpty(btl.weapon.CustomTexture[i]))
-				btl.weaponRenderer[i].material.mainTexture = AssetManager.Load<Texture2D>(btl.weapon.CustomTexture[i], false);
-		}
-		btl_util.SetBBGColor(btl.weapon_geo);
-		if (btl.is_monster_transform)
-			geo.geoAttach(btl.weapon_geo, btl.originalGo, p.wep_bone);
-		else
-			geo.geoAttach(btl.weapon_geo, btl.gameObject, p.wep_bone);
-	}
+    // TODO: maybe apply the system to the enemies as well when there's a sb2MonParm.WeaponModel
+    public static Dictionary<Int32, Int32> EnemyBuiltInWeaponTable = new Dictionary<Int32, Int32>
+    {
+        { 380, 21 }, // Fratley - GEO_SUB_F0_FLT
+        { 410, 31 }, // Lani - GEO_MON_B3_122 or GEO_MON_UP3_122
+    };
 
-	public static void InitEquipPrivilegeAttrib(PLAYER p, BTL_DATA btl)
-	{
-		btl.def_attr.invalid = (btl.def_attr.absorb = (btl.def_attr.half = (btl.def_attr.weak = (btl.p_up_attr = 0))));
-		for (Int32 i = 0; i < 5; i++)
-		{
-			if (p.equip[i] != RegularItem.NoItem)
-			{
-				btl_init.IncrementDefAttr(btl.def_attr, ff9equip.ItemStatsData[ff9item._FF9Item_Data[p.equip[i]].bonus].def_attr);
-				btl.p_up_attr = (Byte)(btl.p_up_attr | ff9equip.ItemStatsData[ff9item._FF9Item_Data[p.equip[i]].bonus].p_up_attr);
-			}
-		}
-	}
+    public static void InitWeapon(PLAYER p, BTL_DATA btl)
+    {
+        btl.builtin_weapon_mode = false;
+        btl.weapon = ff9item.GetItemWeapon(p.equip[0]);
+        p.wep_bone = btl_mot.BattleParameterList[p.info.serial_no].WeaponBone;
+        if (btl.weapon.ModelId != UInt16.MaxValue)
+        {
+            String modelName = FF9BattleDB.GEO.GetValue(btl.weapon.ModelId);
+            btl.weapon_geo = ModelFactory.CreateModel("BattleMap/BattleModel/battle_weapon/" + modelName + "/" + modelName, true);
+            if (btl.weapon_geo == null)
+                btl.weapon_geo = new GameObject("Dummy weapon");
+            if (EnemyBuiltInWeaponTable.ContainsKey(btl.dms_geo_id))
+                btl.builtin_weapon_mode = true;
+        }
+        else
+        {
+            btl.weapon_geo = new GameObject("Dummy weapon");
+        }
+        MeshRenderer[] componentsInChildren = btl.weapon_geo.GetComponentsInChildren<MeshRenderer>();
+        btl.weaponMeshCount = componentsInChildren.Length;
+        btl.weaponRenderer = new Renderer[btl.weaponMeshCount];
+        for (Int32 i = 0; i < btl.weaponMeshCount; i++)
+        {
+            btl.weaponRenderer[i] = componentsInChildren[i].GetComponent<Renderer>();
+            if (btl.weapon.CustomTexture != null && btl.weapon.CustomTexture.Length > i && !String.IsNullOrEmpty(btl.weapon.CustomTexture[i]))
+                btl.weaponRenderer[i].material.mainTexture = AssetManager.Load<Texture2D>(btl.weapon.CustomTexture[i], false);
+        }
+        btl_util.SetBBGColor(btl.weapon_geo);
+        if (btl.is_monster_transform)
+            geo.geoAttach(btl.weapon_geo, btl.originalGo, p.wep_bone);
+        else
+            geo.geoAttach(btl.weapon_geo, btl.gameObject, p.wep_bone);
+    }
+
+    public static void InitEquipPrivilegeAttrib(PLAYER p, BTL_DATA btl)
+    {
+        btl.def_attr.invalid = (btl.def_attr.absorb = (btl.def_attr.half = (btl.def_attr.weak = (btl.p_up_attr = 0))));
+        for (Int32 i = 0; i < 5; i++)
+        {
+            if (p.equip[i] != RegularItem.NoItem)
+            {
+                btl_init.IncrementDefAttr(btl.def_attr, ff9equip.ItemStatsData[ff9item._FF9Item_Data[p.equip[i]].bonus].def_attr);
+                btl.p_up_attr = (Byte)(btl.p_up_attr | ff9equip.ItemStatsData[ff9item._FF9Item_Data[p.equip[i]].bonus].p_up_attr);
+            }
+        }
+    }
+
+    public static void ProcessBuiltInWeapon()
+    {
+        for (BTL_DATA btl = FF9StateSystem.Battle.FF9Battle.btl_list.next; btl != null; btl = btl.next)
+        {
+            if (btl.builtin_weapon_mode && btl.bi.disappear == 0 && !btl.is_monster_transform && btl_eqp.EnemyBuiltInWeaponTable.TryGetValue(btl.dms_geo_id, out Int32 weaponBoneID))
+            {
+                Transform builtInBone = null;
+                if (btl.gameObject == btl.originalGo)
+                {
+                    builtInBone = btl.originalGo.transform.GetChildByName($"bone{weaponBoneID:D3}");
+                }
+                else if (btl.gameObject == btl.tranceGo && btl.bi.player != 0)
+                {
+                    CharacterSerialNumber serial = btl_util.getSerialNumber(btl);
+                    if (btl_mot.BattleParameterList[serial].ModelId == btl_mot.BattleParameterList[serial].TranceModelId)
+                        builtInBone = btl.tranceGo.transform.GetChildByName($"bone{weaponBoneID:D3}");
+                }
+                if (builtInBone != null)
+                    builtInBone.localScale = SCALE_INVISIBLE;
+                if (btl.weapon_geo != null)
+                    btl.weapon_geo.transform.localScale = builtInBone != null ? SCALE_REBALANCE : Vector3.one;
+            }
+        }
+    }
+
+    private static readonly Vector3 SCALE_INVISIBLE = new Vector3(0.01f, 0.01f, 0.01f);
+    private static readonly Vector3 SCALE_REBALANCE = new Vector3(100f, 100f, 100f);
 }

--- a/Assembly-CSharp/Global/btl_eqp.cs
+++ b/Assembly-CSharp/Global/btl_eqp.cs
@@ -11,6 +11,8 @@ public static class btl_eqp
     {
         { 380, 21 }, // Fratley - GEO_SUB_F0_FLT
         { 410, 31 }, // Lani - GEO_MON_B3_122 or GEO_MON_UP3_122
+        { 301, 17 }, // Baku - GEO_MON_B3_105
+        { 359, 19 }, // King Leo - GEO_MON_B3_106
     };
 
     public static void InitWeapon(PLAYER p, BTL_DATA btl)

--- a/Assembly-CSharp/Global/btl_init.cs
+++ b/Assembly-CSharp/Global/btl_init.cs
@@ -585,12 +585,9 @@ public static class btl_init
 	{
 		// Set normal model
 		String modelName = (btl.dms_geo_id == -1) ? String.Empty : FF9BattleDB.GEO.GetValue(btl.dms_geo_id);
-		Int32 scale = 1;
-		if (ModelFactory.HaveUpScaleModel(modelName))
-			scale = 4;
 
 		GEOTEXHEADER textureAnim = new GEOTEXHEADER();
-		textureAnim.ReadPlayerTextureAnim(btl, "Models/GeoTexAnim/" + modelName + ".tab", scale);
+		textureAnim.ReadBattleTextureAnim(btl, "Models/GeoTexAnim/" + modelName + ".tab");
 		btl.texanimptr = textureAnim;
 
 		// Set trance model
@@ -599,7 +596,7 @@ public static class btl_init
 
 		String tranceModelName = btl_mot.BattleParameterList[btl_util.getSerialNumber(btl)].TranceModelId;
 		GEOTEXHEADER tranceTextureAnim = new GEOTEXHEADER();
-		tranceTextureAnim.ReadTrancePlayerTextureAnim(btl, tranceModelName, scale);
+		tranceTextureAnim.ReadTranceTextureAnim(btl, tranceModelName);
 		btl.tranceTexanimptr = tranceTextureAnim;
 	}
 

--- a/Assembly-CSharp/Global/btl_vfx.cs
+++ b/Assembly-CSharp/Global/btl_vfx.cs
@@ -204,7 +204,7 @@ public static class btl_vfx
         {
             btl.battleModelIsRendering = true;
             btl.tranceGo.SetActive(true);
-            btl.gameObject = btl.tranceGo;
+            btl.ChangeModel(btl.tranceGo);
             GeoTexAnim.geoTexAnimPlay(btl.tranceTexanimptr, 2);
         }
         else
@@ -212,7 +212,7 @@ public static class btl_vfx
             btl.battleModelIsRendering = true;
             btl.originalGo.SetActive(true);
             btl.tranceGo.SetActive(false);
-            btl.gameObject = btl.originalGo;
+            btl.ChangeModel(btl.originalGo);
             btl.dms_geo_id = btl_init.GetModelID(serialNo, isTrance);
             GeoTexAnim.geoTexAnimPlay(btl.texanimptr, 2);
         }

--- a/Assembly-CSharp/Global/ff9play.cs
+++ b/Assembly-CSharp/Global/ff9play.cs
@@ -255,7 +255,7 @@ public static class ff9play
             play.cur.mp = play.max.mp;
             play.cur.capa = play.max.capa;
         }
-        FF9Play_Update(play, false);
+        FF9Play_Update(play);
         if (lvup)
         {
             play.cur.hp = ccommon.min((UInt32)oldHP, play.max.hp);
@@ -271,15 +271,8 @@ public static class ff9play
         FF9Play_UpdateSA(play);
     }
 
-    public static void FF9Play_Update(PLAYER play, Boolean refreshStats = true)
+    public static void FF9Play_Update(PLAYER play)
     {
-        if (refreshStats)
-        {
-            play.basis.dex = (Byte)ff9level.FF9Level_GetDex(play, play.level, false);
-            play.basis.str = (Byte)ff9level.FF9Level_GetStr(play, play.level, false);
-            play.basis.mgc = (Byte)ff9level.FF9Level_GetMgc(play, play.level, false);
-            play.basis.wpr = (Byte)ff9level.FF9Level_GetWpr(play, play.level, false);
-        }
         FF9PLAY_INFO info = new FF9PLAY_INFO();
         FF9PLAY_SKILL skill = new FF9PLAY_SKILL();
         info.Base = play.basis;

--- a/Assembly-CSharp/Global/ff9play.cs
+++ b/Assembly-CSharp/Global/ff9play.cs
@@ -255,7 +255,7 @@ public static class ff9play
             play.cur.mp = play.max.mp;
             play.cur.capa = play.max.capa;
         }
-        FF9Play_Update(play);
+        FF9Play_Update(play, false);
         if (lvup)
         {
             play.cur.hp = ccommon.min((UInt32)oldHP, play.max.hp);
@@ -271,8 +271,15 @@ public static class ff9play
         FF9Play_UpdateSA(play);
     }
 
-    public static void FF9Play_Update(PLAYER play)
+    public static void FF9Play_Update(PLAYER play, Boolean refreshStats = true)
     {
+        if (refreshStats)
+        {
+            play.basis.dex = (Byte)ff9level.FF9Level_GetDex(play, play.level, false);
+            play.basis.str = (Byte)ff9level.FF9Level_GetStr(play, play.level, false);
+            play.basis.mgc = (Byte)ff9level.FF9Level_GetMgc(play, play.level, false);
+            play.basis.wpr = (Byte)ff9level.FF9Level_GetWpr(play, play.level, false);
+        }
         FF9PLAY_INFO info = new FF9PLAY_INFO();
         FF9PLAY_SKILL skill = new FF9PLAY_SKILL();
         info.Base = play.basis;

--- a/Assembly-CSharp/Memoria/Application/SmoothFrameUpdater_Battle.cs
+++ b/Assembly-CSharp/Memoria/Application/SmoothFrameUpdater_Battle.cs
@@ -34,10 +34,9 @@ namespace Memoria
 		}
 
 		public static Boolean Enabled => Configuration.Graphics.BattleTPS < Configuration.Graphics.BattleFPS;
-
         public static Int32 LastSFXEffectJTex { get; set; }
 
-        public static void RegisterState()
+		public static void RegisterState()
 		{
 			if (!Enabled) return;
 			for (BTL_DATA next = FF9StateSystem.Battle.FF9Battle.btl_list.next; next != null; next = next.next)
@@ -209,8 +208,8 @@ namespace Memoria
 			if(_bg != null)
 			{
 				_bg.localRotation = Quaternion.Lerp(_bgRotPrevious, _bgRotActual, smoothFactor);
-                // Log.Message($"[DEBUG {Time.frameCount} cur {_bg.localRotation.eulerAngles} prev {_bgRotPrevious.eulerAngles} actual {_bgRotActual.eulerAngles} t {smoothFactor}");
-            }
+				// Log.Message($"[DEBUG {Time.frameCount} cur {_bg.localRotation.eulerAngles} prev {_bgRotPrevious.eulerAngles} actual {_bgRotActual.eulerAngles} t {smoothFactor}");
+			}
             // SPS
             if (FF9StateSystem.Battle.FF9Battle.btl_phase != 2)
             {
@@ -219,8 +218,8 @@ namespace Memoria
                     btl2d.Btl2dStatIcon();
                 HonoluluBattleMain.battleSPS.GenerateSPS();
             }
-            // Camera
-            Camera camera = Camera.main ? Camera.main : GameObject.Find("Battle Camera").GetComponent<BattleMapCameraController>().GetComponent<Camera>();
+			// Camera
+			Camera camera = Camera.main ? Camera.main : GameObject.Find("Battle Camera").GetComponent<BattleMapCameraController>().GetComponent<Camera>();
 			if (_cameraRegistered && camera != null)
 			{
 				Vector3 cameraMove = MatrixGetTranslation(_cameraW2CMatrixActual) - MatrixGetTranslation(_cameraW2CMatrixPrevious);
@@ -305,9 +304,8 @@ namespace Memoria
 		private static Matrix4x4 _cameraW2CMatrixActual;
 		private static Matrix4x4 _cameraProjMatrixPrevious;
 		private static Matrix4x4 _cameraProjMatrixActual;
-        private static Int32 _lastEffectJTex = 1;
 
-        private static Transform _bg;
+		private static Transform _bg;
 		private static Quaternion _bgRotPrevious;
 		private static Quaternion _bgRotActual;
 	}

--- a/Assembly-CSharp/Memoria/Assets/Text/TextureHelper.cs
+++ b/Assembly-CSharp/Memoria/Assets/Text/TextureHelper.cs
@@ -24,7 +24,7 @@ namespace Memoria.Assets
             if (texture == null)
                 return null;
 
-            Camera camera = Camera.main ?? GameObject.Find("FieldMap Camera").GetComponent<Camera>();
+            Camera camera = Camera.main ?? GameObject.Find("FieldMap Camera")?.GetComponent<Camera>() ?? GameObject.Find("UI Camera")?.GetComponent<Camera>() ?? UICamera.mainCamera;
             RenderTexture oldTarget = camera.targetTexture;
             RenderTexture oldActive = RenderTexture.active;
 

--- a/Assembly-CSharp/Memoria/Battle/Calculator/BattleCalculator.cs
+++ b/Assembly-CSharp/Memoria/Battle/Calculator/BattleCalculator.cs
@@ -660,6 +660,8 @@ namespace Memoria
 
         public void TryCriticalHit()
         {
+            if ((Target.Flags & CalcFlag.Critical) != 0) // In case another system triggered a critical strike (with possibly other consequences)
+                return;
             Int32 quarterWill = Caster.Data.elem.wpr >> 2;
             if (quarterWill != 0 && (Comn.random16() % quarterWill) + Caster.Data.critical_rate_deal_bonus + Target.Data.critical_rate_receive_bonus > Comn.random16() % 100)
             {

--- a/Assembly-CSharp/Memoria/Battle/Calculator/BattleUnit.cs
+++ b/Assembly-CSharp/Memoria/Battle/Calculator/BattleUnit.cs
@@ -679,7 +679,7 @@ namespace Memoria
             // Let the spell sequence handle the model fadings (in and out)
             //Data.SetActiveBtlData(false);
             String geoName = FF9BattleDB.GEO.GetValue(monsterParam.Geo);
-            Data.gameObject = ModelFactory.CreateModel(geoName, true);
+            Data.ChangeModel(ModelFactory.CreateModel(geoName, true));
             Data.bi.t_gauge = 0;
             if (IsUnderAnyStatus(BattleStatus.Trance))
             {
@@ -876,7 +876,7 @@ namespace Memoria
             btl_cmd.KillSpecificCommand(Data, Data.monster_transform.new_command);
             btl_cmd.KillSpecificCommand(Data, BattleCommandId.EnemyCounter);
             Data.gameObject.SetActive(false);
-            Data.gameObject = Data.originalGo;
+            Data.ChangeModel(Data.originalGo);
             Data.geo_scale_default = 4096;
             geo.geoScaleReset(Data);
             if (battle.TRANCE_GAUGE_FLAG != 0 && (p.category & 16) == 0 && (Data.bi.slot_no != (Byte)CharacterId.Garnet || battle.GARNET_DEPRESS_FLAG == 0))

--- a/Assembly-CSharp/Memoria/Battle/Calculator/BattleUnit.cs
+++ b/Assembly-CSharp/Memoria/Battle/Calculator/BattleUnit.cs
@@ -126,7 +126,25 @@ namespace Memoria
         public Byte Dexterity
         {
             get => Data.special_status_old ? (byte)Math.Max(1, Data.elem.dex >> 3) : Data.elem.dex;
-            set => Data.elem.dex = value;
+            set
+            {
+                if (Data.elem.dex == value)
+                    return;
+                Int16 newMaxATB = (Int16)((60 - value) * 40 << 2);
+                if (Data.cur.at >= Data.max.at)
+                {
+                    Data.elem.dex = value;
+                    Data.max.at = newMaxATB;
+                    Data.cur.at = newMaxATB;
+                }
+                else
+                {
+                    Single atbFill = (Single)Data.cur.at / Data.max.at;
+                    Data.elem.dex = value;
+                    Data.max.at = newMaxATB;
+                    Data.cur.at = (Int16)Math.Round(atbFill * newMaxATB);
+                }
+            }
         }
 
         public Byte Will

--- a/Assembly-CSharp/Memoria/Configuration/DataPatchers.cs
+++ b/Assembly-CSharp/Memoria/Configuration/DataPatchers.cs
@@ -509,14 +509,12 @@ namespace Memoria
                 {
                     // eg.: SwapFieldModelTexture 2250 GEO_MON_B3_093 CustomTextures/OeilvertGuardian/342_0.png CustomTextures/OeilvertGuardian/342_1.png CustomTextures/OeilvertGuardian/342_2.png CustomTextures/OeilvertGuardian/342_3.png CustomTextures/OeilvertGuardian/342_4.png CustomTextures/OeilvertGuardian/342_5.png
                     List<string> TexturesList = new List<string>();
-                    if (!Int32.TryParse(entry[1], out Int32 FieldID))
+                    if (!Int32.TryParse(entry[1], out Int32 fieldID))
                         continue;
                     for (Int32 i = 3; i < entry.Length; i++)
-                    {
                         TexturesList.Add(entry[i]);
-                    }
                     String[] TexturesCustomModel = TexturesList.ToArray();
-                    ModelFactory.CustomModelField.Add(entry[1] + "#" + entry[2], TexturesCustomModel);
+                    ModelFactory.CustomModelField.Add(new KeyValuePair<Int32, String>(fieldID, entry[2]), TexturesCustomModel);
                 }
             }
 			if (shouldUpdateBattleStatus)

--- a/Assembly-CSharp/Memoria/Data/Characters/CharacterAbilityGems.cs
+++ b/Assembly-CSharp/Memoria/Data/Characters/CharacterAbilityGems.cs
@@ -118,10 +118,10 @@ namespace Memoria.Data
                         e.EvaluateParameter += NCalcUtility.commonNCalcParameters;
                         if (String.Equals(formula.Key, "MaxHP")) play.max.hp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.max.hp);
                         else if (String.Equals(formula.Key, "MaxMP")) play.max.mp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.max.mp);
-                        else if (String.Equals(formula.Key, "Speed")) play.basis.dex = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.basis.dex);
-                        else if (String.Equals(formula.Key, "Strength")) play.basis.str = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.basis.str);
-                        else if (String.Equals(formula.Key, "Magic")) play.basis.mgc = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.basis.mgc);
-                        else if (String.Equals(formula.Key, "Spirit")) play.basis.wpr = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.basis.wpr);
+                        else if (String.Equals(formula.Key, "Speed")) play.elem.dex = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.elem.dex);
+                        else if (String.Equals(formula.Key, "Strength")) play.elem.str = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.elem.str);
+                        else if (String.Equals(formula.Key, "Magic")) play.elem.mgc = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.elem.mgc);
+                        else if (String.Equals(formula.Key, "Spirit")) play.elem.wpr = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.elem.wpr);
                         else if (String.Equals(formula.Key, "Defence")) play.defence.PhysicalDefence = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.defence.PhysicalDefence);
                         else if (String.Equals(formula.Key, "Evade")) play.defence.PhysicalEvade = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.defence.PhysicalEvade);
                         else if (String.Equals(formula.Key, "MagicDefence")) play.defence.MagicalDefence = (Int32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.defence.MagicalDefence);

--- a/Assembly-CSharp/Memoria/Data/Characters/CharacterAbilityGems.cs
+++ b/Assembly-CSharp/Memoria/Data/Characters/CharacterAbilityGems.cs
@@ -214,6 +214,7 @@ namespace Memoria.Data
                             if (String.Equals(formula.Key, "FleeGil")) fleeGil = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), fleeGil);
                             else if (String.Equals(formula.Key, "HP")) play.cur.hp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.cur.hp);
                             else if (String.Equals(formula.Key, "MP")) play.cur.mp = (UInt32)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.cur.mp);
+                            else if (String.Equals(formula.Key, "Trance")) play.trance = (Byte)NCalcUtility.ConvertNCalcResult(e.Evaluate(), play.trance);
                             else if (String.Equals(formula.Key, "Status")) play.status = (BattleStatus)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (UInt32)play.status);
                             else if (String.Equals(formula.Key, "BonusAP")) bonus.ap = (UInt16)NCalcUtility.ConvertNCalcResult(e.Evaluate(), bonus.ap);
                             else if (String.Equals(formula.Key, "BonusCard")) bonus.card = (TetraMasterCardId)NCalcUtility.ConvertNCalcResult(e.Evaluate(), (Int32)bonus.card);

--- a/Assembly-CSharp/NCalc/NCalcUtility.cs
+++ b/Assembly-CSharp/NCalc/NCalcUtility.cs
@@ -274,10 +274,10 @@ namespace NCalc
             expr.Parameters["MaxMP"] = play.max.mp;
             expr.Parameters["Level"] = (Int32)play.level;
             expr.Parameters["Exp"] = play.exp;
-            expr.Parameters["Speed"] = (Int32)play.basis.dex;
-            expr.Parameters["Strength"] = (Int32)play.basis.str;
-            expr.Parameters["Magic"] = (Int32)play.basis.mgc;
-            expr.Parameters["Spirit"] = (Int32)play.basis.wpr;
+            expr.Parameters["Speed"] = (Int32)play.elem.dex;
+            expr.Parameters["Strength"] = (Int32)play.elem.str;
+            expr.Parameters["Magic"] = (Int32)play.elem.mgc;
+            expr.Parameters["Spirit"] = (Int32)play.elem.wpr;
             expr.Parameters["Defence"] = play.defence.PhysicalDefence;
             expr.Parameters["Evade"] = play.defence.PhysicalEvade;
             expr.Parameters["PlayerStatus"] = (UInt32)play.status;


### PR DESCRIPTION
In this PR:
- Battle SPS update more consistently with higher FPS.
- Fix a bug with the battle FPS smoothening when a character swap model (trance or monster transform).
- Most of model textures can now be used in mod folders as separate assets (they used to be ignored). They can also be rescaled in any format, bu they need to keep the same overall disposal (eg. if the eye texture of a 3D model is on the upper left of the original texture, it must be on the upper left of the upscaled texture as well).
- #547: the side bars in narrow screen mode can be turned black by changing the texture ``EmbeddedAsset\ui\sprites\overlay canvas\letterbox_verticle`` in a mod folder... for now, it doesn't use the texture itself so it can only be the native border texture or black bars, not anything else.
- When modifying the speed of a ``BattleUnit`` in the middle of a battle, the ATB speed now updates as well.
- Support Ability features ``Permanent`` now work correctly with primary stat boosts (it didn't reset properly when removing a support ability, so it could be toggled on/off multiple times to stack boosts, although there's no native SA that gives a primary stat boost).
- ``TryCritical`` doesn't apply a critical strike if the flag was already triggered for the attack by something else.
- Can now change a character's trance progression in a SA feature ``BattleResult``.
- Now hide the "built-in" weapons for Fratley, Lani, Baku and King Leo (whose weapon models are part of their overall model) when used as playable characters. Courtesy of DV for Baku and King Leo.
- It is now possible to use a custom texture in trance even if the trance model is the same as the normal model, by using a texture name with the ``_trance`` suffix. For example, the textures of Marcus's model (normal and trance) can be overwritten with:
```txt
{ModFolder}/StreamingAssets/assets/resources/Models/2/45/45_0.png
{ModFolder}/StreamingAssets/assets/resources/Models/2/45/45_1.png
{ModFolder}/StreamingAssets/assets/resources/Models/2/45/45_0_trance.png
{ModFolder}/StreamingAssets/assets/resources/Models/2/45/45_1_trance.png
```
- #549: Fix a couple of world map textures being non-moddable. These 2 problematic textures can now be imported with the paths:
```txt
{ModFolder}/StreamingAssets/assets/resources/WorldMap/Textures/res(1_24)_objects.png
{ModFolder}/StreamingAssets/assets/resources/WorldMap/Textures/res(1_24)_terrain.png
```
- Fix Scan moving the camera while the scan window is opened in some situations.
- #566: fix a couple of bugs with the option ``AutoPotionOverhealLimit``.