### PR TITLE
Improve Magic Sword .seq

### DIFF
--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef212/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef212/PlayerSequence.seq
@@ -27,7 +27,7 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-WaitSFXDone: SFX=Fire_Sword ; Reflect=True
+Wait: Time=27
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef212/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef212/PlayerSequence.seq
@@ -27,11 +27,12 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-Wait: Time=27
+Wait: Time=20
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster
 PlayAnimation: Char=Caster ; Anim=Idle
 WaitTurn: Char=Caster
+WaitSFXDone: SFX=Fire_Sword ; Reflect=True
 ActivateReflect
 WaitReflect

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef213/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef213/PlayerSequence.seq
@@ -27,7 +27,7 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-WaitSFXDone: SFX=Fira_Sword ; Reflect=True
+Wait: Time=56
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef213/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef213/PlayerSequence.seq
@@ -27,11 +27,12 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-Wait: Time=56
+Wait: Time=47
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster
 PlayAnimation: Char=Caster ; Anim=Idle
 WaitTurn: Char=Caster
+WaitSFXDone: SFX=Fira_Sword ; Reflect=True
 ActivateReflect
 WaitReflect

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef214/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef214/PlayerSequence.seq
@@ -34,5 +34,6 @@ Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster
 PlayAnimation: Char=Caster ; Anim=Idle
 WaitTurn: Char=Caster
+WaitSFXDone: SFX=Firaga_Sword ; Reflect=True
 ActivateReflect
 WaitReflect

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef214/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef214/PlayerSequence.seq
@@ -28,7 +28,7 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-WaitSFXDone: SFX=Firaga_Sword ; Reflect=True
+Wait: Time=56
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef215/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef215/PlayerSequence.seq
@@ -28,7 +28,7 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-WaitSFXDone: SFX=Thunder_Sword ; Reflect=True
+Wait: Time=39
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef215/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef215/PlayerSequence.seq
@@ -28,11 +28,12 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-Wait: Time=39
+Wait: Time=30
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster
 PlayAnimation: Char=Caster ; Anim=Idle
 WaitTurn: Char=Caster
+WaitSFXDone: SFX=Thunder_Sword ; Reflect=True
 ActivateReflect
 WaitReflect

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef216/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef216/PlayerSequence.seq
@@ -28,7 +28,7 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-WaitSFXDone: SFX=Thundara_Sword ; Reflect=True
+Wait: Time=59
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef216/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef216/PlayerSequence.seq
@@ -28,11 +28,12 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-Wait: Time=59
+Wait: Time=50
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster
 PlayAnimation: Char=Caster ; Anim=Idle
 WaitTurn: Char=Caster
+WaitSFXDone: SFX=Thundara_Sword ; Reflect=True
 ActivateReflect
 WaitReflect

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef217/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef217/PlayerSequence.seq
@@ -28,11 +28,12 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-Wait: Time=67
+Wait: Time=56
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster
 PlayAnimation: Char=Caster ; Anim=Idle
 WaitTurn: Char=Caster
+WaitSFXDone: SFX=Thundaga_Sword ; Reflect=True
 ActivateReflect
 WaitReflect

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef217/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef217/PlayerSequence.seq
@@ -28,7 +28,7 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-WaitSFXDone: SFX=Thundaga_Sword ; Reflect=True
+Wait: Time=67
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef218/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef218/PlayerSequence.seq
@@ -27,11 +27,12 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-Wait: Time=45
+Wait: Time=36
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster
 PlayAnimation: Char=Caster ; Anim=Idle
 WaitTurn: Char=Caster
+WaitSFXDone: SFX=Blizzard_Sword ; Reflect=True
 ActivateReflect
 WaitReflect

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef218/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef218/PlayerSequence.seq
@@ -27,7 +27,7 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-WaitSFXDone: SFX=Blizzard_Sword ; Reflect=True
+Wait: Time=45
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef219/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef219/PlayerSequence.seq
@@ -27,7 +27,7 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-WaitSFXDone: SFX=Blizzara_Sword ; Reflect=True
+Wait: Time=55
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef219/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef219/PlayerSequence.seq
@@ -27,11 +27,12 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-Wait: Time=55
+Wait: Time=48
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster
 PlayAnimation: Char=Caster ; Anim=Idle
 WaitTurn: Char=Caster
+WaitSFXDone: SFX=Blizzara_Sword ; Reflect=True
 ActivateReflect
 WaitReflect

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef220/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef220/PlayerSequence.seq
@@ -27,7 +27,7 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-WaitSFXDone: SFX=Blizzaga_Sword ; Reflect=True
+Wait: Time=72
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef220/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef220/PlayerSequence.seq
@@ -27,11 +27,12 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-Wait: Time=72
+Wait: Time=62
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster
 PlayAnimation: Char=Caster ; Anim=Idle
 WaitTurn: Char=Caster
+WaitSFXDone: SFX=Blizzaga_Sword ; Reflect=True
 ActivateReflect
 WaitReflect

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef221/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef221/PlayerSequence.seq
@@ -27,7 +27,7 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-WaitSFXDone: SFX=Bio_Sword ; Reflect=True
+Wait: Time=57
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef221/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef221/PlayerSequence.seq
@@ -18,12 +18,12 @@ WaitAnimation: Char=Vivi
 Turn: Char=Vivi ; BaseAngle=Default ; Time=4
 PlayAnimation: Char=Caster ; Anim=MP_SET
 WaitAnimation: Char=Caster
-PlaySFX: SFX=Bio_Sword ; Reflect=True
 MoveToTarget: Char=Caster ; Target=AllTargets ; Distance=600 ; UseCollisionRadius=True ; Anim=MP_RUN
 Turn: Char=Caster ; BaseAngle=AllTargets ; Time=10
 WaitMove: Char=Caster
 MoveToTarget: Char=Caster ; Target=AllTargets ; Distance=0 ; UseCollisionRadius=True ; Anim=MP_RUN_TO_ATTACK
 WaitMove: Char=Caster
+PlaySFX: SFX=Bio_Sword ; Reflect=True
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef221/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef221/PlayerSequence.seq
@@ -27,11 +27,12 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-Wait: Time=57
+Wait: Time=50
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster
 PlayAnimation: Char=Caster ; Anim=Idle
 WaitTurn: Char=Caster
+WaitSFXDone: SFX=Bio_Sword ; Reflect=True
 ActivateReflect
 WaitReflect

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef221/Sequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef221/Sequence.seq
@@ -2,7 +2,7 @@
 
 PlaySound: Sound=2433
 PlaySound: Sound=2434
-Wait: Time=15
+Wait: Time=2
 PlaySound: Sound=159
 PlaySound: Sound=142
 PlaySound: Sound=252

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef222/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef222/PlayerSequence.seq
@@ -27,11 +27,12 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-Wait: Time=61
+Wait: Time=54
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster
 PlayAnimation: Char=Caster ; Anim=Idle
 WaitTurn: Char=Caster
+WaitSFXDone: SFX=Water_Sword ; Reflect=True
 ActivateReflect
 WaitReflect

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef222/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef222/PlayerSequence.seq
@@ -27,7 +27,7 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-WaitSFXDone: SFX=Water_Sword ; Reflect=True
+Wait: Time=61
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef223/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef223/PlayerSequence.seq
@@ -28,7 +28,7 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-WaitSFXDone: SFX=Flare_Sword ; Reflect=True
+Wait: Time=110
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef223/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef223/PlayerSequence.seq
@@ -28,11 +28,12 @@ WaitMove: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-Wait: Time=110
+Wait: Time=92
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster
 PlayAnimation: Char=Caster ; Anim=Idle
 WaitTurn: Char=Caster
+WaitSFXDone: SFX=Flare_Sword ; Reflect=True
 ActivateReflect
 WaitReflect

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef224/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef224/PlayerSequence.seq
@@ -30,7 +30,7 @@ WaitAnimation: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-WaitSFXDone: SFX=Doomsday_Sword ; Reflect=True
+Wait: Time=119
 SetVariable: Variable=cmd_status ; Value=|2 ; Reflect=True
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4

--- a/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef224/PlayerSequence.seq
+++ b/Memoria.Patcher/StreamingAssets/Data/SpecialEffects/ef224/PlayerSequence.seq
@@ -30,12 +30,13 @@ WaitAnimation: Char=Caster
 PlayAnimation: Char=Caster ; Anim=MP_ATTACK
 Wait: Time=5
 PlayAnimation: Char=Caster ; Speed=0
-Wait: Time=119
+Wait: Time=120
 SetVariable: Variable=cmd_status ; Value=|2 ; Reflect=True
 MoveToPosition: Char=Caster ; AbsolutePosition=Default ; Anim=MP_BACK
 Turn: Char=Caster ; BaseAngle=Default ; Time=4
 WaitMove: Caster
 PlayAnimation: Char=Caster ; Anim=Idle
 WaitTurn: Char=Caster
+WaitSFXDone: SFX=Doomsday_Sword ; Reflect=True
 ActivateReflect
 WaitReflect


### PR DESCRIPTION
Remove `WaitSFXDone` from some .seq file (Magic Sword type), to be more precise on the wait juste before Steiner jump back in his position.

It's based on the `Wait` from the `Sequence.seq`, which is quite precise. 
I replace all `WaitSFXDone` by this kind of formula : `WaitSFXDone` => `Wait: Time=(Total Wait from Sequence.seq - 5)`
Except for the one with Doomsday, which is quite long.

Resolve the issue #605 then.