### PR TITLE
Synth shops inventory tip + minor fixes

### DIFF
--- a/Assembly-CSharp/Assets/Sources/Scripts/UI/Common/FF9UIDataTool.cs
+++ b/Assembly-CSharp/Assets/Sources/Scripts/UI/Common/FF9UIDataTool.cs
@@ -8,12 +8,13 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using XInputDotNetPure;
+using static Memoria.Assets.DataResources;
 
 namespace Assets.Sources.Scripts.UI.Common
 {
     public static class FF9UIDataTool
     {
-        public static void DisplayItem(RegularItem itemId, UISprite itemIcon, UILabel itemName, Boolean isEnable)
+        public static void DisplayItem(RegularItem itemId, UISprite itemIcon, UILabel itemName, Boolean isEnable, Boolean displayStock = false)
         {
             if (itemId != RegularItem.NoItem)
             {
@@ -29,6 +30,14 @@ namespace Assets.Sources.Scripts.UI.Common
                     itemName.text = FF9TextTool.ItemName(itemId);
                     itemName.color = isEnable ? FF9TextTool.White : FF9TextTool.Gray;
                     itemName.multiLine = true;
+                    if (displayStock && Configuration.Interface.SynthIngredientStockDisplayed)
+                    {
+                        Int32 itemAmount = ff9item.FF9Item_GetCount(itemId);
+                        if (itemAmount > 0)
+                        {
+                            itemName.text += $" ({itemAmount})";
+                        }
+                    }
                 }
             }
             else
@@ -40,7 +49,7 @@ namespace Assets.Sources.Scripts.UI.Common
             }
         }
 
-        public static void DisplayMultipleItems(Dictionary<RegularItem, Int32> items, UISprite itemIcon, UILabel itemName, Dictionary<RegularItem, Boolean> isEnable)
+        public static void DisplayMultipleItems(Dictionary<RegularItem, Int32> items, UISprite itemIcon, UILabel itemName, Dictionary<RegularItem, Boolean> isEnable, Boolean displayStock = false)
         {
             String itemLabel = String.Empty;
             String spriteName = String.Empty;
@@ -61,6 +70,14 @@ namespace Assets.Sources.Scripts.UI.Common
                 itemLabel += $"[{NGUIText.EncodeColor(enabled ? FF9TextTool.White : FF9TextTool.Gray)}]{FF9TextTool.ItemName(kvp.Key)}";
                 if (kvp.Value > 1)
                     itemLabel += $" × {kvp.Value}";
+                if (displayStock && Configuration.Interface.SynthIngredientStockDisplayed)
+                {
+                    Int32 itemAmount = ff9item.FF9Item_GetCount(kvp.Key);
+                    if (itemAmount > 0)
+                    {
+                        itemLabel += $" ({itemAmount})";
+                    }
+                }
             }
             if (itemIcon != null)
                 itemIcon.spriteName = spriteName;

--- a/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
+++ b/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
@@ -2241,31 +2241,27 @@ public partial class EventEngine
                 // 3-5: depends on the sps code.
                 // Load Sps (sps type)
                 // Enable Attribute (attribute list, boolean enable/disable)
-                // Set Position (X, -Z, Y)
-                // Set Rotation (angle X, angle Z, angle Y)
+                // Set Position (X, -Y, Z)
+                // Set Rotation (angle X, angle Y, angle Z)
                 // Set Scale (scale factor)
                 // Attach (object's entry to attach, bone number)
                 // Set Fade (fade)
                 // Set Animation Rate (rate)
                 // Set Frame Rate (rate)
                 // Set Frame (value) where the value is factored by 16 to get the frame
-                // Set Position Offset (X, -Z, Y)
+                // Set Position Offset (X, -Y, Z)
                 // Set Depth Offset (depth)
                 Int32 objNo = this.getv1(); // arg1: sps ID.
                 Int32 parmType = this.getv1(); // arg2: sps code.
-                Int32 arg0 = 0;
-                if (eventCodeBinary == EBin.event_code_binary.SPS)
-                    arg0 = this.getv2();
-                else
-                    arg0 = this.getv1();
-                Int32 arg1 = this.getv2();
+                Int32 arg1 = (eventCodeBinary == EBin.event_code_binary.SPS) ? this.getv2() : this.getv1();
                 Int32 arg2 = this.getv2();
+                Int32 arg3 = this.getv2();
                 if (this.gMode == 1)
-                    this.fieldSps.SetObjParm(objNo, parmType, arg0, arg1, arg2);
+                    this.fieldSps.SetObjParm(objNo, parmType, arg1, arg2, arg3);
                 else if (this.gMode == 2)
-                    HonoluluBattleMain.battleSPS.SetObjParm(objNo, parmType, arg0, arg1, arg2);
+                    HonoluluBattleMain.battleSPS.SetObjParm(objNo, parmType, arg1, arg2, arg3);
                 else if (this.gMode == 3)
-                    ff9.world.WorldSPSSystem.SetObjParm(objNo, parmType, arg0, arg1, arg2);
+                    ff9.world.WorldSPSSystem.SetObjParm(objNo, parmType, arg1, arg2, arg3);
                 return 0;
             }
             case EBin.event_code_binary.FULLMEMBER: // 0xB4, "SetPartyReserve", "Define the party member availability for a future Party call"

--- a/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
+++ b/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
@@ -349,7 +349,16 @@ public partial class EventEngine
                     }
                     else if (mapNo == 2211 && scCounter == 9200 && (po.sid == 5 || po.sid == 6) && posX == -465 && posZ == -5796) // Kuja ATE: Zorn Thorn position
                     {
-                        posX = (po.sid == 5) ? posX = -200 : posX = 0; //Log.Message("posX:" + posX + " posZ:" + posZ + " po.sid:" + po.sid);
+                        posX = (po.sid == 5) ? -200 : 0; //Log.Message("posX:" + posX + " posZ:" + posZ + " po.sid:" + po.sid);
+                    }
+                    else if (mapNo == 2600 && scCounter == 10700 && po.sid == 8 && Configuration.Graphics.WidescreenSupport && posX == 1173 && posZ == -1685) // Dagga appears in frame
+                    {
+                        posZ = -1985; // Log.Message("posX" + posX + " posZ" + posZ);
+                    }
+                    else if (mapNo == 2651 && scCounter == 10890 && po.sid == 4 && Configuration.Graphics.WidescreenSupport && posX == 1449 && posZ == -6844) // Mikito appears in frame
+                    {
+                        posX = 1749;
+                        posZ = -7244; // Log.Message("posX" + posX + " posZ" + posZ);
                     }
                     else if (mapNo == 2914 && scCounter == 11670 && po.sid >= 6 && po.sid <= 10) // Disable fishes shadows
                     {

--- a/Assembly-CSharp/Global/SPS/CommonSPSSystem.cs
+++ b/Assembly-CSharp/Global/SPS/CommonSPSSystem.cs
@@ -113,7 +113,11 @@ public class CommonSPSSystem
     private Vector3 adjustSpsPrecise(String name, Vector3 pos)
     {
         Int16 MapNo = FF9StateSystem.Common.FF9.fldMapNo;
-        //Log.Message("if (MapNo == " + MapNo + " && name == " + name + " && pos.x == " + pos.x + " && pos.y == " + pos.y + ")");
+        //Log.Message("if (MapNo == " + MapNo + " && name == \"" + name + "\" && pos.x == " + pos.x + " && pos.y == " + pos.y + " && pos.z == " + pos.z + ")"); // 3D positions, pos.y calculated from bottom
+        if (MapNo == 2215 && name == "SPS_0008" && pos.x == 1330 && pos.y == 1150 && pos.z == 1125)
+        {
+            pos.y = 1025;
+        }
         return pos;
     }
 
@@ -169,7 +173,7 @@ public class CommonSPSSystem
             {
                 sps.meshRenderer.enabled = false;
             }
-            else if (FF9StateSystem.Common.FF9.fldMapNo == 2928 || FF9StateSystem.Common.FF9.fldMapNo == 1206 || FF9StateSystem.Common.FF9.fldMapNo == 1223)
+            else if (FF9StateSystem.Common.FF9.fldMapNo == 1206 || FF9StateSystem.Common.FF9.fldMapNo == 1223 || FF9StateSystem.Common.FF9.fldMapNo == 2928)
             {
                 // Hill of Despair
                 // A. Castle/Queen's Chamber
@@ -201,7 +205,10 @@ public class CommonSPSSystem
         }
         else if (ParmType == SPSConst.OPERATION_SCALE)
         {
-            sps.scale = Arg0;
+            if ((FF9StateSystem.Common.FF9.fldMapNo == 50 && sps.name == "SPS_0001") || (FF9StateSystem.Common.FF9.fldMapNo == 51 && sps.name == "SPS_0000")) // candle lights made a bit bigger
+                sps.scale = (Int32)(Arg0 * 1.30);
+            else
+                sps.scale = Arg0;
         }
         else if (ParmType == SPSConst.OPERATION_CHAR)
         {

--- a/Assembly-CSharp/Global/SPS/CommonSPSSystem.cs
+++ b/Assembly-CSharp/Global/SPS/CommonSPSSystem.cs
@@ -110,6 +110,13 @@ public class CommonSPSSystem
         return true;
     }
 
+    private Vector3 adjustSpsPrecise(String name, Vector3 pos)
+    {
+        Int16 MapNo = FF9StateSystem.Common.FF9.fldMapNo;
+        //Log.Message("if (MapNo == " + MapNo + " && name == " + name + " && pos.x == " + pos.x + " && pos.y == " + pos.y + ")");
+        return pos;
+    }
+
     public void SetObjParm(SPSEffect sps, Int32 ParmType, Int32 Arg0, Int32 Arg1, Int32 Arg2)
     {
         if (ParmType == SPSConst.OPERATION_CHANGE_FIELD)
@@ -176,15 +183,16 @@ public class CommonSPSSystem
         }
         else if (ParmType == SPSConst.OPERATION_POS)
         {
+            Vector3 adjustedFloatPos = adjustSpsPrecise(sps.name, new Vector3((Single)Arg0, -(Single)Arg1, (Single)Arg2));
             if (FF9StateSystem.Common.FF9.fldMapNo == 911 || FF9StateSystem.Common.FF9.fldMapNo == 1911)
             {
                 // Treno/Queen's House
                 if (sps.spsBin != null)
-                    sps.pos = new Vector3(Arg0, -Arg1, Arg2);
+                    sps.pos = adjustedFloatPos;
             }
             else
             {
-                sps.pos = new Vector3(Arg0, -Arg1, Arg2);
+                sps.pos = adjustedFloatPos;
             }
         }
         else if (ParmType == SPSConst.OPERATION_ROT)

--- a/Assembly-CSharp/Global/ShopUI.cs
+++ b/Assembly-CSharp/Global/ShopUI.cs
@@ -709,7 +709,7 @@ public class ShopUI : UIScene
                     if (i < synth.Ingredients.Length && synth.Ingredients[i] != RegularItem.NoItem)
                     {
                         hud[i].Self.SetActive(true);
-                        FF9UIDataTool.DisplayItem(synth.Ingredients[i], hud[i].IconSprite, hud[i].NameLabel, ff9item.FF9Item_GetCount(synth.Ingredients[i]) >= ingredients[synth.Ingredients[i]]);
+                        FF9UIDataTool.DisplayItem(synth.Ingredients[i], hud[i].IconSprite, hud[i].NameLabel, ff9item.FF9Item_GetCount(synth.Ingredients[i]) >= ingredients[synth.Ingredients[i]], true);
                         ingredients[synth.Ingredients[i]]--;
                     }
                     else
@@ -734,7 +734,7 @@ public class ShopUI : UIScene
                 for (Int32 i = 0; i < 2; i++)
                 {
                     hud[i].Self.SetActive(true);
-                    FF9UIDataTool.DisplayMultipleItems(ingrSplit[i], hud[i].IconSprite, hud[i].NameLabel, ingrEnabled[i]);
+                    FF9UIDataTool.DisplayMultipleItems(ingrSplit[i], hud[i].IconSprite, hud[i].NameLabel, ingrEnabled[i], true);
                 }
             }
         }

--- a/Assembly-CSharp/Memoria/Configuration/Access/Interface.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Access/Interface.cs
@@ -23,6 +23,11 @@ namespace Memoria
                 get => Instance._interface.ScanDisplay;
                 set => Instance._interface.ScanDisplay.Value = value;
             }
+            public static Boolean SynthIngredientStockDisplayed
+            {
+                get => Instance._interface.SynthIngredientStockDisplayed;
+                set => Instance._interface.SynthIngredientStockDisplayed.Value = value;
+            }
             public static Int32 BattleRowCount
             {
                 get => Math.Max(1, Instance._interface.BattleRowCount);
@@ -127,6 +132,7 @@ namespace Memoria
                 SaveValue(Instance._interface.Name, Instance._interface.MenuAbilityRowCount);
                 SaveValue(Instance._interface.Name, Instance._interface.MenuEquipRowCount);
                 SaveValue(Instance._interface.Name, Instance._interface.MenuChocographRowCount);
+                SaveValue(Instance._interface.Name, Instance._interface.SynthIngredientStockDisplayed);
             }
         }
     }

--- a/Assembly-CSharp/Memoria/Configuration/Memoria.ini
+++ b/Assembly-CSharp/Memoria/Configuration/Memoria.ini
@@ -186,7 +186,7 @@ GilMax = 0
 	; RopeJumpingIncrement (default 1) Number of points per jump
 	; FrogCatchingIncrement (default 1) Number of frogs per catch
 	; HippaulRacingViviSpeed (default 33) Vivi's speed in the hippaul racing
-	; StealingAlwaysWorks (default 0) 1 = Always steals when move succeeds / 2 = Stealing has a 100% success rate (bandit ability)
+	; StealingAlwaysWorks (default 0) 1 = Always steals when move succeeds / 2 = Stealing has a 100% success rate (bandit ability). Targets the rarest item first.
 	; DisableNameChoice (default 0) Skip the character renaming windows
 	; ExcaliburIINoTimeLimit (default 0) Give Excalibur II even when time is over
 Enabled = 0

--- a/Assembly-CSharp/Memoria/Configuration/Memoria.ini
+++ b/Assembly-CSharp/Memoria/Configuration/Memoria.ini
@@ -239,6 +239,7 @@ DiscardExclusions = 56, 75, 76, 77, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 
 	; BattleMPDamageTextFormat (default empty) Same as above for MP damage
 	; BattleMPRestoreTextFormat (default empty) Same as above for MP heal
 	; FadeDuration (default 40, original game 300) Duration of the fade between interface transitions in milliseconds, navigation cannot occur during transition. Setting it to 0 will allow instant navigation.
+	; SynthIngredientStockDisplayed (default 1) 1 = In synthesis shops, display the amount of ingredients in inventory between "()" / 0 = don't display
 BattleRowCount = 5
 BattleColumnCount = 1
 BattleMenuPosX = -400
@@ -261,6 +262,7 @@ MenuAbilityRowCount = 6
 MenuEquipRowCount = 5
 MenuChocographRowCount = 5
 FadeDuration = 40
+SynthIngredientStockDisplayed = 1
 
 [Fixes]
 Enabled = 1

--- a/Assembly-CSharp/Memoria/Configuration/Structure/InterfaceSection.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Structure/InterfaceSection.cs
@@ -9,6 +9,7 @@ namespace Memoria
         {
             public readonly IniValue<Boolean> PSXBattleMenu;
             public readonly IniValue<Boolean> ScanDisplay;
+            public readonly IniValue<Boolean> SynthIngredientStockDisplayed;
             public readonly IniValue<Int32> BattleRowCount;
             public readonly IniValue<Int32> BattleColumnCount;
             public readonly IniValue<Int32> BattleMenuPosX;
@@ -36,6 +37,7 @@ namespace Memoria
             {
                 PSXBattleMenu = BindBoolean(nameof(PSXBattleMenu), false);
                 ScanDisplay = BindBoolean(nameof(ScanDisplay), true);
+                SynthIngredientStockDisplayed = BindBoolean(nameof(SynthIngredientStockDisplayed), true);
                 BattleRowCount = BindInt32(nameof(BattleRowCount), 5);
                 BattleColumnCount = BindInt32(nameof(BattleColumnCount), 1);
                 BattleMenuPosX = BindInt32(nameof(BattleMenuPosX), -400);

--- a/Memoria.Launcher/Ini/Memoria.ini
+++ b/Memoria.Launcher/Ini/Memoria.ini
@@ -186,7 +186,7 @@ GilMax = 0
 	; RopeJumpingIncrement (default 1) Number of points per jump
 	; FrogCatchingIncrement (default 1) Number of frogs per catch
 	; HippaulRacingViviSpeed (default 33) Vivi's speed in the hippaul racing
-	; StealingAlwaysWorks (default 0) 1 = Always steals when move succeeds / 2 = Stealing has a 100% success rate (bandit ability)
+	; StealingAlwaysWorks (default 0) 1 = Always steals when move succeeds / 2 = Stealing has a 100% success rate (bandit ability). Targets the rarest item first.
 	; DisableNameChoice (default 0) Skip the character renaming windows
 	; ExcaliburIINoTimeLimit (default 0) Give Excalibur II even when time is over
 Enabled = 0

--- a/Memoria.Launcher/Ini/Memoria.ini
+++ b/Memoria.Launcher/Ini/Memoria.ini
@@ -239,6 +239,7 @@ DiscardExclusions = 56, 75, 76, 77, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 
 	; BattleMPDamageTextFormat (default empty) Same as above for MP damage
 	; BattleMPRestoreTextFormat (default empty) Same as above for MP heal
 	; FadeDuration (default 40, original game 300) Duration of the fade between interface transitions in milliseconds, navigation cannot occur during transition. Setting it to 0 will allow instant navigation.
+	; SynthIngredientStockDisplayed (default 1) 1 = In synthesis shops, display the amount of ingredients in inventory between "()" / 0 = don't display
 BattleRowCount = 5
 BattleColumnCount = 1
 BattleMenuPosX = -400
@@ -261,6 +262,7 @@ MenuAbilityRowCount = 6
 MenuEquipRowCount = 5
 MenuChocographRowCount = 5
 FadeDuration = 40
+SynthIngredientStockDisplayed = 1
 
 [Fixes]
 Enabled = 1

--- a/Memoria.Launcher/Memoria/MemoriaIniControl.cs
+++ b/Memoria.Launcher/Memoria/MemoriaIniControl.cs
@@ -1339,7 +1339,7 @@ namespace Memoria.Launcher
                 {
                     RemoveDuplicateKeys(_iniPath);
                     IniFile iniFile = new IniFile(_iniPath);
-                    String _checklatestadded = iniFile.ReadValue("Interface", "FadeDuration"); // check if the latest ini parameter is already there
+                    String _checklatestadded = iniFile.ReadValue("Interface", "SynthIngredientStockDisplayed"); // check if the latest ini parameter is already there
                     if (String.IsNullOrEmpty(_checklatestadded))
                     {
                         MakeIniNotNull("Mod", "FolderNames", "");
@@ -1463,6 +1463,7 @@ namespace Memoria.Launcher
                         MakeIniNotNull("Interface", "MenuEquipRowCount", "5");
                         MakeIniNotNull("Interface", "MenuChocographRowCount", "5");
                         MakeIniNotNull("Interface", "FadeDuration", "40");
+                        MakeIniNotNull("Interface", "SynthIngredientStockDisplayed", "1");
 
                         MakeIniNotNull("Fixes", "Enabled", "1");
                         MakeIniNotNull("Fixes", "KeepRestTimeInBattle", "1");


### PR DESCRIPTION
- Ingredients available in inventory displayed in synth shops #594
- fixed 2 widescreen scenes where characters appeared in frame
- Adjusted sps position in desert palace (#574) and in first room