### PR TITLE
System SHP overlap

### DIFF
--- a/Assembly-CSharp/Global/SPS/BattleSPSSystem.cs
+++ b/Assembly-CSharp/Global/SPS/BattleSPSSystem.cs
@@ -218,7 +218,7 @@ public class BattleSPSSystem : MonoBehaviour
                 this._shpEffects[slot].Init(CommonSPSSystem.SHPPrototypes[shpId]);
                 this._shpEffects[slot].posOffset = extraPos;
             }
-            if (CommonSPSSystem.SHPPrototypes[shpId].OverlapGroup >= 0)
+            if (CommonSPSSystem.SHPPrototypes[shpId].OverlapGroup > 0)
             {
                 KeyValuePair<Int32, Int32> OverlapSHPUnit = new KeyValuePair<Int32, Int32>(unit.Position, CommonSPSSystem.SHPPrototypes[shpId].OverlapGroup);
                 if (_overlapSHPgroup.ContainsKey(OverlapSHPUnit))
@@ -255,7 +255,8 @@ public class BattleSPSSystem : MonoBehaviour
                 go.SetActive(false);
 
             KeyValuePair<Int32, Int32> OverlapSHPUnit = new KeyValuePair<Int32, Int32>(unit.Position, CommonSPSSystem.SHPPrototypes[this._shpEffects[shpIndex].shpId].OverlapGroup);
-            _overlapSHPgroup[OverlapSHPUnit].Remove(this._statusToSHPIndex[effectCode]);
+            if (_overlapSHPgroup.ContainsKey(OverlapSHPUnit))
+                _overlapSHPgroup[OverlapSHPUnit].Remove(this._statusToSHPIndex[effectCode]);
             //this._shpEffects[shpIndex].Unload();
             //this._statusToSHPIndex.Remove(effectCode);
         }

--- a/Assembly-CSharp/Global/SPS/BattleSPSSystem.cs
+++ b/Assembly-CSharp/Global/SPS/BattleSPSSystem.cs
@@ -140,6 +140,28 @@ public class BattleSPSSystem : MonoBehaviour
         if (this._statusToSHPIndex.TryGetValue(effectCode, out Int32 shpIndex))
         {
             SHPEffect shp = this._shpEffects[shpIndex];
+            KeyValuePair<Int32, Int32> OverlapSHPUnit = new KeyValuePair<Int32, Int32>(unit.Position, CommonSPSSystem.SHPPrototypes[shp.shpId].OverlapGroup);
+            if (_overlapSHPgroup.ContainsKey(OverlapSHPUnit))
+            {
+                if (_overlapSHPgroup[OverlapSHPUnit].Count > 1)
+                {
+                    if ((shp.attr & SPSConst.ATTR_OVERLAP_HIDDEN) == 0)
+                    {
+                        if (shp.overlapDuration <= 0)
+                        {
+                            shp.attr |= SPSConst.ATTR_OVERLAP_HIDDEN;
+                            this._shpEffects[shpIndex].overlapDuration = CommonSPSSystem.SHPPrototypes[shp.shpId].TextureCount;
+                            int overlapSHPindex = _overlapSHPgroup[OverlapSHPUnit].FindIndex(a => (a == shpIndex));
+                            overlapSHPindex++;
+
+                            if (overlapSHPindex >= _overlapSHPgroup[OverlapSHPUnit].Count)
+                                this._shpEffects[_overlapSHPgroup[OverlapSHPUnit][0]].attr &= unchecked((Byte)~(SPSConst.ATTR_OVERLAP_HIDDEN + SPSConst.ATTR_LAST_FRAME));
+                            else
+                                this._shpEffects[_overlapSHPgroup[OverlapSHPUnit][overlapSHPindex]].attr &= unchecked((Byte)~(SPSConst.ATTR_OVERLAP_HIDDEN + SPSConst.ATTR_LAST_FRAME));
+                        }
+                    }
+                }
+            }
             shp.attr |= SPSConst.ATTR_VISIBLE | SPSConst.ATTR_UPDATE_THIS_FRAME;
             if (shpPos.HasValue)
                 shp.pos = shpPos.Value;
@@ -182,6 +204,7 @@ public class BattleSPSSystem : MonoBehaviour
             {
                 this._shpEffects[shpIndex].attr |= SPSConst.ATTR_VISIBLE;
                 this._shpEffects[shpIndex].posOffset = extraPos;
+                this._shpEffects[shpIndex].overlapDuration = CommonSPSSystem.SHPPrototypes[shpId].TextureCount;
             }
             else
             {
@@ -194,6 +217,22 @@ public class BattleSPSSystem : MonoBehaviour
                 this._statusToSHPIndex[effectCode] = slot;
                 this._shpEffects[slot].Init(CommonSPSSystem.SHPPrototypes[shpId]);
                 this._shpEffects[slot].posOffset = extraPos;
+            }
+            if (CommonSPSSystem.SHPPrototypes[shpId].OverlapGroup >= 0)
+            {
+                KeyValuePair<Int32, Int32> OverlapSHPUnit = new KeyValuePair<Int32, Int32>(unit.Position, CommonSPSSystem.SHPPrototypes[shpId].OverlapGroup);
+                if (_overlapSHPgroup.ContainsKey(OverlapSHPUnit))
+                {
+                    if (!_overlapSHPgroup[OverlapSHPUnit].Contains(this._statusToSHPIndex[effectCode]))
+                    {
+                        _overlapSHPgroup[OverlapSHPUnit].Add(this._statusToSHPIndex[effectCode]);
+                        this._shpEffects[this._statusToSHPIndex[effectCode]].attr = SPSConst.ATTR_OVERLAP_HIDDEN;
+                    }
+                }
+                else
+                {
+                    _overlapSHPgroup.Add(OverlapSHPUnit, new List<Int32> { this._statusToSHPIndex[effectCode] });
+                }
             }
         }
     }
@@ -214,6 +253,9 @@ public class BattleSPSSystem : MonoBehaviour
             this._shpEffects[shpIndex].attr = 0;
             foreach (GameObject go in this._shpEffects[shpIndex].shpGo)
                 go.SetActive(false);
+
+            KeyValuePair<Int32, Int32> OverlapSHPUnit = new KeyValuePair<Int32, Int32>(unit.Position, CommonSPSSystem.SHPPrototypes[this._shpEffects[shpIndex].shpId].OverlapGroup);
+            _overlapSHPgroup[OverlapSHPUnit].Remove(this._statusToSHPIndex[effectCode]);
             //this._shpEffects[shpIndex].Unload();
             //this._statusToSHPIndex.Remove(effectCode);
         }
@@ -323,4 +365,6 @@ public class BattleSPSSystem : MonoBehaviour
     private Dictionary<KeyValuePair<Int32, Int32>, Int32> _statusToSPSIndex;
     [NonSerialized]
     private Dictionary<KeyValuePair<Int32, Int32>, Int32> _statusToSHPIndex;
+    [NonSerialized]
+    public Dictionary<KeyValuePair<Int32, Int32>, List<Int32>> _overlapSHPgroup = new Dictionary<KeyValuePair<Int32, Int32>, List<Int32>>();
 }

--- a/Assembly-CSharp/Global/SPS/BattleSPSSystem.cs
+++ b/Assembly-CSharp/Global/SPS/BattleSPSSystem.cs
@@ -155,9 +155,9 @@ public class BattleSPSSystem : MonoBehaviour
                             overlapSHPindex++;
 
                             if (overlapSHPindex >= _overlapSHPgroup[OverlapSHPUnit].Count)
-                                this._shpEffects[_overlapSHPgroup[OverlapSHPUnit][0]].attr &= unchecked((Byte)~(SPSConst.ATTR_OVERLAP_HIDDEN + SPSConst.ATTR_LAST_FRAME));
+                                this._shpEffects[_overlapSHPgroup[OverlapSHPUnit][0]].attr &= unchecked((Byte)~SPSConst.ATTR_OVERLAP_HIDDEN);
                             else
-                                this._shpEffects[_overlapSHPgroup[OverlapSHPUnit][overlapSHPindex]].attr &= unchecked((Byte)~(SPSConst.ATTR_OVERLAP_HIDDEN + SPSConst.ATTR_LAST_FRAME));
+                                this._shpEffects[_overlapSHPgroup[OverlapSHPUnit][overlapSHPindex]].attr &= unchecked((Byte)~(SPSConst.ATTR_OVERLAP_HIDDEN));
                         }
                     }
                 }

--- a/Assembly-CSharp/Global/SPS/SHPEffect.cs
+++ b/Assembly-CSharp/Global/SPS/SHPEffect.cs
@@ -32,6 +32,7 @@ public class SHPEffect : MonoBehaviour
             this.shpGo[i] = go;
             this.shpGo[i].SetActive(false);
         }
+        this.overlapDuration = prototype.TextureCount;
     }
 
     public void Unload()
@@ -54,7 +55,7 @@ public class SHPEffect : MonoBehaviour
     {
         if ((this.attr & SPSConst.ATTR_VISIBLE) == 0)
             return;
-        if ((this.attr & (SPSConst.ATTR_UPDATE_THIS_FRAME | SPSConst.ATTR_UPDATE_ANY_FRAME)) != 0)
+        if ((this.attr & (SPSConst.ATTR_UPDATE_THIS_FRAME | SPSConst.ATTR_UPDATE_ANY_FRAME)) != 0 && (this.attr & SPSConst.ATTR_OVERLAP_HIDDEN) == 0)
         {
             if (this.attach != null)
                 this.pos = this.attach.position;
@@ -69,12 +70,15 @@ public class SHPEffect : MonoBehaviour
             base.transform.localRotation = Quaternion.Euler(this.rot.x, this.rot.y, this.rot.z);
             base.transform.localPosition = this.pos + this.posOffset;
             base.transform.LookAt(base.transform.position + directionForward, -directionDown);
+            Int32 previousIndex = this.textureindex;
             foreach (GameObject go in this.shpGo)
                 go.SetActive(false);
-            Int32 shpIndex = this.cycleDuration >= 0 ? (this.frame * this.shpGo.Length / this.cycleDuration) % this.shpGo.Length
+            this.textureindex = this.cycleDuration >= 0 ? (this.frame * this.shpGo.Length / this.cycleDuration) % this.shpGo.Length
                              : this.shpGo.Length - 1 + (this.frame * this.shpGo.Length / this.cycleDuration) % this.shpGo.Length;
-            this.shpGo[shpIndex].SetActive(true);
-            this.attr &= unchecked((Byte)~SPSConst.ATTR_UPDATE_THIS_FRAME);
+            this.shpGo[this.textureindex].SetActive(true);
+            if (this.overlapDuration > 0 && previousIndex != this.textureindex)
+                this.overlapDuration--;
+            this.attr &= unchecked((Byte)~SPSConst.ATTR_UPDATE_THIS_FRAME);   
         }
         else
         {
@@ -89,8 +93,10 @@ public class SHPEffect : MonoBehaviour
 
     public Byte attr;
     public Int32 frame;
+    public Int32 textureindex;
     public Int32 duration;
     public Int32 cycleDuration;
+    public Int32 overlapDuration;
 
     public Vector3 pos;
     public Vector3 scale;

--- a/Assembly-CSharp/Global/SPS/SPSConst.cs
+++ b/Assembly-CSharp/Global/SPS/SPSConst.cs
@@ -7,8 +7,7 @@ public static class SPSConst
     public const Byte ATTR_UPDATE_ANY_FRAME = 2;
     public const Byte ATTR_UPDATE_THIS_FRAME = 4;
     public const Byte ATTR_UNLOAD_ON_FINISH = 8;
-    public const Byte ATTR_LAST_FRAME = 16;
-    public const Byte ATTR_OVERLAP_HIDDEN = 32;
+    public const Byte ATTR_OVERLAP_HIDDEN = 16;
 
     public const Int32 FIELD_DEFAULT_OBJCOUNT = 16;
     public const Int32 BATTLE_DEFAULT_OBJCOUNT = 96;

--- a/Assembly-CSharp/Global/SPS/SPSConst.cs
+++ b/Assembly-CSharp/Global/SPS/SPSConst.cs
@@ -7,6 +7,8 @@ public static class SPSConst
     public const Byte ATTR_UPDATE_ANY_FRAME = 2;
     public const Byte ATTR_UPDATE_THIS_FRAME = 4;
     public const Byte ATTR_UNLOAD_ON_FINISH = 8;
+    public const Byte ATTR_LAST_FRAME = 16;
+    public const Byte ATTR_OVERLAP_HIDDEN = 32;
 
     public const Int32 FIELD_DEFAULT_OBJCOUNT = 16;
     public const Int32 BATTLE_DEFAULT_OBJCOUNT = 96;

--- a/Assembly-CSharp/Memoria/Data/SpecialEffects/SHPPrototype.cs
+++ b/Assembly-CSharp/Memoria/Data/SpecialEffects/SHPPrototype.cs
@@ -13,6 +13,7 @@ namespace Memoria.Data
         public Int32 TextureCount;
         public Byte ShaderType;
         public Int32 CycleDuration;
+        public Int32 OverlapGroup;
 
         private Texture2D[] textures = null;
         public Texture2D[] Textures
@@ -43,6 +44,8 @@ namespace Memoria.Data
             TextureCount = CsvParser.Int32(raw[index++]);
             ShaderType = CsvParser.Byte(raw[index++]);
             CycleDuration = CsvParser.Int32(raw[index++]);
+            if (metadata.HasOption($"IncludeOverlapGroup"))
+                OverlapGroup = CsvParser.Int32(raw[index++]);
         }
 
         public void WriteEntry(CsvWriter sw, CsvMetaData metadata)
@@ -54,6 +57,8 @@ namespace Memoria.Data
             sw.Int32(TextureCount);
             sw.Byte(ShaderType);
             sw.Int32(CycleDuration);
+            if (metadata.HasOption($"IncludeOverlapGroup"))
+                sw.Int32(OverlapGroup);
         }
     }
 }

--- a/Assembly-CSharp/NCalc/NCalcUtility.cs
+++ b/Assembly-CSharp/NCalc/NCalcUtility.cs
@@ -260,12 +260,12 @@ namespace NCalc
                         {
                             if (enumValueStr.TryStaticFieldParse(typeof(BattleStatusConst), out FieldInfo field))
                             {
-                                args.Result = Convert.ToInt32(field.GetValue(null));
+                                args.Result = Convert.ToUInt64(field.GetValue(null));
                                 return;
                             }
                             else if (enumValueStr.StartsWith("Set_") && enumValueStr.Substring("Set_".Length).TryEnumParse(out StatusSetId setId))
                             {
-                                args.Result = Convert.ToInt32(FF9BattleDB.StatusSets[setId]);
+                                args.Result = Convert.ToUInt64(FF9BattleDB.StatusSets[setId]);
                                 return;
                             }
                         }


### PR DESCRIPTION
https://github.com/user-attachments/assets/f3486d1a-3d40-4306-a749-cd7145f12e49

I got this idea from the status numbers I've added to Trance Seek, especially the “Break” and “Up” ones, which are 4 icons next to the character... that's quite a lot when you have 8 Units in battle.

To achieve this, I've set up SHP groups, called `OverlapGroup` in the `SHP.csv` : when SHPs share the same group, they scroll in order.

When a SHP exceeds its texture total, it hides to make room for the next one, and so on... until it comes back at the first SHP.

I also took the opportunity to change a little trick in the `NCalcUtility` to avoid error messages in the `Memoria.Log` (seen with Tirlititi) => If it's still NOK, I can remove it.
