### PR TITLE
[Bugfix] fix battle outline setting applied on filed map character

### DIFF
--- a/Assembly-CSharp/Global/NormalSolver.cs
+++ b/Assembly-CSharp/Global/NormalSolver.cs
@@ -216,7 +216,7 @@ public static class NormalSolver
         foreach (var renderer in renderers)
         {
             renderer.material.SetFloat("_OutlineWidth", 2f);
-            renderer.material.SetFloat("_ShowOutline", Configuration.Shaders.Shader_Battle_Outlines == 1 ? 1f : 0f);
+            renderer.material.SetFloat("_ShowOutline", Configuration.Shaders.Shader_Field_Outlines == 1 ? 1f : 0f);
         }
     }
 


### PR DESCRIPTION
## [Bug] https://github.com/Albeoris/Memoria/issues/726

## Cause
When applying the outline setup. I accidentally use the battle character's setup from the ini file instead of using the one for fieldmap character.

