### PR TITLE
Trance Seek 0.3.25

### DIFF
--- a/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
+++ b/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
@@ -85,9 +85,9 @@ This is actually a lighter version of Alternate Fantasy, to benefit from its add
 	
 <Mod>
 	<Name>Trance Seek</Name>
-	<Version>0.3.24</Version>
+	<Version>0.3.25</Version>
 	<InstallationPath>TranceSeek</InstallationPath>
-	<ReleaseDate>2024-08-10</ReleaseDate>
+	<ReleaseDate>2024-08-14</ReleaseDate>
 	<Author>DV</Author>
 	<Description>A hard mod that allows you to experience a new whole adventure! All the monsters and bosses have been redesigned (not only a stats boost but all the AIs are revisited), new skills, mechanics and many other things!
 
@@ -106,27 +106,39 @@ This is not an EXTREME hardcore difficult mod: it only adds a higher difficulty 
 It's currently a demo : CD1 + CD2 + CD3 available but almost +30 hours of gameplay !
 Don't hesitate to try!
 
+/_!_\ IMPORTANT /_!_\
 Recommended language : Français / English (UK)
 Not supported language : Japanese</Description>
-	<PatchNotes>- [WIP] Fixed "Sleep" status on bosses (Note: this gives a "freeze" effect on bosses for the moment, waiting for the next Memoria update).
-- Added visual effect for Regen (not definitive).
-- Eiko can now learn "Scan".
-- Correction to the IOverloadDamageModifierScript script, concerning attacks that steal HP or MP (or both).
-- Fixed a bug from a monster's Holy spell that use SFX Firaga under Boomerang effect.
-- Fixed a bug on the "Trance" status, where a character lost all his Trance during a "Combo" attack.
-- Amarant's claws now have an additional effect, as do most weapons.
-- Major fix to SA Proliferation and Proliferation+.
-- Curse and Curse+ have been corrected.
-- Fragility and Fragility+ have been corrected.
-- Beatrix's Illumina has been renamed Judgment, and is now a Magic Weapon attack.
-- Corrected PowerBreak/MagicBreak/ArmorBreak/MentalBreak scripts, which did not take accuracy into account.
-- Trance removes PowerBreak/MagicBreak/ArmorBreak/MentalBreak status.
-- Cleave skill fixed.
-- Correction of the description of Minimum.
-- Limblulline item description corrected.
-- Major fix to RagTime questions, which were buggy in the US version.
-- Moug will not assist Eiko if she is under "Heat".
-- Correction of a softlock in the Alexandria/Pub (field 112)</PatchNotes>
+	<PatchNotes>- Rework of Rackets: now purely magical weapons, they depend on the attacker's magic and the target's magical defense.
+However, the weapon is still subject to physical dodge (and therefore sensitive to Darkness or Vanish).
+
+- The damage formula for "Heavy Spears" on the "Jump" skill has been fixed.
+- Added a description of the effects on the following weapons: Heavy Spears, Boomerangs and Rackets.
+- Improved Heat script on bosses (had a problem with counters).
+- Fix on Gizamaluke's fight (damage problem with "Heat").
+- Fixed "Heat" status script, which could kill bosses and softlock the game.
+- Fix scripts of "PerfectCrit" and "PerfectDodge" statuses.
+- Slight change to Garland's AI, concerning the end of the fight.
+- Fixed some Epitaf battles where softlocks was possible.
+- Correction of the "Doctor" SA, making it compatible with more heals.
+- The cost of the SA "Mug" has been increased from 4 to 6.
+- "Mug" and "Mug+" are now compatible with Eye of the Thief, Bandit+, Master Thief and the steal bonus under Trance.
+- Improved display of stolen items when Zidane attempts to "Mug" with these daggers.
+- Healer+ SA now inflicts 100% damage against zombies (as opposed to 200% previously).
+- Freyja can no longer learn "Healer" and is replaced by a new SA called "Dragon's Eye".
+- SOS-type SA are more precise in their triggering: they can be activated by Poison, for example.
+- SOS Regen cost modified: 5 -> 4.
+- SOS Haste cost modified: 4 -> 3.
+- "Esuna" now correctly removes Old.
+- Changed description of "Throw" command.
+- Corrected "Cook" damage formula.
+- Corrected animations of some Sand Scorpions in Clayra.
+- Changed a Raitaime question in French, which could lead to confusion.
+- Fixed a bug with Prison Cage and Vivi combat, where the AttachObject was incorrect.
+- Fixed the items to be stolen in Tantarian combat.
+- Improved script against the special boss at the entrance to Ypsen Castle at the start of CD3.
+- All new statuses are now correctly removed at the end of combat.
+- Redesign of several codes in AbilityFeatures.</PatchNotes>
 	<Category>Gameplay</Category>
 	<PreviewFileUrl>https://i.ibb.co/NTbTds6/Logo-Trance-Seek.png</PreviewFileUrl>
 	<PreviewFile>Thumbnail/LogoTranceSeek.png</PreviewFile>


### PR DESCRIPTION
### ChangeLog :
- Rework of Rackets: now purely magical weapons, they depend on the attacker's magic and the target's magical defense.
However, the weapon is still subject to physical dodge (and therefore sensitive to Darkness or Vanish).

- The damage formula for "Heavy Spears" on the "Jump" skill has been fixed.
- Added a description of the effects on the following weapons: Heavy Spears, Boomerangs and Rackets.
- Improved Heat script on bosses (had a problem with counters).
- Fix on Gizamaluke's fight (damage problem with "Heat").
- Fixed "Heat" status script, which could kill bosses and softlock the game.
- Fix scripts of "PerfectCrit" and "PerfectDodge" statuses.
- Slight change to Garland's AI, concerning the end of the fight.
- Fixed some Epitaf battles where softlocks was possible.
- Correction of the "Doctor" SA, making it compatible with more heals.
- The cost of the SA "Mug" has been increased from 4 to 6.
- "Mug" and "Mug+" are now compatible with Eye of the Thief, Bandit+, Master Thief and the steal bonus under Trance.
- Improved display of stolen items when Zidane attempts to "Mug" with these daggers.
- Healer+ SA now inflicts 100% damage against zombies (as opposed to 200% previously).
- Freyja can no longer learn "Healer" and is replaced by a new SA called "Dragon's Eye".
- SOS-type SA are more precise in their triggering: they can be activated by Poison, for example.
- SOS Regen cost modified: 5 -> 4.
- SOS Haste cost modified: 4 -> 3.
- "Esuna" now correctly removes Old.
- Changed description of "Throw" command.
- Corrected "Cook" damage formula.
- Corrected animations of some Sand Scorpions in Clayra.
- Changed a Raitaime question in French, which could lead to confusion.
- Fixed a bug with Prison Cage & Vivi combat, where the AttachObject was incorrect.
- Fixed the items to be stolen in Tantarian combat.
- Improved script against the special boss at the entrance to Ypsen Castle at the start of CD3.
- All new statuses are now correctly removed at the end of combat.
- Redesign of several codes in AbilityFeatures.