### PR TITLE
[Bugfix]use stencil to prevent outline for thin mesh

### DIFF
--- a/Assembly-CSharp/FF9/btl_util.cs
+++ b/Assembly-CSharp/FF9/btl_util.cs
@@ -462,7 +462,9 @@ namespace FF9
                     componentsInChildren[i].material.SetFloat("_OutlineWidth", 2.3f);
                     componentsInChildren[i].material.SetFloat("_ShowOutline", Configuration.Shaders.Shader_Battle_Outlines == 1 ? 1f : 0f);
                     componentsInChildren[i].material.SetFloat("_IsEnemy", btl.bi.player == 0 ? 1 : 0);
-                    componentsInChildren[i].material.SetInt("_StencilOp", btl.bi.player == 0 ? 2 : 1);   
+                    componentsInChildren[i].material.SetInt("_StencilOp", 2);
+                    componentsInChildren[i].material.SetInt("_StencilRef", 101);
+                    componentsInChildren[i].material.SetInt("_StencilOpOutline", btl.bi.player == 0 ? 6 : 8);
                 }
 			}
 			MeshRenderer[] componentsInChildren2 = go.GetComponentsInChildren<MeshRenderer>();
@@ -480,7 +482,9 @@ namespace FF9
                         material.SetFloat("_OutlineWidth", 2.3f);
                         material.SetFloat("_ShowOutline", Configuration.Shaders.Shader_Battle_Outlines == 1 ? 1f : 0f);
                         material.SetFloat("_IsEnemy", btl.bi.player == 0 ? 1 : 0);
-                        material.SetInt("_StencilOp", btl.bi.player == 0 ? 2 : 1);
+                        material.SetInt("_StencilOp", 2);
+                        material.SetInt("_StencilRef", 101);
+                        material.SetInt("_StencilOpOutline", btl.bi.player == 0 ? 6 : 8);
                     }
 				}
 			}

--- a/Memoria.Patcher/StreamingAssets/Shaders/PSX/BattleMap_StatusEffect_RealLighting.txt
+++ b/Memoria.Patcher/StreamingAssets/Shaders/PSX/BattleMap_StatusEffect_RealLighting.txt
@@ -8,6 +8,8 @@ Shader "PSX/BattleMap_StatusEffect_RealLighting" {
 		_IsEnemy ("Is Enemy", Float) = 0.000000
 		_StencilOp ("stencil op", Float) = 2
 		_OutlineWidth ("Outline width", Float) = 2
+		_StencilRef ("Stencil Pass Ref", Float) = 0
+		_StencilOpOutline ("Outline Stencil Pass op", Float) = 0
 	}
 	SubShader { 
 		LOD 100
@@ -18,7 +20,7 @@ Shader "PSX/BattleMap_StatusEffect_RealLighting" {
 			
 			Stencil
             {
-              Ref 101
+              Ref [_StencilRef]
               Comp Always
               Pass [_StencilOp]
             }
@@ -176,6 +178,10 @@ Shader "PSX/BattleMap_StatusEffect_RealLighting" {
 		    Name "OUTLINE"
 		    Cull Front
 			Tags { "QUEUE"="AlphaTest+3" "IGNOREPROJECTOR"="true" "RenderType"="TransparentCutOff" }
+			Stencil {
+			    Ref [_StencilRef]
+                Comp [_StencilOpOutline]
+            }
 			Program "vp" {
 				SubProgram "d3d9 " {
 					Bind "vertex" Vertex

--- a/Memoria.Patcher/StreamingAssets/Shaders/PSX/BattleMap_StatusEffect_Toon.txt
+++ b/Memoria.Patcher/StreamingAssets/Shaders/PSX/BattleMap_StatusEffect_Toon.txt
@@ -8,6 +8,8 @@ Shader "PSX/BattleMap_StatusEffect_Toon" {
 		_IsEnemy ("Is Enemy", Float) = 0.000000
 		_StencilOp ("stencil op", Float) = 2
 		_OutlineWidth ("Outline width", Float) = 2
+		_StencilRef ("Stencil Pass Ref", Float) = 0
+		_StencilOpOutline ("Outline Stencil Pass op", Float) = 0
 	}
 	SubShader { 
 		LOD 100
@@ -16,9 +18,9 @@ Shader "PSX/BattleMap_StatusEffect_Toon" {
 			Tags { "LightMode" = "ForwardBase" "QUEUE"="AlphaTest+3" "IGNOREPROJECTOR"="true" "RenderType"="TransparentCutOff" }
 			GpuProgramID 15200
 			
-			Stencil
+            Stencil
             {
-              Ref 101
+              Ref [_StencilRef]
               Comp Always
               Pass [_StencilOp]
             }
@@ -154,6 +156,10 @@ Shader "PSX/BattleMap_StatusEffect_Toon" {
 		    Name "OUTLINE"
 		    Cull Front
 			Tags { "QUEUE"="AlphaTest+3" "IGNOREPROJECTOR"="true" "RenderType"="TransparentCutOff" }
+			Stencil {
+			    Ref [_StencilRef]
+                Comp [_StencilOpOutline]
+            }
 			Program "vp" {
 				SubProgram "d3d9 " {
 					Bind "vertex" Vertex


### PR DESCRIPTION
# [Bugfix] Outline shows artifacts on thin mesh.

![image](https://github.com/user-attachments/assets/b77700d7-a00c-4d3d-954c-b8592a141dc9)

# Cause
The outline method I use is called inverted hull method. which doesn't play well with thin mesh(But it's the most popular outline method since it's cheap for performance and simple). 

# How to fix
In this PR I use[ stencil buffer](https://learnopengl.com/Advanced-OpenGL/Stencil-testing) to prevent outline pixel happening on the thin mesh. It's not perfect solution (it will mostly making thin parts outline disappear) but at least no more unwanted artifacts.

![image](https://github.com/user-attachments/assets/d91e24c8-47a7-4c42-8bba-d0f232053f58)