### PR TITLE
Quick fix (Floating glass Alexandria Pub + Daguerro PNJ + little change in Soft Reset)

### DIFF
--- a/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
+++ b/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
@@ -523,11 +523,6 @@ public partial class EventEngine
                 {
                     destX = -1635;
                 }
-                else if (mapNo == 2800 && po.sid == 17) // TODO Check Native: #147
-                {
-                    destX = -4702;
-                    destZ = 2702;
-                }
                 else if (mapNo == 2954 && po.sid == 4 && destX == -1159 && destZ == 13130)
                 {
                     SettingUtils.FieldMapSettings fieldMapSettings = SettingUtils.fieldMapSettings;

--- a/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
+++ b/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
@@ -737,14 +737,16 @@ public partial class EventEngine
                     po.go = ModelFactory.CreateModel(FF9BattleDB.GEO.GetValue(po.model), false);
                     Singleton<WMWorld>.Instance.addGameObjectToWMActor(po.go, ((Actor)po).wmActor);
                 }
-
-                if (mapNo == 112 && po.model == 223)
-                    this.gCur.flags = (Byte)((this.gCur.flags & -64) | (Int32)14); // floating glass Alex pub: set flag 14 (invisible)
                 return 0;
             }
             case EBin.event_code_binary.AIDLE: // 0x33, "SetStandAnimation", "Change the standing animation", true, 1, { 2 }, { "Animation" }, { AT_ANIMATION }, 0
             {
                 actor.idle = (UInt16)this.getv2(); // arg1: animation ID
+                if (mapNo == 112 && po.model == 223) 
+                {
+                    if ((actor.idle == 8239 && actor.uid == 3) || (actor.idle == 1870 && actor.uid == 6)) // Remove SetStandAnimation( 8239 ) for Dante's glass in Alexandria/Pub
+                        actor.idle = 5384; // Better stand animation imo for the Red Mage (uid == 6) or remove it... it's just a detail.
+                }
                 AnimationFactory.AddAnimWithAnimatioName(actor.go, FF9DBAll.AnimationDB.GetValue((Int32)actor.idle));
                 if (mapNo == 2365 && actor.uid == 14 && actor.idle == 11611)
                 {
@@ -768,7 +770,7 @@ public partial class EventEngine
                     this._geoTexAnim = actor.go.GetComponent<GeoTexAnim>();
                     if ((Int32)actor.idle == 7503)
                         this._geoTexAnim.geoTexAnimPlay(2);
-                }
+                }            
                 return 0;
             }
             case EBin.event_code_binary.AWALK: // 0x34, "SetWalkAnimation", "Change the walking animation", true, 1, { 2 }, { "Animation" }, { AT_ANIMATION }, 0
@@ -1095,6 +1097,20 @@ public partial class EventEngine
                 GameObject attachedObjUnity = attachedObj.go;
                 GameObject targetObject = targetObj.go;
                 Int32 bone_index = this.getv1(); // arg3: attachment point (unknown format)
+
+                if (mapNo == 112 && po.model == 223) // [DV] Fix the glasses in Alexandria's pub at the begin of the game
+                {
+                    if (po.uid == 6) // Red Mage's glass ?
+                    {
+                        attachedObjUnity = this.GetObjUID(6).go;
+                        targetObject = this.GetObjUID(4).go;
+                    }
+                    else // Dante's glass
+                    {
+                        geo.geoAttach(this.GetObjUID(3).go, this.GetObjUID(2).go, 13);
+                    }
+                }
+
                 if ((UnityEngine.Object)attachedObjUnity != (UnityEngine.Object)null && (UnityEngine.Object)targetObject != (UnityEngine.Object)null)
                 {
                     if (this.gMode == 1 || this.gMode == 2)

--- a/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
+++ b/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
@@ -58,6 +58,14 @@ public class UIKeyTrigger : MonoBehaviour
         && keyCommand == Control.Pause && keyCommand == Control.Select || UIManager.Input.GetKey(Control.LeftBumper) && UIManager.Input.GetKey(Control.LeftTrigger)
         && UIManager.Input.GetKey(Control.RightBumper) && UIManager.Input.GetKey(Control.RightTrigger) && UIManager.Input.GetKey(Control.Pause) && UIManager.Input.GetKey(Control.Select);
 
+    private Boolean SoftResetKeyPSXForPause => // L1 + R1 + L2 + R2 + select
+    PersistenSingleton<HonoInputManager>.Instance.IsInputDown(Control.LeftBumper) && PersistenSingleton<HonoInputManager>.Instance.IsInputDown(Control.LeftTrigger)
+    && PersistenSingleton<HonoInputManager>.Instance.IsInputDown(Control.RightBumper) && PersistenSingleton<HonoInputManager>.Instance.IsInputDown(Control.RightTrigger)
+    && PersistenSingleton<HonoInputManager>.Instance.IsInputDown(Control.Select)
+    || keyCommand == Control.LeftBumper && keyCommand == Control.LeftTrigger && keyCommand == Control.RightBumper && keyCommand == Control.RightTrigger
+    && keyCommand == Control.Select || UIManager.Input.GetKey(Control.LeftBumper) && UIManager.Input.GetKey(Control.LeftTrigger)
+    && UIManager.Input.GetKey(Control.RightBumper) && UIManager.Input.GetKey(Control.RightTrigger) && UIManager.Input.GetKey(Control.Select);
+
     public UIKeyTrigger()
     {
         keyCommand = Control.None;
@@ -517,7 +525,7 @@ public class UIKeyTrigger : MonoBehaviour
             activeButton = UICamera.selectedObject;
         if (sceneFromState != null && (!PersistenSingleton<UIManager>.Instance.Dialogs.Activate || PersistenSingleton<UIManager>.Instance.IsPause))
         {
-            if (sceneFromState.GetType() == typeof(ConfigUI) && FF9StateSystem.AndroidTVPlatform && PersistenSingleton<HonoInputManager>.Instance.IsInputDown(Control.Pause) && !SoftResetKeyPSXDown)
+            if (sceneFromState.GetType() == typeof(ConfigUI) && FF9StateSystem.AndroidTVPlatform && PersistenSingleton<HonoInputManager>.Instance.IsInputDown(Control.Pause) && !SoftResetKeyPSXForPause)
             {
                 if (PersistenSingleton<UIManager>.Instance.IsPauseControlEnable)
                     sceneFromState.OnKeyPause(activeButton);
@@ -552,7 +560,7 @@ public class UIKeyTrigger : MonoBehaviour
             {
                 autoConfirmDownTime = 0;
             }
-            if ((PersistenSingleton<HonoInputManager>.Instance.IsInputDown(Control.Pause) || keyCommand == Control.Pause) && !SoftResetKeyPSXDown)
+            if ((PersistenSingleton<HonoInputManager>.Instance.IsInputDown(Control.Pause) || keyCommand == Control.Pause) && !SoftResetKeyPSXForPause)
             {
                 keyCommand = Control.None;
                 if (PersistenSingleton<UIManager>.Instance.IsPauseControlEnable)


### PR DESCRIPTION
Here is the fix for the mysterious flying glass in Alexandria Pub :

![image](https://github.com/Albeoris/Memoria/assets/17729817/09f47e1e-2397-462a-a961-235ae19d6742)

After some investigations, here's what I've come up with: there are two glasses in this field and both are bugged.
The first one in the screen is not for Dante (the worker sitting on the left) but for an another PNJ... when we take a look in the pub, the only candidate who is drinking is the Red Mage.
Why not Dante for this glass ? Because, as you can see in the picture, Dante is not here : a part of the script is trigger only if Vivi accept to help Puck (the scene with the ladder to steal).

```
        InitObject( 14, 0 ) // Vivi
        InitObject( 1, 0 ) // ThugB
        InitObject( 4, 0 ) // Red_Mage_Male
        InitObject( 5, 0 ) // YoungWomanA
        InitObject( 6, 0 ) // First Glass
        InitRegion( 11, 0 ) // Region11
        if ( General_ScenarioCounter >= 1151 ) { <====== After Vivi accept Puck's request
            InitObject( 3, 0 ) // Second Glass
            InitObject( 2, 0 ) // Dante
        }
        InitObject( 7, 0 ) // Gilgamesh
        MoveCamera( 290, 112, 1, 8 )
        break
```

So why these glasses are bugged ? If we take a look on these field scripts, the issue is quite simple : their Loop function are wrong (their `AttachObject` precisely).
- The first glass is attached to himself so that's why he is floating near to the table... that's a mistake from dev, even since the PSX version.

```
Function Glass_Loop
    DisableShadow(  )
    AttachObject( 3, 255, 13 ) // Attach Glass to himself.... ?
    Wait( 1 )
    loop

```

- For the second glass, the `AttachObject` is missing !

```
Function Glass_Loop
    DisableShadow(  )
    Wait( 1 )
    loop
```

So i add a fix on Memoria for this field (in the `EventEngine.DoEventCode`) :
- Their `AttachObject` are fixed, the first glass is attached to the Red Mage and the second to Dante.
- I change also their `StandAnimation` because the one used on Dante is wrong (he holds the glass in upside down lol) and for the Red Mage, i think it looks better!

Link for the final result => https://youtu.be/_zdbS2i4YpI

That's all ! Next, i will try to look the PNJ who is dissapearing from Daguerreo