### PR TITLE
Update Catalog (PSX Sounds + Trance Seel + Better Card Drop)

### DIFF
--- a/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
+++ b/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
@@ -572,9 +572,9 @@ Half exp, 1 Gem abilities, Portraits extended Characters
 
 <Mod>
 	<Name>Trance Seek</Name>
-	<Version>0.3.20</Version>
+	<Version>0.3.21</Version>
 	<InstallationPath>TranceSeek</InstallationPath>
-	<ReleaseDate>2024-02-27</ReleaseDate>
+	<ReleaseDate>2020-08-26</ReleaseDate>
 	<Author>DV</Author>
 	<Description>
 	A hard mod that allows you to experience a new whole adventure! All the monsters and bosses have been redesigned (not only a stats boost but all the AIs are revisited), new skills, mechanics and many other things!
@@ -597,17 +597,24 @@ Half exp, 1 Gem abilities, Portraits extended Characters
 	/_!_\ IMPORTANT : Please read the README file inside the mod folder, the installation is not YET fully automatic ! (Just move 1 or 2 files, don't worry !)
 	</Description>
 	<PatchNotes>
-	- Trance Seek is now compatible with Memoria v2024.05.19 => All features are integrated into Memoria, no need for custom .dll anymore! (Thanks to the Memoria team!)
-	- [WIP] New Mogster dialog boxes about mod information!
-	- Slight correction to the fight against the Guardian of the Earth.
-	- Slight correction of a fight against Zorn and Thorn in the cavern of Gizamaluke where a softlock was possible with Petrify.
-	- Correction of the rocks quest in Passe Condéa.
-	- Fixed a major bug in Meltigemini mechanics.
-	- Correction of Zombies animations on the Iifa Tree/Roots (1652 + 1759).
-	- Fixed Zombies' "Arsenic" spell on the Iifa Tree/Roots (1652 + 1759).
-	- Correction of SA "EX Mode" and "EX Mode+".
-	- Corrected English (US) dialogues on field 352 (Dali/Inn)
-	- Added an extra dialog box at the start of the game concerning Zidane's Trance.
+	- Corrected damage to Zidane's daggers when counterattacking
+	- Tantarian is now immune to Mini (he could have had it with Doom).
+	- Slight script modification against Red Scarlet.
+	- Correction (again...) of Tomberrys' AI in Ypsen Castle.
+	- Restoration of Tomberrys' death animations (which are not used as standard in the game).
+	- Ores cost reduced from 300 to 200 gils.
+	- Review of the cost of all ores, which can now be sold at a higher price (before 1 gil).
+	- Changes some items that can be stolen/earned from certain monsters.
+	- New rebalance and correction of treasures in Chocobo Forest and Chocobo Bay.
+	- Increased the chance of finding a chocograph in Chocobo Bay (33% => 50%).
+	- Corrected the description of the Gizamaluke Staff in some languages.
+	- Added Beatrix to the escape scene on the Invincible at CD3.
+	- Correction of the description of the Suiton item in various languages.
+	- Corrected the description of the following SA items: Devilkiller+, MP+5%, MP+10%.
+	- Debug removed from Memoria.ini
+
+	Known bug: Some animations (e.g. Steiner's Bulwark, Eiko's passive, Zidane's weapon mechanic) have been buggy since the last Memoria release.
+	The most problematic have been temporarily fixed. Under investigation for the next Memoria release.
 	</PatchNotes>
 	<Category>Gameplay</Category>
 	<PreviewFileUrl>https://i.ibb.co/NTbTds6/Logo-Trance-Seek.png</PreviewFileUrl>
@@ -618,12 +625,16 @@ Half exp, 1 Gem abilities, Portraits extended Characters
 
 <Mod>
 	<Name>Playstation Sounds</Name>
-	<Version>2.0</Version>
+	<Version>2.1</Version>
 	<InstallationPath>PlaystationSounds</InstallationPath>
+	<ReleaseDate>2022-03-19</ReleaseDate>
 	<Author>DV</Author>
 	<Description>Replace the sound assets by the PSX sounds (specially Battle + Tetra Master + Miscellaneous).
 More than 1540 sound files fixed!
 	</Description>
+	<PatchNotes>
+		- Improve "Trance Spear" SFX : se510236, se510237, se510238, se510240, se510241 et se510242 (report by Quetzal and SamsamTS)
+	</PatchNotes>
 	<Category>Audio</Category>
 	<Website>https://steamcommunity.com/app/377840/discussions/0/3189117724409401717/</Website>
 	<DownloadUrl>https://www.dropbox.com/scl/fi/mm4tc5k1g2admrl5klw3g/FF9_Sounds_Fix-by-DV.zip?rlkey=d2q5gk289coixe9s4kcdat1ir&amp;dl=1</DownloadUrl>
@@ -642,15 +653,10 @@ Change some card textures (add boss + characters)
 </Mod>
 <Mod>
 	<Name>BetterCardDrop</Name>
-	<Version>1.0</Version>
+	<Version>1.1</Version>
 	<InstallationPath>BetterCardDrop</InstallationPath>
 	<ReleaseDate>2024-05-12</ReleaseDate>
 	<Author>Snouz + DV</Author>
-	<Description>
-		Get the matching card from mobs/bosses !
-		You can use different options to modify the drop rate.
-		Idea by Snouz and made by DV.
-	</Description>
 	<Category>Gameplay</Category>
 	<DownloadUrl>https://www.dropbox.com/scl/fi/jeu88un3m1e0f4qff5b40/BetterCardDrop-by-DV.zip?rlkey=4woy4rml3pwv65wg6tyionc90&amp;dl=1</DownloadUrl>
 	<SubMod>
@@ -677,6 +683,20 @@ Change some card textures (add boss + characters)
 		<Description>Drop rate of 100%</Description>
 		<Priority>4</Priority>
 	</SubMod>
+	<Category>Gameplay</Category>
+	<Description>
+		Get the matching card from mobs/bosses !
+		You can use different options to modify the drop rate.
+		Idea by Snouz and made by DV.
+	</Description>
+	<PatchNotes>
+		- Add a thumbnail (thank you Faospark ! :D)
+		- Merge RandomCard options from Mog Add-ons to BetterCardDrop (by Faospark)
+	</PatchNotes>
+	<Category>Gameplay</Category>
+	<DownloadUrl>https://www.dropbox.com/scl/fi/jeu88un3m1e0f4qff5b40/BetterCardDrop-by-DV.zip?rlkey=4woy4rml3pwv65wg6tyionc90&amp;dl=1</DownloadUrl>
+	<PreviewFileUrl>https://i.ibb.co/q74DHNz/preview-better-cards.png</PreviewFileUrl>
+	<PreviewFile>Thumbnail/BetterCardDrop.png</PreviewFile>
 </Mod>
 <Mod>
 	<Name>Nexus Mods</Name>


### PR DESCRIPTION
Trance Seek update to 0.3.21 :

```
	- Corrected damage to Zidane's daggers when counterattacking
	- Tantarian is now immune to Mini (he could have had it with Doom).
	- Slight script modification against Red Scarlet.
	- Correction (again...) of Tomberrys' AI in Ypsen Castle.
	- Restoration of Tomberrys' death animations (which are not used as standard in the game).
	- Ores cost reduced from 300 to 200 gils.
	- Review of the cost of all ores, which can now be sold at a higher price (before 1 gil).
	- Changes some items that can be stolen/earned from certain monsters.
	- New rebalance and correction of treasures in Chocobo Forest and Chocobo Bay.
	- Increased the chance of finding a chocograph in Chocobo Bay (33% => 50%).
	- Corrected the description of the Gizamaluke Staff in some languages.
	- Added Beatrix to the escape scene on the Invincible at CD3.
	- Correction of the description of the Suiton item in various languages.
	- Corrected the description of the following SA items: Devilkiller+, MP+5%, MP+10%.
	- Debug removed from Memoria.ini

	Known bug: Some animations (e.g. Steiner's Bulwark, Eiko's passive, Zidane's weapon mechanic) have been buggy since the last Memoria release.
	The most problematic have been temporarily fixed. Under investigation for the next Memoria release.
```

Playstations Sounds update to 2.1 :
`- Improve "Trance Spear" SFX : se510236, se510237, se510238, se510240, se510241 et se510242 (report by Quetzal and SamsamTS)`

BetterCardDrop update to 1.1 :
```
- Add a thumbnail (thank you Faospark ! :D)
- Merge RandomCard options from Mog Add-ons to BetterCardDrop (by Faospark)
```