### PR TITLE
Fix shader compatibility in AMD GPU

### DIFF
--- a/Memoria.Patcher/Memoria.Patcher.csproj
+++ b/Memoria.Patcher/Memoria.Patcher.csproj
@@ -3368,7 +3368,7 @@
     </Content>
     <Content Include="StreamingAssets\Shaders\PSX\BattleCharacterShaderRef.txt" />
     <Content Include="StreamingAssets\Shaders\PSX\BattleMap_StatusEffect_RealLighting.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="StreamingAssets\Shaders\PSX\BattleMap_StatusEffect_Toon.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/Memoria.Patcher/StreamingAssets/Shaders/PSX/BattleMap_StatusEffect_RealLighting.txt
+++ b/Memoria.Patcher/StreamingAssets/Shaders/PSX/BattleMap_StatusEffect_RealLighting.txt
@@ -30,53 +30,41 @@ Shader "PSX/BattleMap_StatusEffect_RealLighting" {
 					Bind "normal" Normal
 					Matrix 0 [glstate_matrix_modelview0]
 					Matrix 4 [glstate_matrix_projection]
-					Vector 8 [_ProjectionParams]
-					Vector 9 [_MainTex_ST]
-					Vector 10 [_DetailTex_ST]
-					"vs_2_0
-						def c11, 20, 1, 60000, 0
-						def c12, 1, 0, 0, 0
-						def c13, 0.200000003, 0.300000012, 2, 0
-						dcl_position v0
-						dcl_texcoord v1
-						dcl_normal v2
-						dp4 r0.x, c0, v0
-						dp4 r0.y, c1, v0
-						dp4 r0.w, c3, v0
-						dp4 r0.z, c2, v0
-						dp4 r1.x, c7, r0
-						rcp r1.x, r1.x
-						dp4 r2.x, c4, r0
-						dp4 r2.y, c5, r0
-						mov r3.xyw, r0
-						mul oPos.xy, r1.x, r2
-						mov r0.xw, c11.xyzy
-						add r0.x, r0.x, c8.y
-						add r3.z, -r0.x, r0.z
-						sge r0.x, r0.z, -r0.x
-						dp4 r0.y, c7, r3
-						dp4 r0.z, c6, r3
-						rcp r0.y, r0.y
-						mul r0.z, r0.y, r0.z
-						add r1.xy, -r0.zwzw, c11.zyzw
-						mad oPos.zw, r0.x, r1.xyxy, r0
-						mad oT0.xy, v1, c9, c9.zwzw
-						mad oT0.zw, v1.xyxy, c10.xyxy, c10
-						mad r4, v0.xyzx, c12.xxxy, c12.yyyx
-						dp3 r4.x, c0, v2
-                        dp3 r4.y, c1, v2
-                        dp3 r4.z, c2, v2
-                        dp3 r4.w, r4, r4
-                        rsq r4.w, r4.w
-                        mul oT1.xyz, r4.w, r4
-                        mad r5, v0.xyzx, c12.xxxy, c12.yyyx
-                        dp4 r6.x, c0, r5
-                        dp4 r6.y, c1, r5
-                        dp4 r6.z, c2, r5
-                        add r5.xyz, -r6, c13
-                        dp3 r5.w, r5, r5
-                        rsq r5.w, r5.w
-                        mul oT2.xyz, r5.w, r5
+					Vector 8 [_MainTex_ST]
+					Vector 9 [_DetailTex_ST]
+					"vs_3_0
+					    def c10, 0.200000003, 0.300000012, 2, 0
+                        def c11, 1, 0, 0, 0
+                        dcl_position v0
+                        dcl_normal v1
+                        dcl_texcoord v2
+                        dcl_texcoord o0
+                        dcl_texcoord1 o1.xyz
+                        dcl_texcoord2 o2.xyz
+                        dcl_position o3
+                        mad r0, v0.xyzx, c11.xxxy, c11.yyyx
+                        dp4 r1.w, c3, r0
+                        dp4 r1.x, c0, r0
+                        dp4 r1.y, c1, r0
+                        dp4 r1.z, c2, r0
+                        dp4 r2.x, c4, r1
+                        dp4 r2.y, c5, r1
+                        dp4 r2.z, c6, r1
+                        dp4 r2.w, c7, r1
+                        add r0.xyz, -r1, c10
+                        dp3 r1.x, c0, v1
+                        dp3 r1.y, c1, v1
+                        dp3 r1.z, c2, v1
+                        dp3 r0.w, r1, r1
+                        rsq r0.w, r0.w
+                        mul o1.xyz, r0.w, r1
+                        mad o0.xy, v2, c8, c8.zwzw
+                        mad o0.zw, v2.xyxy, c9.xyxy, c9
+                        dp3 r0.w, r0, r0
+                        rsq r0.w, r0.w
+                        mul o2.xyz, r0.w, r0
+                        mad o3.xy, r2.w, c255, r2
+                        mov o3.zw, r2
 						"
 				}
 			}


### PR DESCRIPTION
The realistic battle character shader did not compile succeefully in some GPU.
Mostly AMD user.

## Cause 
While not 100% sure about it. Since I don't have machine with AMD's GPU. But there's some suspcious part of the shader I made. Which might cause the issue - 
The battle character shader was using vs_2_0 assembly code for vertex shader and ps_3_0 assembly code for pixel shader.
This model version difference seems have no trouble in nvidia gpu but might not work in AMD gpu.

> A shader file is a combination of vertex shader & pixel shader.
## Changes
The main difference in code is that **vs_2_0** become **vs_3_0** and changes the contained assembly code accordingly.

This PR make sure the battle character shader use 3_0 version assembly code for both vertex shader and pixel shader.
And according to faospark's test. It fix the issue on his AMD GPU. 

I've let faospark test a modified one and this changes fix the issue on his machine without using 3rd party dll as well.


## Alternative Solution - Install Dxvk (works for AMD users)

Dxvk: https://github.com/doitsujin/dxvk/releases/tag/v2.4
Download and Open the tar file and locate the x64 version. Copy the d3d9.dll and dxgi.dll to 
SteamLibrary\steamapps\common\FINAL FANTASY IX\x64 folder