### PR TITLE
Certif signing: offset code auto-adjustment

### DIFF
--- a/Memoria.Patcher/Program.cs
+++ b/Memoria.Patcher/Program.cs
@@ -118,10 +118,6 @@ namespace Memoria.Patcher
                 }
                 else
                 {
-                    // Confirm! do we want this?
-                    //Console.WriteLine("The Version of Memoria Patcher your using is not signed and is not the offical version");
-                    //Console.WriteLine("If you trust this source press enter to continue, otherwise close this window.");
-                    //Console.ReadLine();
                     // if the file is not signed
                     inputFile.Seek(-0x18, SeekOrigin.End);
 

--- a/Memoria.Patcher/Program.cs
+++ b/Memoria.Patcher/Program.cs
@@ -94,9 +94,9 @@ namespace Memoria.Patcher
                 Assembly assembly = Assembly.GetExecutingAssembly();
                 Module module = assembly.GetModules().First();
                 X509Certificate certificate = module.GetSignerCertificate();
-                // certificates vary slightly in size but are always within a few bys this range is small enough that it's quick but will find the magic number
+                // certificates vary slightly in size but are always within a few bytes this range is small enough that it's quick but will find the magic number if it's there
                 // how to sign this patcher once it's completly built run from Output directory
-                // signtool sign /d "Memoria Patcher for Modding FF9" /td SHA256 /fd SHA256 /sha1 D0E766E285EBE4E93AC723FAE9369495440A67F9 /tr http://timestamp.digicert.com .\Memoria.Patcher.exe 
+                // signtool sign /d "Memoria Patcher for Modding FF9" /td SHA256 /fd SHA256 /sha1 {your certificates SHA1 signature} /tr http://timestamp.digicert.com .\Memoria.Patcher.exe 
                 if (certificate != null)
                 {
                     Console.WriteLine("Memoria.Patcher is Digitally signed, please wait while we validate");
@@ -114,7 +114,7 @@ namespace Memoria.Patcher
                         possition += 1;
                     }
                     if (!Found)
-                        throw new InvalidDataException("File is Signed but could not find magic number, file is corrupt please notify a Memoria Team Member.");
+                        throw new InvalidDataException("File is Signed but could not find magic number, file is corrupt");
                 }
                 else
                 {

--- a/Memoria.Patcher/Program.cs
+++ b/Memoria.Patcher/Program.cs
@@ -91,8 +91,8 @@ namespace Memoria.Patcher
                 BinaryReader br = new BinaryReader(inputFile);
                 try
                 {
-                    // if the file is signed
-                    inputFile.Seek(-0x28B2, SeekOrigin.End);
+                    // if the file is not signed
+                    inputFile.Seek(-3 * 8, SeekOrigin.End);
 
                     magicNumber = br.ReadInt64();
                     if (magicNumber != 0x004149524F4D454D)// MEMORIA\0 
@@ -100,8 +100,10 @@ namespace Memoria.Patcher
                 }
                 catch (Exception ex)
                 {
-                    // if the file is not signed
-                    inputFile.Seek(-3 * 8, SeekOrigin.End);
+                    // if the file is signed this offset might change slightly due to the way signing works.
+                    // you will need to use a Hex editor to make sure that from the M of MEMORIA to the end of the file
+                    // is length you offset this by
+                    inputFile.Seek(-0x28F5, SeekOrigin.End);
 
                     magicNumber = br.ReadInt64();
                     if (magicNumber != 0x004149524F4D454D)// MEMORIA\0 


### PR DESCRIPTION
Certificates slightly vary in size originally we had an offset programmed however it was a pain to get it to line up correctly, as such i have changed the code since the 3'd commit on this branch to scan a range of 544 bytes in the file looking for the magic number if the file is signed. it should always be within this range from all my testing. otherwise it will use the -3*8 which is -0x18 and act as it always did.