### PR TITLE
Bandaid for #637

### DIFF
--- a/Assembly-CSharp/Global/Sound/SoLoud/SdLibAPIWithSoloud.cs
+++ b/Assembly-CSharp/Global/Sound/SoLoud/SdLibAPIWithSoloud.cs
@@ -166,6 +166,14 @@ namespace Global.Sound.SoLoud
                 double start = stream.akbHeader.LoopStart / (double)stream.akbHeader.SampleRate;
                 double end = stream.akbHeader.LoopEnd / (double)stream.akbHeader.SampleRate;
 
+                // Adjustement for looping sound at the top of Alexendria Castle (A. Castle/Altar)
+                // It still pops after a while, Soloud just isn't precise enough with the looping
+                if (streams[bankID].profile.ResourceID == "Sounds03/SE12/se120018")
+                {
+                    start = 104120 / (double)stream.akbHeader.SampleRate;
+                    end = 216632 / (double)stream.akbHeader.SampleRate;
+                }
+
                 SoundLib.Log($"LoopStart: {start} LoopEnd: {end} Length: {stream.data.getLength()}");
 
                 soloud.setLoopStartPoint((uint)soundID, start);


### PR DESCRIPTION
This doesn't fix the issue entirely.

The poping is gone but after a while it comes back. I guess the looping point slowly drift because SoLoud isn't quite precise enough. I made some attempts to fix it in Soloud directly with no success.

This also only fix that one particular looping audio (Sounds03/SE12/se120018). There are possibly more looping audio with this issue.