### PR TITLE
Battlemap shaders fixes

### DIFF
--- a/Assembly-CSharp/Global/battlebg.cs
+++ b/Assembly-CSharp/Global/battlebg.cs
@@ -85,6 +85,10 @@ public static class battlebg
                 {
                     material.shader = ShadersLoader.Find("PSX/BattleMap_Plus_Abr_1_Off");
                 }
+                else if (battlebg.nf_BbgNumber == 32 && matID == 3 && text.Contains("a"))
+                {
+                    material.shader = ShadersLoader.Find("PSX/BattleMap_Plus_Abr_1_Off");
+                }
                 else if (text.Contains("a"))
                 {
                     material.shader = ShadersLoader.Find(shaderName + "_Abr_1");

--- a/Assembly-CSharp/Global/battlebg.cs
+++ b/Assembly-CSharp/Global/battlebg.cs
@@ -75,32 +75,31 @@ public static class battlebg
                 Material material = materials[matID];
                 String text = material.name.Replace("(Instance)", String.Empty);
                 material.mainTexture.wrapMode = TextureWrapMode.Clamp; // Fixes PNG Textures having seams between them
-                if (battlebg.nf_BbgNumber == 171 && matID == 0 && shaderName.Contains("Minus")) // Crystal World, Crystal
+                if (text.Contains("a"))
                 {
-                    material.shader = ShadersLoader.Find("PSX/BattleMap_Moon");
-                }
-                else if (text.Contains("a"))
-                {
-                    if (battlebg.nf_BbgNumber == 92 // Desert Palace, Dock
-                      || battlebg.nf_BbgNumber == 52 // Cleyra's Trunk, Inside, Sandfall
-                      || battlebg.nf_BbgNumber == 57 // Clayra outpost waterfall
-                      || battlebg.nf_BbgNumber == 32) // Oeilvert bridge flames
+                    if (battlebg.nf_BbgNumber == 21) // Duel Amarant Zidane
+                        material.shader = ShadersLoader.Find("PSX/BattleMap_Plus_Abr_0_Substract"); // Apply "Substract" (light colors darken the image)
+                    else if (battlebg.nf_BbgNumber == 171) // Crystal World, ball
+                        material.shader = ShadersLoader.Find("PSX/BattleMap_Moon");
+                    else if (battlebg.nf_BbgNumber == 92 // Desert Palace, Dock
+                          || battlebg.nf_BbgNumber == 52 // Cleyra's Trunk, Inside, Sandfall
+                          || battlebg.nf_BbgNumber == 57 // Clayra outpost waterfall
+                          || battlebg.nf_BbgNumber == 32) // Oeilvert bridge flames
                         material.shader = ShadersLoader.Find("PSX/BattleMap_Plus_Abr_1_Off");
                     else
                         material.shader = ShadersLoader.Find(shaderName + "_Abr_1");
                 }
-                else if (text.Contains("s"))
+                else if (text.Contains("s")) // 23-3, 25-8
                 {
-                    material.shader = ShadersLoader.Find(shaderName + "_Abr_0");
-                    material.SetColor("_Color", new Color32(Byte.MaxValue, Byte.MaxValue, Byte.MaxValue, 110));
+                    material.shader = ShadersLoader.Find("PSX/BattleMap_Plus_Abr_0_Multiply"); // Apply "Multiply" (darkens)
                 }
                 else
                 {
                     material.shader = ShadersLoader.Find(shaderName);
                     if (shaderName.CompareTo("PSX/BattleMap_Ground") == 0 && !(battlebg.nf_BbgNumber == 57 && matID == 0)) // Exception Clayra outpost waterfall, for ground to appear on top of waterfall
-                        material.SetInt("_ZWrite", 0); // DEBUG: Can't make the default value in "_ZWrite ("ZWrite", Int) = 0" works correctly for some reason
+                        material.SetInt("_ZWrite", 0); // ZWrite 0 to ignore depth buffer (1 to activate), Ground is the only one that was set to 1
                 }
-                //Log.Message("SetMaterialShader - go:" + go.name + " rendIdx:" + rendID + " battlebg.nf_BbgNumber:" + battlebg.nf_BbgNumber + " matID:" + matID + " shaderName:" + shaderName + " shader:" + text + " _ZWrite:" + material.GetInt("_ZWrite"));
+                //Log.Message("SetMaterialShader - go:" + go.name + " rendIdx:" + rendID + " battlebg.nf_BbgNumber:" + battlebg.nf_BbgNumber + " matID:" + matID + " shaderName:" + shaderName + " text:\"" + text + "\" _ZWrite:" + material.GetInt("_ZWrite") + " renderqueue:" + material.shader.renderQueue);
             }
         }
     }

--- a/Assembly-CSharp/Global/battlebg.cs
+++ b/Assembly-CSharp/Global/battlebg.cs
@@ -79,19 +79,15 @@ public static class battlebg
                 {
                     material.shader = ShadersLoader.Find("PSX/BattleMap_Moon");
                 }
-                else if ((battlebg.nf_BbgNumber == 92 && matID == 3 && shaderName.Contains("Plus")) // Desert Palace, Dock
-                      || (battlebg.nf_BbgNumber == 52 && matID == 6 && shaderName.Contains("Plus")) // Cleyra's Trunk, Inside, Sandfall
-                      || (battlebg.nf_BbgNumber == 57 && matID == 0 && text.Contains("a"))) // Clayra outpost waterfall
-                {
-                    material.shader = ShadersLoader.Find("PSX/BattleMap_Plus_Abr_1_Off");
-                }
-                else if (battlebg.nf_BbgNumber == 32 && matID == 3 && text.Contains("a"))
-                {
-                    material.shader = ShadersLoader.Find("PSX/BattleMap_Plus_Abr_1_Off");
-                }
                 else if (text.Contains("a"))
                 {
-                    material.shader = ShadersLoader.Find(shaderName + "_Abr_1");
+                    if (battlebg.nf_BbgNumber == 92 // Desert Palace, Dock
+                      || battlebg.nf_BbgNumber == 52 // Cleyra's Trunk, Inside, Sandfall
+                      || battlebg.nf_BbgNumber == 57 // Clayra outpost waterfall
+                      || battlebg.nf_BbgNumber == 32) // Oeilvert bridge flames
+                        material.shader = ShadersLoader.Find("PSX/BattleMap_Plus_Abr_1_Off");
+                    else
+                        material.shader = ShadersLoader.Find(shaderName + "_Abr_1");
                 }
                 else if (text.Contains("s"))
                 {

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -886,7 +886,10 @@ namespace Memoria.Assets
                 if (geoList[index].Kind == MODEL_KIND_NORMAL)
                     currentModel = ModelFactory.CreateModel(geoList[index].Name);
                 else if (geoList[index].Kind == MODEL_KIND_BBG)
+                {
                     currentModel = ModelFactory.CreateModel($"BattleMap/BattleModel/battleMap_all/{geoList[index].Name}/{geoList[index].Name}", true);
+                    battlebg.nf_BbgNumber = Int32.Parse(geoList[index].Name.Replace("BBG_B", ""));
+                }
                 else if (geoList[index].Kind == MODEL_KIND_BBG_OBJ)
                     currentModel = ModelFactory.CreateModel($"BattleMap/BattleModel/battleMap_all/{geoList[index].Name}/{geoList[index].Name}");
                 else

--- a/Memoria.Patcher/Memoria.Patcher.csproj
+++ b/Memoria.Patcher/Memoria.Patcher.csproj
@@ -3539,6 +3539,12 @@
     <None Include="StreamingAssets\Shaders\PSX\BattleMap_Plus_Abr_1_Off.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="StreamingAssets\Shaders\PSX\BattleMap_Plus_Abr_0_Substract.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="StreamingAssets\Shaders\PSX\BattleMap_Plus_Abr_0_Multiply.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="StreamingAssets\Shaders\PSX\BattleMap_SelectCursor_Abr_1.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Memoria.Patcher/StreamingAssets/Shaders/PSX/BattleMap_Plus_Abr_0_Multiply.txt
+++ b/Memoria.Patcher/StreamingAssets/Shaders/PSX/BattleMap_Plus_Abr_0_Multiply.txt
@@ -1,0 +1,139 @@
+Shader "PSX/BattleMap_Plus_Abr_0_Multiply" {
+	Properties {
+		_Color ("Tint Color", Color) = (0.5,0.5,0.5,0.5)
+		_MainTex ("Particle Texture", 2D) = "white" { }
+		_InvFade ("Soft Particles Factor", Range(0.01,3)) = 1
+		_Intensity ("Intensity", Float) = 128
+	}
+	SubShader { 
+		Tags { "QUEUE"="AlphaTest+3" "IGNOREPROJECTOR"="true" "RenderType"="TransparentCutout" }
+		Pass {
+			Tags { "QUEUE"="AlphaTest+3" "IGNOREPROJECTOR"="true" "RenderType"="TransparentCutout" }
+			Blend Zero SrcColor
+			ColorMask RGB
+			GpuProgramID 30279
+			Program "vp" {
+				SubProgram "d3d9 " {
+					Keywords { "SOFTPARTICLES_OFF" }
+					Bind "vertex" Vertex
+					Bind "color" Color
+					Bind "texcoord" TexCoord0
+					Matrix 0 [glstate_matrix_modelview0]
+					Matrix 4 [glstate_matrix_projection]
+					Vector 9 [_MainTex_ST]
+					Vector 8 [_ProjectionParams]
+					"vs_2_0
+						def c10, 20, 1, 60000, 0
+						dcl_position v0
+						dcl_color v1
+						dcl_texcoord v2
+						dp4 r0.x, c0, v0
+						dp4 r0.y, c1, v0
+						dp4 r0.w, c3, v0
+						dp4 r0.z, c2, v0
+						dp4 r1.x, c7, r0
+						rcp r1.x, r1.x
+						dp4 r2.x, c4, r0
+						dp4 r2.y, c5, r0
+						mov r3.xyw, r0
+						mul oPos.xy, r1.x, r2
+						mov r0.xw, c10.xyzy
+						add r0.x, r0.x, c8.y
+						add r3.z, -r0.x, r0.z
+						sge r0.x, r0.z, -r0.x
+						dp4 r0.y, c7, r3
+						dp4 r0.z, c6, r3
+						rcp r0.y, r0.y
+						mul r0.z, r0.y, r0.z
+						add r1.xy, -r0.zwzw, c10.zyzw
+						mad oPos.zw, r0.x, r1.xyxy, r0
+						mad oT0.xy, v2, c9, c9.zwzw
+						mov oD0, v1
+						
+						"
+				}
+				SubProgram "d3d9 " {
+					Keywords { "SOFTPARTICLES_ON" }
+					Bind "vertex" Vertex
+					Bind "color" Color
+					Bind "texcoord" TexCoord0
+					Matrix 0 [glstate_matrix_modelview0]
+					Matrix 4 [glstate_matrix_projection]
+					Vector 9 [_MainTex_ST]
+					Vector 8 [_ProjectionParams]
+					"vs_2_0
+						def c10, 20, 1, 60000, 0
+						dcl_position v0
+						dcl_color v1
+						dcl_texcoord v2
+						dp4 r0.x, c0, v0
+						dp4 r0.y, c1, v0
+						dp4 r0.w, c3, v0
+						dp4 r0.z, c2, v0
+						dp4 r1.x, c7, r0
+						rcp r1.x, r1.x
+						dp4 r2.x, c4, r0
+						dp4 r2.y, c5, r0
+						mov r3.xyw, r0
+						mul oPos.xy, r1.x, r2
+						mov r0.xw, c10.xyzy
+						add r0.x, r0.x, c8.y
+						add r3.z, -r0.x, r0.z
+						sge r0.x, r0.z, -r0.x
+						dp4 r0.y, c7, r3
+						dp4 r0.z, c6, r3
+						rcp r0.y, r0.y
+						mul r0.z, r0.y, r0.z
+						add r1.xy, -r0.zwzw, c10.zyzw
+						mad oPos.zw, r0.x, r1.xyxy, r0
+						mad oT0.xy, v2, c9, c9.zwzw
+						mov oD0, v1
+						
+						"
+				}
+			}
+			Program "fp" {
+				SubProgram "d3d9 " {
+					Keywords { "SOFTPARTICLES_OFF" }
+					Vector 0 [_Color]
+					Float 1 [_Intensity]
+					SetTexture 0 [_MainTex] 2D 0
+					"ps_2_0
+						def c2, 0.0078125, 0, 0, 0
+						dcl v0
+						dcl t0.xy
+						dcl_2d s0
+						texld r0, t0, s0
+						mul r1, v0, c0
+						mul_pp r0, r0, r1
+						mov r1.x, c1.x
+						mul r1.x, r1.x, c2.x
+						mul_pp r0.xyz, r0, r1.x
+						mov_pp oC0, r0
+						
+						"
+				}
+				SubProgram "d3d9 " {
+					Keywords { "SOFTPARTICLES_ON" }
+					Vector 0 [_Color]
+					Float 1 [_Intensity]
+					SetTexture 0 [_MainTex] 2D 0
+					"ps_2_0
+						def c2, 0.0078125, 0, 0, 0
+						dcl v0
+						dcl t0.xy
+						dcl_2d s0
+						texld r0, t0, s0
+						mul r1, v0, c0
+						mul_pp r0, r0, r1
+						mov r1.x, c1.x
+						mul r1.x, r1.x, c2.x
+						mul_pp r0.xyz, r0, r1.x
+						mov_pp oC0, r0
+						
+						"
+				}
+			}
+		}
+	}
+}

--- a/Memoria.Patcher/StreamingAssets/Shaders/PSX/BattleMap_Plus_Abr_0_Substract.txt
+++ b/Memoria.Patcher/StreamingAssets/Shaders/PSX/BattleMap_Plus_Abr_0_Substract.txt
@@ -1,0 +1,139 @@
+Shader "PSX/BattleMap_Plus_Abr_0_Substract" {
+	Properties {
+		_Color ("Tint Color", Color) = (0.5,0.5,0.5,0.5)
+		_MainTex ("Particle Texture", 2D) = "white" { }
+		_InvFade ("Soft Particles Factor", Range(0.01,3)) = 1
+		_Intensity ("Intensity", Float) = 128
+	}
+	SubShader { 
+		Tags { "QUEUE"="AlphaTest+3" "IGNOREPROJECTOR"="true" "RenderType"="TransparentCutout" }
+		Pass {
+			Tags { "QUEUE"="AlphaTest+3" "IGNOREPROJECTOR"="true" "RenderType"="TransparentCutout" }
+			Blend Zero OneMinusSrcColor
+			ColorMask RGB
+			GpuProgramID 30279
+			Program "vp" {
+				SubProgram "d3d9 " {
+					Keywords { "SOFTPARTICLES_OFF" }
+					Bind "vertex" Vertex
+					Bind "color" Color
+					Bind "texcoord" TexCoord0
+					Matrix 0 [glstate_matrix_modelview0]
+					Matrix 4 [glstate_matrix_projection]
+					Vector 9 [_MainTex_ST]
+					Vector 8 [_ProjectionParams]
+					"vs_2_0
+						def c10, 20, 1, 60000, 0
+						dcl_position v0
+						dcl_color v1
+						dcl_texcoord v2
+						dp4 r0.x, c0, v0
+						dp4 r0.y, c1, v0
+						dp4 r0.w, c3, v0
+						dp4 r0.z, c2, v0
+						dp4 r1.x, c7, r0
+						rcp r1.x, r1.x
+						dp4 r2.x, c4, r0
+						dp4 r2.y, c5, r0
+						mov r3.xyw, r0
+						mul oPos.xy, r1.x, r2
+						mov r0.xw, c10.xyzy
+						add r0.x, r0.x, c8.y
+						add r3.z, -r0.x, r0.z
+						sge r0.x, r0.z, -r0.x
+						dp4 r0.y, c7, r3
+						dp4 r0.z, c6, r3
+						rcp r0.y, r0.y
+						mul r0.z, r0.y, r0.z
+						add r1.xy, -r0.zwzw, c10.zyzw
+						mad oPos.zw, r0.x, r1.xyxy, r0
+						mad oT0.xy, v2, c9, c9.zwzw
+						mov oD0, v1
+						
+						"
+				}
+				SubProgram "d3d9 " {
+					Keywords { "SOFTPARTICLES_ON" }
+					Bind "vertex" Vertex
+					Bind "color" Color
+					Bind "texcoord" TexCoord0
+					Matrix 0 [glstate_matrix_modelview0]
+					Matrix 4 [glstate_matrix_projection]
+					Vector 9 [_MainTex_ST]
+					Vector 8 [_ProjectionParams]
+					"vs_2_0
+						def c10, 20, 1, 60000, 0
+						dcl_position v0
+						dcl_color v1
+						dcl_texcoord v2
+						dp4 r0.x, c0, v0
+						dp4 r0.y, c1, v0
+						dp4 r0.w, c3, v0
+						dp4 r0.z, c2, v0
+						dp4 r1.x, c7, r0
+						rcp r1.x, r1.x
+						dp4 r2.x, c4, r0
+						dp4 r2.y, c5, r0
+						mov r3.xyw, r0
+						mul oPos.xy, r1.x, r2
+						mov r0.xw, c10.xyzy
+						add r0.x, r0.x, c8.y
+						add r3.z, -r0.x, r0.z
+						sge r0.x, r0.z, -r0.x
+						dp4 r0.y, c7, r3
+						dp4 r0.z, c6, r3
+						rcp r0.y, r0.y
+						mul r0.z, r0.y, r0.z
+						add r1.xy, -r0.zwzw, c10.zyzw
+						mad oPos.zw, r0.x, r1.xyxy, r0
+						mad oT0.xy, v2, c9, c9.zwzw
+						mov oD0, v1
+						
+						"
+				}
+			}
+			Program "fp" {
+				SubProgram "d3d9 " {
+					Keywords { "SOFTPARTICLES_OFF" }
+					Vector 0 [_Color]
+					Float 1 [_Intensity]
+					SetTexture 0 [_MainTex] 2D 0
+					"ps_2_0
+						def c2, 0.0078125, 0, 0, 0
+						dcl v0
+						dcl t0.xy
+						dcl_2d s0
+						texld r0, t0, s0
+						mul r1, v0, c0
+						mul_pp r0, r0, r1
+						mov r1.x, c1.x
+						mul r1.x, r1.x, c2.x
+						mul_pp r0.xyz, r0, r1.x
+						mov_pp oC0, r0
+						
+						"
+				}
+				SubProgram "d3d9 " {
+					Keywords { "SOFTPARTICLES_ON" }
+					Vector 0 [_Color]
+					Float 1 [_Intensity]
+					SetTexture 0 [_MainTex] 2D 0
+					"ps_2_0
+						def c2, 0.0078125, 0, 0, 0
+						dcl v0
+						dcl t0.xy
+						dcl_2d s0
+						texld r0, t0, s0
+						mul r1, v0, c0
+						mul_pp r0, r0, r1
+						mov r1.x, c1.x
+						mul r1.x, r1.x, c2.x
+						mul_pp r0.xyz, r0, r1.x
+						mov_pp oC0, r0
+						
+						"
+				}
+			}
+		}
+	}
+}

--- a/Memoria.Patcher/StreamingAssets/Shaders/PSX/BattleMap_Plus_Abr_1.txt
+++ b/Memoria.Patcher/StreamingAssets/Shaders/PSX/BattleMap_Plus_Abr_1.txt
@@ -6,9 +6,9 @@ Shader "PSX/BattleMap_Plus_Abr_1" {
 		_Intensity ("Intensity", Float) = 128
 	}
 	SubShader { 
-		Tags { "QUEUE"="AlphaTest+3" "IGNOREPROJECTOR"="true" "RenderType"="TransparentCutout" }
+		Tags { "QUEUE"="AlphaTest+4" "IGNOREPROJECTOR"="true" "RenderType"="TransparentCutout" }
 		Pass {
-			Tags { "QUEUE"="AlphaTest+3" "IGNOREPROJECTOR"="true" "RenderType"="TransparentCutout" }
+			Tags { "QUEUE"="AlphaTest+4" "IGNOREPROJECTOR"="true" "RenderType"="TransparentCutout" }
 			ZWrite Off
 			Blend One OneMinusSrcColor
 			ColorMask RGB


### PR DESCRIPTION
- Fixed invisible stage flame
- Fixed Branbal web behind a texture
- Fixed invisible flame in Oeilvert
- Fixed shadows in 2 Lindblum scenes and the Amarant fight
- Model viewer loads correct shaders