### PR TITLE
Fix Trance Model bone refresh + off set weapon refresh.

### DIFF
--- a/Assembly-CSharp/Global/battle/battle.cs
+++ b/Assembly-CSharp/Global/battle/battle.cs
@@ -534,11 +534,6 @@ public static class battle
             btlsys.btl_load_status |= ff9btl.LOAD_CHR;
             BattleVoice.TriggerOnBattleInOut("BattleStart");
         }
-
-        foreach (BattleUnit next in FF9StateSystem.Battle.FF9Battle.EnumerateBattleUnits())
-        {
-            btl_eqp.InitOffSetWeapon(next);
-        }
     }
 
     private static void BattleSubSystem(FF9StateGlobal sys, FF9StateBattleSystem btlsys)

--- a/Assembly-CSharp/Global/btl_cmd.cs
+++ b/Assembly-CSharp/Global/btl_cmd.cs
@@ -1164,13 +1164,6 @@ public class btl_cmd
                             tranceMessage = BattleMesages.Trance;
                     }
                     UIManager.Battle.SetBattleFollowMessage(tranceMessage);
-                    if (caster.IsPlayer)
-                        caster.Data.dms_geo_id = btl_init.GetModelID(btl_util.getSerialNumber(caster.Data), true);
-                }
-                else
-                {
-                    if (caster.IsPlayer)
-                        caster.Data.dms_geo_id = btl_init.GetModelID(btl_util.getSerialNumber(caster.Data), false);
                 }
                 return true;
             case BattleCommandId.SysDead: // Unused anymore

--- a/Assembly-CSharp/Global/btl_eqp.cs
+++ b/Assembly-CSharp/Global/btl_eqp.cs
@@ -68,17 +68,21 @@ public static class btl_eqp
     {
         for (BTL_DATA btl = FF9StateSystem.Battle.FF9Battle.btl_list.next; btl != null; btl = btl.next)
         {
+            InitOffSetWeapon(btl);
             if (btl.builtin_weapon_mode && btl.bi.disappear == 0 && !btl.is_monster_transform && btl_eqp.EnemyBuiltInWeaponTable.TryGetValue(btl.dms_geo_id, out Int32 weaponBoneID))
-            {
+            {               
+                CharacterSerialNumber serial = btl_util.getSerialNumber(btl);
+                FF9BattleDB.GEO.TryGetKey(btl_mot.BattleParameterList[serial].ModelId, out Int32 NormalgeoId);
+                FF9BattleDB.GEO.TryGetKey(btl_mot.BattleParameterList[serial].TranceModelId, out Int32 TrancegeoId);
                 Transform builtInBone = null;
-                if (btl.gameObject == btl.originalGo)
+                if (btl.dms_geo_id == NormalgeoId)
                 {
                     builtInBone = btl.originalGo.transform.GetChildByName($"bone{weaponBoneID:D3}");
                 }
-                else if (btl.gameObject == btl.tranceGo && btl.bi.player != 0)
+                else if (btl.dms_geo_id == TrancegeoId && btl.bi.player != 0)
                 {
-                    CharacterSerialNumber serial = btl_util.getSerialNumber(btl);
-                    if (btl_mot.BattleParameterList[serial].ModelId == btl_mot.BattleParameterList[serial].TranceModelId)
+
+                    if (btl_mot.BattleParameterList[serial].ModelId == btl_mot.BattleParameterList[serial].TranceModelId || btl_mot.BattleParameterList[serial].TranceParameters)
                         builtInBone = btl.tranceGo.transform.GetChildByName($"bone{weaponBoneID:D3}");
                 }
                 if (builtInBone != null)

--- a/Assembly-CSharp/Global/btl_eqp.cs
+++ b/Assembly-CSharp/Global/btl_eqp.cs
@@ -68,22 +68,16 @@ public static class btl_eqp
     {
         for (BTL_DATA btl = FF9StateSystem.Battle.FF9Battle.btl_list.next; btl != null; btl = btl.next)
         {
-            InitOffSetWeapon(btl);
             if (btl.builtin_weapon_mode && btl.bi.disappear == 0 && !btl.is_monster_transform && btl_eqp.EnemyBuiltInWeaponTable.TryGetValue(btl.dms_geo_id, out Int32 weaponBoneID))
-            {               
-                CharacterSerialNumber serial = btl_util.getSerialNumber(btl);
-                FF9BattleDB.GEO.TryGetKey(btl_mot.BattleParameterList[serial].ModelId, out Int32 NormalgeoId);
-                FF9BattleDB.GEO.TryGetKey(btl_mot.BattleParameterList[serial].TranceModelId, out Int32 TrancegeoId);
+            {
                 Transform builtInBone = null;
-                if (btl.dms_geo_id == NormalgeoId)
+                if (btl.gameObject == btl.originalGo)
                 {
                     builtInBone = btl.originalGo.transform.GetChildByName($"bone{weaponBoneID:D3}");
                 }
-                else if (btl.dms_geo_id == TrancegeoId && btl.bi.player != 0)
+                else if (btl.gameObject == btl.tranceGo && btl.bi.player != 0)
                 {
-
-                    if (btl_mot.BattleParameterList[serial].ModelId == btl_mot.BattleParameterList[serial].TranceModelId || btl_mot.BattleParameterList[serial].TranceParameters)
-                        builtInBone = btl.tranceGo.transform.GetChildByName($"bone{weaponBoneID:D3}");
+                    builtInBone = btl.tranceGo.transform.GetChildByName($"bone{weaponBoneID:D3}");
                 }
                 if (builtInBone != null)
                     builtInBone.localScale = SCALE_INVISIBLE;

--- a/Assembly-CSharp/Global/btl_vfx.cs
+++ b/Assembly-CSharp/Global/btl_vfx.cs
@@ -207,6 +207,7 @@ public static class btl_vfx
             btl.battleModelIsRendering = true;
             btl.tranceGo.SetActive(true);
             btl.ChangeModel(btl.tranceGo);
+            btl.dms_geo_id = btl_init.GetModelID(serialNo, isTrance);
             GeoTexAnim.geoTexAnimPlay(btl.tranceTexanimptr, 2);
         }
         else
@@ -236,18 +237,6 @@ public static class btl_vfx
         geo.geoAttach(btl.weapon_geo, btl.gameObject, btl.weapon_bone);
         //btl_eqp.InitWeapon(FF9StateSystem.Common.FF9.player[(CharacterId)btl.bi.slot_no], btl);
         AnimationFactory.AddAnimToGameObject(btl.gameObject, btl_mot.BattleParameterList[serialNo].ModelId, true);
-
-        if (btlParam.WeaponOffset.Any(off => off != 0f)) // Don't edit values if all values are 0
-        {
-            Single[] CurrentWeaponOffset;
-            if (isTrance && btlParam.TranceWeaponOffset.Any(off => off != 0f))
-                CurrentWeaponOffset = btlParam.TranceWeaponOffset;
-            else
-                CurrentWeaponOffset = btlParam.WeaponOffset;
-
-            btl.weapon_geo.transform.localPosition = new Vector3(CurrentWeaponOffset[0], CurrentWeaponOffset[1], CurrentWeaponOffset[2]);
-            btl.weapon_geo.transform.localRotation = Quaternion.Euler(CurrentWeaponOffset[3], CurrentWeaponOffset[4], CurrentWeaponOffset[5]);
-        }
     }
 
     public static SpecialEffect GetPlayerAttackVfx(BTL_DATA btl)


### PR DESCRIPTION
I found 2 bugs when my previous PR was merged with Tir's modifications : 
- The Trance Model parameter was not compatible when a model try a hide his weapon (in my example, with Baku <-> King Leo)
- When Mikoto get into Trance, her weapon offset rotation is reset to zero.

These two bugs are fixed now => Tested with Scan also and no issue.

I remove WeaponOffset check from `battle.BattleLoadLoop` and `btl_vfx.SetTranceModel` since it's now in `btl_eqp.ProcessBuiltInWeapon()`, refresh continuously the `InitOffSetWeapon(btl)`

Also, i delete the change on `caster.Data.dms_geo_id` in `BattleCommandId.SysTrans` from `btl_cmd.CheckCommandCondition` => The reason is this change is quite imprecise when a character get into Trance, it's better to make this change in `btl_vfx.SetTranceModel`. In that way, we prevent to have weird things when a character use `EnemyBuiltInWeaponTable` in his Normal and Trance model, like loosing his head during the transformation instead of his weapon.

To finish, i change the condition in btl_eqp.ProcessBuiltInWeapon() by using the `dms_geo_id` => More precise imo and prevent some bugs. (typically, the hidden weapon in his Trance model).