### PR TITLE
Fix Custom Anim for BTL monster (on Init)

### DIFF
--- a/Assembly-CSharp/Global/btl_init.cs
+++ b/Assembly-CSharp/Global/btl_init.cs
@@ -509,6 +509,11 @@ public static class btl_init
                 btl.base_pos[0] = btl.evt.posBattle[0];
                 btl.base_pos[1] = btl.evt.posBattle[1];
                 btl.base_pos[2] = btl.evt.posBattle[2];
+                for (Int16 j = 0; j < btl.mot.Length; j++) // [DV] Check each anims if a clip exist, otherwise create them (if we don't that for custom anim, the battle is frozen).
+                {
+                    if (btl.gameObject.GetComponent<Animation>().GetClip(btl.mot[j]) == null)
+                        AnimationFactory.AddAnimWithAnimatioName(btl.gameObject, btl.mot[j]);
+                }
                 btl.currentAnimationName = btl.mot[btl.bi.def_idle];
                 btl.evt.animFrame = (Byte)(Comn.random8() % GeoAnim.geoAnimGetNumFrames(btl));
             }


### PR DESCRIPTION
Here is a very old bug (and quite specific) that bother me for quite some time!

Here's the problem: when we use custom animations for models in combat on their btl.mot (meaning `Idle, Idle Alt, Hit, Hit Alt, Death and Death Alt`), they can't use them... (the battle is frozen and it's a softlock)

After spending an ENTIRE NIGHT (due to a serious lack of knowledge of all things about anim), I finally found the problem: these custom animations don't have an associated clip!

So you have to declare them so that there's no more problem: I've put them in the `btl_init`, but maybe you can put them somewhere else to make it cleaner... will see, will see ! 👀 