### PR TITLE
Fixes

### DIFF
--- a/Assembly-CSharp/Assets/Sources/Graphics/Movie/MovieMaterial.cs
+++ b/Assembly-CSharp/Assets/Sources/Graphics/Movie/MovieMaterial.cs
@@ -335,16 +335,16 @@ namespace Assets.Sources.Graphics.Movie
 
 		private void CalculateUVScaleOffset()
 		{
-			Single num = (Single)this.Width;
-			Single num2 = (Single)this.Height;
-			Single num3 = (Single)this.m_picX;
-			Single num4 = (Single)this.m_picY;
-			Single num5 = (Single)this.m_yStride;
-			Single num6 = (Single)this.m_yHeight;
-			Single num7 = (Single)this.m_uvStride;
-			Single num8 = (Single)this.m_uvHeight;
-			this.m_uvYScale = new Vector2(num / num5, -(num2 / num6));
-			this.m_uvYOffset = new Vector2(num3 / num5, (num2 + num4) / num6);
+			Single w = (Single)this.Width;
+			Single h = (Single)this.Height;
+			Single x = (Single)this.m_picX;
+			Single y = (Single)this.m_picY;
+			Single yStride = (Single)this.m_yStride;
+			Single yHeight = (Single)this.m_yHeight;
+			Single uvStride = (Single)this.m_uvStride;
+			Single uvHeight = (Single)this.m_uvHeight;
+			this.m_uvYScale = new Vector2(w / yStride, -(h / yHeight));
+			this.m_uvYOffset = new Vector2(x / yStride, (h + y) / yHeight);
 			this.m_uvCrCbScale = default(Vector2);
 			this.m_uvCrCbOffset = default(Vector2);
 			if (this.m_uvStride == this.m_yStride)
@@ -353,7 +353,7 @@ namespace Assets.Sources.Graphics.Movie
 			}
 			else
 			{
-				this.m_uvCrCbScale.x = num / 2f / num7;
+				this.m_uvCrCbScale.x = w / 2f / uvStride;
 			}
 			if (this.m_uvHeight == this.m_yHeight)
 			{
@@ -362,8 +362,8 @@ namespace Assets.Sources.Graphics.Movie
 			}
 			else
 			{
-				this.m_uvCrCbScale.y = -(num2 / 2f / num8);
-				this.m_uvCrCbOffset = new Vector2(num3 / 2f / num7, (num2 + num4) / 2f / num8);
+				this.m_uvCrCbScale.y = -(h / 2f / uvHeight);
+				this.m_uvCrCbOffset = new Vector2(x / 2f / uvStride, (h + y) / 2f / uvHeight);
 			}
 		}
 

--- a/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
+++ b/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
@@ -307,7 +307,16 @@ public partial class EventEngine
             }
             case EBin.event_code_binary.BGVPORT: // 0x1E, "SetCameraBounds", "Redefine the field camera boundaries (default value is part of the background's data)", true, 5, { 1, 2, 2, 2, 2 }, { "Camera", "Min X", "Max X", "Min Y", "Max Y" }, { AT_USPIN, AT_SPIN, AT_SPIN, AT_SPIN, AT_SPIN }, 0
             {
-                this.fieldmap.EBG_cameraSetViewport(this.getv1(), (Int16)this.getv2(), (Int16)this.getv2(), (Int16)this.getv2(), (Int16)this.getv2()); // arg1: camera ID | arg2-5: MinX, MaxX, MinY, MaxY
+                Int32 camId = this.getv1(); // arg1: camera ID
+                Int16 minX = (Int16)this.getv2(); // arg2-5: MinX, MaxX, MinY, MaxY
+                Int16 maxX = (Int16)this.getv2();
+                Int16 minY = (Int16)this.getv2();
+                Int16 maxY = (Int16)this.getv2();
+
+                if (mapNo == 2220 && minX == 154 && FieldMap.ActualPsxScreenWidth > 390) // Desert Palace fix to widescreen cam seeing hidden path too soon
+                    minX = (Int16)544;
+
+                this.fieldmap.EBG_cameraSetViewport(camId, minX, maxX, minY, maxY);
                 return 0;
             }
             case EBin.event_code_binary.MES: // 0x1F, "WindowSync", "Display a window with text inside and wait until it closes", true, 3, { 1, 1, 2 }, { "Window ID", "UI", "Text" }, { AT_USPIN, AT_BOOLLIST, AT_TEXT }, 0

--- a/Assembly-CSharp/Global/Field/Map/FieldMap.cs
+++ b/Assembly-CSharp/Global/Field/Map/FieldMap.cs
@@ -2486,6 +2486,10 @@ public class FieldMap : HonoBehavior
         [913,0,0,100],      // Treno Tower lights
         [913,0,3,0],        // Treno Tower lights
         [913,0,4,0],        // Treno Tower lights
+        [1900,0,20,500],     // Treno Thug Inn light
+        [1913,0,0,100],      // Treno Tower lights
+        [1913,0,3,0],        // Treno Tower lights
+        [1913,0,4,0],        // Treno Tower lights
         [951,0,2,1214],     // Gargan Roo's railing
         [1000,0,12,0],      // Clayra's Trunk text (in English version)
         [1206,0,21,800],    // Alexandria, purple chadelier

--- a/Assembly-CSharp/Global/fldfmv.cs
+++ b/Assembly-CSharp/Global/fldfmv.cs
@@ -97,23 +97,28 @@ public class fldfmv : Singleton<fldfmv>
 
 	public unsafe void ff9fieldFMVService()
 	{
+		Boolean speedLoad = true;
 		switch (fldfmv.fmvStatus)
 		{
 		case 1:
 			fldfmv.fmvStatus = 2;
+			if (speedLoad) ff9fieldFMVService();
 			break;
 		case 2:
 			fldfmv.ff9fieldFMVAttr |= 8;
 			fldfmv.fmvStatus = 3;
+			if (speedLoad) ff9fieldFMVService();
 			break;
 		case 3:
 			if ((fldfmv.ff9fieldFMVAttr & 8) != 0)
 			{
 				fldfmv.fmvStatus = 4;
+				if (speedLoad) ff9fieldFMVService();
 			}
 			break;
 		case 4:
 			fldfmv.fmvStatus = 5;
+			if (speedLoad) ff9fieldFMVService();
 			break;
 		case 5:
 			if ((fldfmv.ff9fieldFMVAttr & 1) != 0)
@@ -127,13 +132,13 @@ public class fldfmv : Singleton<fldfmv>
 				FieldMap.FF9FieldAttr.ff9[0, num - 1] = 25;
 				if (!this.mbg.isFMV045)
 				{
-                        FieldMap.FF9FieldAttr.field[0, num - 1] |= (UInt16)2048;
-                    }
+					FieldMap.FF9FieldAttr.field[0, num - 1] |= (UInt16)2048;
+				}
 				if (fldfmv.fmvDepth != 0)
 				{
-                        FieldMap.FF9FieldAttr.ff9[0, num - 1] |= (UInt16)68;
-                        FieldMap.FF9FieldAttr.field[0, num - 1] |= (UInt16)1;
-                    }
+					FieldMap.FF9FieldAttr.ff9[0, num - 1] |= (UInt16)68;
+					FieldMap.FF9FieldAttr.field[0, num - 1] |= (UInt16)1;
+				}
 				FieldMap.FF9FieldAttr.fmv[0, num - 1] = 64;
 				FieldMap.FF9FieldAttr.fmv[1, num] = 64;
 				FieldMap.FF9FieldAttr.fmv[0, num] = 2;
@@ -141,6 +146,7 @@ public class fldfmv : Singleton<fldfmv>
 				this.mbg.Set24BitMode(fldfmv.fmvDepth);
 				this.mbg.Play();
 				fldfmv.fmvStatus = 6;
+				if (speedLoad) ff9fieldFMVService();
 			}
 			break;
 		case 6:
@@ -205,6 +211,7 @@ public class fldfmv : Singleton<fldfmv>
 		this.mbg.Purge();
 		fldfmv.ff9fieldFMVAttr |= 4;
 		fldfmv.fmvStatus = 7;
+		ff9fieldFMVService();
 		UIManager.Field.MovieHitArea.SetActive(false);
 		MBG.Instance.ResetFlags();
 	}

--- a/Assembly-CSharp/Global/fldfmv.cs
+++ b/Assembly-CSharp/Global/fldfmv.cs
@@ -97,29 +97,17 @@ public class fldfmv : Singleton<fldfmv>
 
 	public unsafe void ff9fieldFMVService()
 	{
-		Boolean speedLoad = true;
-		switch (fldfmv.fmvStatus)
+		if (fldfmv.fmvStatus == 1 || fldfmv.fmvStatus == 2)
 		{
-		case 1:
-			fldfmv.fmvStatus = 2;
-			if (speedLoad) ff9fieldFMVService();
-			break;
-		case 2:
 			fldfmv.ff9fieldFMVAttr |= 8;
 			fldfmv.fmvStatus = 3;
-			if (speedLoad) ff9fieldFMVService();
-			break;
-		case 3:
-			if ((fldfmv.ff9fieldFMVAttr & 8) != 0)
-			{
-				fldfmv.fmvStatus = 4;
-				if (speedLoad) ff9fieldFMVService();
-			}
-			break;
-		case 4:
+		}
+		if ((fldfmv.fmvStatus == 3 && (fldfmv.ff9fieldFMVAttr & 8) != 0) || fldfmv.fmvStatus == 4)
+		{
 			fldfmv.fmvStatus = 5;
-			if (speedLoad) ff9fieldFMVService();
-			break;
+		}
+		switch (fldfmv.fmvStatus)
+		{
 		case 5:
 			if ((fldfmv.ff9fieldFMVAttr & 1) != 0 || FF9StateSystem.Common.FF9.fldMapNo == 100)
 			{
@@ -146,7 +134,6 @@ public class fldfmv : Singleton<fldfmv>
 				this.mbg.Set24BitMode(fldfmv.fmvDepth);
 				this.mbg.Play();
 				fldfmv.fmvStatus = 6;
-				if (speedLoad) ff9fieldFMVService();
 			}
 			break;
 		case 6:

--- a/Assembly-CSharp/Global/fldfmv.cs
+++ b/Assembly-CSharp/Global/fldfmv.cs
@@ -121,7 +121,7 @@ public class fldfmv : Singleton<fldfmv>
 			if (speedLoad) ff9fieldFMVService();
 			break;
 		case 5:
-			if ((fldfmv.ff9fieldFMVAttr & 1) != 0)
+			if ((fldfmv.ff9fieldFMVAttr & 1) != 0 || FF9StateSystem.Common.FF9.fldMapNo == 100)
 			{
 				Int32 num = 1;
 				if (FF9StateSystem.Common.FF9.id != 0)

--- a/Assembly-CSharp/Memoria/Configuration/Access/Graphics.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Access/Graphics.cs
@@ -27,7 +27,7 @@ namespace Memoria
 
             public static Boolean InitializeWidescreenSupport()
             {
-                if (!Instance._graphics.WidescreenSupport || (Instance._debug.Enabled && Instance._debug.StartFieldCreator))
+                if (!Instance._graphics.WidescreenSupport || (Instance._debug.Enabled && Instance._debug.StartFieldCreator) || Math.Abs((Double)Screen.width / (Double)Screen.height) < 1.34)
                 {
                     return false;
                 }

--- a/Memoria.Launcher/Memoria/GameSettingsControl.cs
+++ b/Memoria.Launcher/Memoria/GameSettingsControl.cs
@@ -79,7 +79,7 @@ namespace Memoria.Launcher
             resolutiontext.Margin = rowMargin;
             resolutiontext.ToolTip = Lang.Settings.Resolution_Tooltip;
             UiComboBox resolution = AddUiElement(UiComboBoxFactory.Create(), row: 10, col: 3, rowSpan: 3, colSpan: 5);
-            resolution.ItemsSource = EnumerateDisplaySettings().OrderByDescending(x => Convert.ToInt32(x.Split('x')[0])).ToArray();
+            resolution.ItemsSource = EnumerateDisplaySettings(true).OrderByDescending(x => Convert.ToInt32(x.Split('x')[0])).ToArray();
             resolution.SetBinding(Selector.SelectedItemProperty, new Binding(nameof(ScreenResolution)) { Mode = BindingMode.TwoWay });
             resolution.Margin = rowMargin;
             resolution.Height = 20;
@@ -146,7 +146,6 @@ namespace Memoria.Launcher
             {
                 UiHelper.ShowError(Application.Current.MainWindow, ex);
             }
-            //LoadSettings("");
         }
 
         #region Properties
@@ -158,7 +157,7 @@ namespace Memoria.Launcher
             {
                 if (_resolution != value)
                 {
-                    _resolution = value;
+                    _resolution = addRatio(value);
                     OnPropertyChanged();
                 }
             }
@@ -371,7 +370,7 @@ namespace Memoria.Launcher
                 switch (propertyName)
                 {
                     case nameof(ScreenResolution):
-                        iniFile.WriteValue("Settings", propertyName, ScreenResolution ?? "1280x960");
+                        iniFile.WriteValue("Settings", propertyName, ScreenResolution.Split('|')[0].Trim(' ') ?? "1280x960");
                         break;
                     case nameof(ActiveMonitor):
                         iniFile.WriteValue("Settings", propertyName, ActiveMonitor ?? String.Empty);
@@ -431,13 +430,13 @@ namespace Memoria.Launcher
             {
                 IniFile iniFile = new IniFile(IniPath);
 
-                String value = iniFile.ReadValue("Settings", nameof(ScreenResolution));
+                String value = iniFile.ReadValue("Settings", nameof(ScreenResolution)).Split('|')[0].Trim(' ');
                 //if res in settings.ini exists AND corresponds to something in the res list
-                if ((!String.IsNullOrEmpty(value)) && EnumerateDisplaySettings().ToArray().Any(value.Contains)) 
-                    _resolution = value;
+                if ((!String.IsNullOrEmpty(value)) && EnumerateDisplaySettings(false).ToArray().Any(value.Contains))
+                    _resolution = addRatio(value);
                 //else we choose the largest available one
                 else
-                    _resolution = EnumerateDisplaySettings().OrderByDescending(x => Convert.ToInt32(x.Split('x')[0])).ToArray()[0];
+                    _resolution = EnumerateDisplaySettings(false).OrderByDescending(x => Convert.ToInt32(x.Split('x')[0])).ToArray()[0];
 
                 value = iniFile.ReadValue("Settings", nameof(ActiveMonitor));
                 if (!String.IsNullOrEmpty(value))
@@ -690,7 +689,7 @@ namespace Memoria.Launcher
         [DllImport("user32.dll")]
         private static extern Boolean EnumDisplaySettings(String deviceName, Int32 modeNum, ref DevMode devMode);
 
-        private IEnumerable<String> EnumerateDisplaySettings()
+        private IEnumerable<String> EnumerateDisplaySettings(Boolean displayRatio)
         {
             HashSet<String> set = new HashSet<String>();
             DevMode devMode = new DevMode();
@@ -700,26 +699,38 @@ namespace Memoria.Launcher
                 if (devMode.dmPelsWidth >= 640 && devMode.dmPelsHeight >= 480)
                 {
                     String resolution = $"{devMode.dmPelsWidth.ToString(CultureInfo.InvariantCulture)}x{devMode.dmPelsHeight.ToString(CultureInfo.InvariantCulture)}";
-                    String ratio = "";
 
-                    if ((devMode.dmPelsWidth / 16) == (devMode.dmPelsHeight / 9)) ratio = " | 16:9";
-                    else if ((devMode.dmPelsWidth / 8) == (devMode.dmPelsHeight / 5)) ratio = " | 16:10";
-                    else if ((devMode.dmPelsWidth / 4) == (devMode.dmPelsHeight / 3)) ratio = " | 4:3";
-                    else if ((devMode.dmPelsWidth / 14) == (devMode.dmPelsHeight / 9)) ratio = " | 14:9";
-                    else if ((devMode.dmPelsWidth / 32) == (devMode.dmPelsHeight / 9)) ratio = " | 32:9";
-                    else if ((devMode.dmPelsWidth / 64) == (devMode.dmPelsHeight / 27)) ratio = " | 64:27";
-                    else if ((devMode.dmPelsWidth / 3) == (devMode.dmPelsHeight / 2)) ratio = " | 3:2";
-                    else if ((devMode.dmPelsWidth / 5) == (devMode.dmPelsHeight / 4)) ratio = " | 5:4";
-                    else if ((devMode.dmPelsWidth / 256) == (devMode.dmPelsHeight / 135)) ratio = " | 256:135";
-                    else if ((devMode.dmPelsWidth / 25) == (devMode.dmPelsHeight / 16)) ratio = " | 25:16";
-                    else if ((devMode.dmPelsWidth) == (devMode.dmPelsHeight)) ratio = " | 1:1";
-
-                    resolution += ratio; 
+                    if (displayRatio)
+                        resolution = addRatio(resolution);
 
                     if (set.Add(resolution))
                         yield return resolution;
                 }
             }
+        }
+
+        private String addRatio(String resolution)
+        {
+            if (!resolution.Contains("|") && resolution.Contains("x"))
+            {
+                String ratio = "";
+                Int32 x = Int32.Parse(resolution.Split('x')[0]);
+                Int32 y = Int32.Parse(resolution.Split('x')[1]);
+
+                if ((x / 16) == (y / 9)) ratio = " | 16:9";
+                else if ((x / 8) == (y / 5)) ratio = " | 16:10";
+                else if ((x / 4) == (y / 3)) ratio = " | 4:3";
+                else if ((x / 14) == (y / 9)) ratio = " | 14:9";
+                else if ((x / 32) == (y / 9)) ratio = " | 32:9";
+                else if ((x / 64) == (y / 27)) ratio = " | 64:27";
+                else if ((x / 3) == (y / 2)) ratio = " | 3:2";
+                else if ((x / 5) == (y / 4)) ratio = " | 5:4";
+                else if ((x / 256) == (y / 135)) ratio = " | 256:135";
+                else if ((x / 25) == (y / 16)) ratio = " | 25:16";
+                else if ((x) == (y)) ratio = " | 1:1";
+                resolution += ratio;
+            }
+            return resolution;
         }
 
         private String[] GetAvailableMonitors()

--- a/Memoria.Launcher/Memoria/GameSettingsControl.cs
+++ b/Memoria.Launcher/Memoria/GameSettingsControl.cs
@@ -421,7 +421,7 @@ namespace Memoria.Launcher
         private Boolean _isX64 = true;
         private Boolean _isX64Enabled = true;
         private Boolean _isDebugMode;
-        private Boolean _checkUpdates;
+        private Boolean _checkUpdates = true;
         private String[] _downloadMirrors;
 
         private void LoadSettings()
@@ -491,9 +491,9 @@ namespace Memoria.Launcher
 
                 value = iniFile.ReadValue("Memoria", nameof(CheckUpdates));
                 if (String.IsNullOrEmpty(value))
-                    value = "false";
+                    value = "true";
                 if (!Boolean.TryParse(value, out _checkUpdates))
-                    _checkUpdates = false;
+                    _checkUpdates = true;
 
                 value = iniFile.ReadValue("Memoria", nameof(AutoRunGame));
                 if (String.IsNullOrEmpty(value))


### PR DESCRIPTION
- Field 2220 - Unspoiled area in widescreen
- Fixed delay/flash before some video backgrounds #560
- Remade settings.ini compatible with original launcher
- Restricted widescreen when screen is 4:3 or narrower
- 2 layer fixes (treno 2)
--
- Made "check update" on by default