### PR TITLE
Allow character swaps in battles

### DIFF
--- a/Assembly-CSharp/FF9/btl_util.cs
+++ b/Assembly-CSharp/FF9/btl_util.cs
@@ -110,7 +110,7 @@ namespace FF9
                         return true;
                     if ((mode & BusyMode.TARGET) != 0 && ((cmd.tar_id & btl.btl_id) != 0 || (btl_cmd.MergeReflecTargetID(cmd.reflec) & btl.btl_id) != 0))
                         return true;
-                    if ((mode & BusyMode.MAGIC_CASTER) != 0 && cmd.cmd_no == BattleCommandId.MagicSword && btl.bi.player != 0 && btl.bi.slot_no == 1)
+                    if ((mode & BusyMode.MAGIC_CASTER) != 0 && (cmd.magic_caster_id & btl.btl_id) != 0)
                         return true;
                 }
             if ((mode & BusyMode.ANY_QUEUED) != 0)
@@ -120,7 +120,7 @@ namespace FF9
                         return true;
                     if ((mode & BusyMode.QUEUED_TARGET) != 0 && (cmd.tar_id & btl.btl_id) != 0)
                         return true;
-                    if ((mode & BusyMode.QUEUED_MAGIC_CASTER) != 0 && cmd.cmd_no == BattleCommandId.MagicSword && btl.bi.player != 0 && btl.bi.slot_no == 1)
+                    if ((mode & BusyMode.QUEUED_MAGIC_CASTER) != 0 && (cmd.magic_caster_id & btl.btl_id) != 0)
                         return true;
                 }
             return false;

--- a/Assembly-CSharp/Global/CMD_DATA.cs
+++ b/Assembly-CSharp/Global/CMD_DATA.cs
@@ -16,6 +16,7 @@ public class CMD_DATA
     public BTL_DATA regist;
     public AA_DATA aa;
     public UInt16 tar_id;
+    public UInt16 magic_caster_id;
     public BattleCommandId cmd_no;
     public Int32 sub_no;
     public CMD_DATA.SELECT_INFO info;

--- a/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
+++ b/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
@@ -2270,7 +2270,8 @@ public partial class EventEngine
             {
                 FF9PARTY_INFO sPartyInfo = new FF9PARTY_INFO();
                 List<CharacterId> selectList = new List<CharacterId>();
-                sPartyInfo.party_ct = this.getv1(); // arg1: party size (if characters occupy slots beyond it, they are locked)
+                sPartyInfo.party_ct = this.getv1(); // arg1: minimal party size (if characters occupy slots beyond it, they are locked)
+                sPartyInfo.exact_party_ct = -1;
                 foreach (PLAYER p in FF9StateSystem.Common.FF9.PlayerList)
                     if (p.info.party != 0)
                         selectList.Add(p.info.slot_no);

--- a/Assembly-CSharp/Global/Field/FieldHUD.cs
+++ b/Assembly-CSharp/Global/Field/FieldHUD.cs
@@ -489,11 +489,12 @@ public class FieldHUD : UIScene
     {
         FF9PARTY_INFO defaultParty = new FF9PARTY_INFO
         {
-            menu = new CharacterId[4] { CharacterId.Zidane, CharacterId.Vivi, CharacterId.Garnet, CharacterId.Steiner },
-            select = new CharacterId[4] { CharacterId.Freya, CharacterId.Quina, CharacterId.Eiko, CharacterId.Amarant }
+            menu = [CharacterId.Zidane, CharacterId.Vivi, CharacterId.Garnet, CharacterId.Steiner],
+            select = [CharacterId.Freya, CharacterId.Quina, CharacterId.Eiko, CharacterId.Amarant]
         };
         defaultParty.fix.Add(CharacterId.Zidane);
         defaultParty.party_ct = 4;
+        defaultParty.exact_party_ct = -1;
         PersistenSingleton<UIManager>.Instance.PartySettingScene.Info = defaultParty;
         PersistenSingleton<UIManager>.Instance.ChangeUIState(UIManager.UIState.PartySetting);
     }

--- a/Assembly-CSharp/Global/HUDMessage/HUDMessage.cs
+++ b/Assembly-CSharp/Global/HUDMessage/HUDMessage.cs
@@ -125,6 +125,21 @@ public class HUDMessage : Singleton<HUDMessage>
         return hudmessageChild;
     }
 
+    public HUDMessageChild Show(BTL_DATA target, Int32 iconPos, String message, HUDMessage.MessageStyle style)
+    {
+        HUDMessageChild hudmessageChild = null;
+        if (base.gameObject.activeInHierarchy)
+        {
+            Byte readyObjectIndex = this.GetReadyObjectIndex();
+            hudmessageChild = this.childHud[readyObjectIndex];
+            btl2d.GetIconPosition(target, iconPos, out Transform attach, out Vector3 offset);
+            hudmessageChild.Show(attach, message, style, offset);
+            hudmessageChild.Follower.targetBtl = target;
+            hudmessageChild.Follower.iconPosition = iconPos;
+        }
+        return hudmessageChild;
+    }
+
     private IEnumerator WaitForOriginalDelay(Byte delay)
     {
         Single cumulativeTime = 0f;

--- a/Assembly-CSharp/Global/HUDMessage/HUDMessageChild.cs
+++ b/Assembly-CSharp/Global/HUDMessage/HUDMessageChild.cs
@@ -25,28 +25,17 @@ public class HUDMessageChild : MonoBehaviour
 
     public Int32 FontSize
     {
-        get
-        {
-            return this.label.fontSize;
-        }
-        set
-        {
-            this.label.fontSize = value;
-        }
+        get => this.label.fontSize;
+        set => this.label.fontSize = value;
     }
 
     public UILabel.Effect effectStyle
     {
-        get
-        {
-            return this.label.effectStyle;
-        }
+        get => this.label.effectStyle;
         set
         {
             if (this.label.effectStyle != value)
-            {
                 this.label.effectStyle = value;
-            }
         }
     }
 
@@ -81,6 +70,8 @@ public class HUDMessageChild : MonoBehaviour
         this.follower.target = target;
         this.follower.targetTransformOffset = offset;
         this.follower.clampToScreen = true;
+        this.follower.targetBtl = null;
+        this.follower.iconPosition = -1;
         this.label.text = message;
         this.tweenPosition.duration = this.tweenPositionDuration / Singleton<HUDMessage>.Instance.Speed;
         this.tweenAlpha.duration = this.tweenAlphaDuration / Singleton<HUDMessage>.Instance.Speed;

--- a/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
+++ b/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
@@ -270,11 +270,6 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
                     btl[i].weapon_geo = ModelFactory.CreateModel("BattleMap/BattleModel/battle_weapon/" + sb2MonParm.WeaponModel + "/" + sb2MonParm.WeaponModel, true, true, Configuration.Graphics.ElementsSmoothTexture);
                 else
                     btl[i].weapon_geo = ModelFactory.CreateModel(sb2MonParm.WeaponModel, true, true, Configuration.Graphics.ElementsSmoothTexture);
-                MeshRenderer[] weaponRenderers = btl[i].weapon_geo.GetComponentsInChildren<MeshRenderer>();
-                btl[i].weaponMeshCount = weaponRenderers.Length;
-                btl[i].weaponRenderer = new Renderer[btl[i].weaponMeshCount];
-                for (Int32 j = 0; j < btl[i].weaponMeshCount; ++j)
-                    btl[i].weaponRenderer[j] = weaponRenderers[j].GetComponent<Renderer>();
                 geo.geoAttach(btl[i].weapon_geo, btl[i].gameObject, sb2MonParm.WeaponAttachment);
                 if (btl_eqp.EnemyBuiltInWeaponTable.ContainsKey(sb2MonParm.Geo))
                     btl[i].builtin_weapon_mode = true;
@@ -284,11 +279,6 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
                 if (path.Contains("GEO_MON_B3_168"))
                     btl[i].gameObject.transform.FindChild("mesh5").gameObject.SetActive(false);
                 btl[i].weapon_geo = ModelFactory.CreateDefaultWeaponForCharacterWhenUseAsEnemy(path);
-                MeshRenderer[] weaponRenderers = btl[i].weapon_geo.GetComponentsInChildren<MeshRenderer>();
-                btl[i].weaponMeshCount = weaponRenderers.Length;
-                btl[i].weaponRenderer = new Renderer[btl[i].weaponMeshCount];
-                for (Int32 j = 0; j < btl[i].weaponMeshCount; ++j)
-                    btl[i].weaponRenderer[j] = weaponRenderers[j].GetComponent<Renderer>();
                 geo.geoAttach(btl[i].weapon_geo, btl[i].gameObject, ModelFactory.GetDefaultWeaponBoneIdForCharacterWhenUseAsEnemy(path));
             }
             else
@@ -299,14 +289,14 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
                 ModelFactory.ChangeModelTexture(btl[i].gameObject, sb2MonParm.TextureFiles);
             if (btl[i].weapon_geo != null)
             {
-                MeshRenderer[] componentsInChildren = btl[i].weapon_geo.GetComponentsInChildren<MeshRenderer>();
-                btl[i].weaponMeshCount = componentsInChildren.Length;
+                MeshRenderer[] weaponRenderers = btl[i].weapon_geo.GetComponentsInChildren<MeshRenderer>();
+                btl[i].weaponMeshCount = weaponRenderers.Length;
                 btl[i].weaponRenderer = new Renderer[btl[i].weaponMeshCount];
                 if (btl[i].weaponMeshCount > 0)
                 {
                     for (Int32 j = 0; j < btl[i].weaponMeshCount; j++)
                     {
-                        btl[i].weaponRenderer[j] = componentsInChildren[j].GetComponent<Renderer>();
+                        btl[i].weaponRenderer[j] = weaponRenderers[j].GetComponent<Renderer>();
                         if (sb2MonParm.WeaponTextureFiles != null && sb2MonParm.WeaponTextureFiles.Length > j && !String.IsNullOrEmpty(sb2MonParm.WeaponTextureFiles[j]))
                             btl[i].weaponRenderer[j].material.mainTexture = AssetManager.Load<Texture2D>(sb2MonParm.WeaponTextureFiles[j], false);
                     }
@@ -324,7 +314,6 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
             btl[i].meshIsRendering = new Boolean[meshCount];
             for (Int32 j = 0; j < meshCount; ++j)
                 btl[i].meshIsRendering[j] = true;
-            btl[i].animation = btl[i].gameObject.GetComponent<Animation>();
             btl[i].animation = btl[i].gameObject.GetComponent<Animation>();
         }
     }

--- a/Assembly-CSharp/Global/MainMenuUI.cs
+++ b/Assembly-CSharp/Global/MainMenuUI.cs
@@ -14,7 +14,6 @@ public class MainMenuUI : UIScene
     public static MenuUIControlPanel UIControlPanel { get; set; }
 
     public Vector3 FrontRowPosition => new Vector3(-418f, 0f, 0f);
-
     public Vector3 BackRowPosition => new Vector3(-392f, 0f, 0f);
 
     public MainMenuUI.SubMenu CurrentSubMenu
@@ -76,6 +75,8 @@ public class MainMenuUI : UIScene
         this.OrderSubMenu.GetComponentInChildren<UILabel>().color = IsSubMenuEnabled(SubMenu.Order) ? FF9TextTool.White : FF9TextTool.Gray;
         this.CardSubMenu.GetComponentInChildren<UILabel>().color = IsSubMenuEnabled(SubMenu.Card) ? FF9TextTool.White : FF9TextTool.Gray;
         this.ConfigSubMenu.GetComponentInChildren<UILabel>().color = IsSubMenuEnabled(SubMenu.Config) ? FF9TextTool.White : FF9TextTool.Gray;
+        if (this.PartySubMenu != null)
+            this.PartySubMenu.GetComponentInChildren<UILabel>().color = IsSubMenuEnabled(SubMenu.Party) ? FF9TextTool.White : FF9TextTool.Gray;
         if (!UIManager.IsUIStateMenu(PersistenSingleton<UIManager>.Instance.PreviousState))
             ImpactfulActionCount = 0;
     }
@@ -133,6 +134,7 @@ public class MainMenuUI : UIScene
     {
         if (base.OnKeyConfirm(go))
         {
+            Single shiftFactor = this.PartySubMenu == null ? 1f : 7f / 8f;
             if (ButtonGroupState.ActiveGroup == MainMenuUI.SubMenuGroupButton)
             {
                 if (IsSubMenuEnabled(this.GetSubMenuFromGameObject(go)))
@@ -173,7 +175,7 @@ public class MainMenuUI : UIScene
                             break;
                         case MainMenuUI.SubMenu.Card:
                             this.NeedTweenAndHideSubMenu = false;
-                            this.submenuTransition.ShiftContentClip = new Vector2(0f, 499f);
+                            this.submenuTransition.ShiftContentClip = new Vector2(0f, 9f + shiftFactor * 490f);
                             this.CardSubMenu.GetComponent<UIButton>().SetState(UIButtonColor.State.Normal, false);
                             this.Hide(delegate
                             {
@@ -183,11 +185,25 @@ public class MainMenuUI : UIScene
                             break;
                         case MainMenuUI.SubMenu.Config:
                             this.NeedTweenAndHideSubMenu = false;
-                            this.submenuTransition.ShiftContentClip = new Vector2(0f, 597f);
+                            this.submenuTransition.ShiftContentClip = new Vector2(0f, 9f + shiftFactor * (this.PartySubMenu == null ? 588f : 686f));
                             this.ConfigSubMenu.GetComponent<UIButton>().SetState(UIButtonColor.State.Normal, false);
                             this.Hide(delegate
                             {
                                 PersistenSingleton<UIManager>.Instance.ChangeUIState(UIManager.UIState.Config);
+                                base.Loading = true;
+                            });
+                            break;
+                        case MainMenuUI.SubMenu.Party:
+                            this.NeedTweenAndHideSubMenu = false;
+                            this.submenuTransition.ShiftContentClip = new Vector2(0f, 9f + shiftFactor * 588f);
+                            this.PartySubMenu.GetComponent<UIButton>().SetState(UIButtonColor.State.Normal, false);
+                            this.Hide(delegate
+                            {
+                                PersistenSingleton<UIManager>.Instance.PartySettingScene.AccessFromMenu = true;
+                                PersistenSingleton<UIManager>.Instance.PartySettingScene.Info = UISceneHelper.GetCurrentPartyForMenu();
+                                if (PersistenSingleton<UIManager>.Instance.UnityScene == UIManager.Scene.Battle)
+                                    PersistenSingleton<UIManager>.Instance.PartySettingScene.ExactPartyCount = FF9StateSystem.Common.FF9.party.MemberCount;
+                                PersistenSingleton<UIManager>.Instance.ChangeUIState(UIManager.UIState.PartySetting);
                                 base.Loading = true;
                             });
                             break;
@@ -212,7 +228,7 @@ public class MainMenuUI : UIScene
                             case MainMenuUI.SubMenu.Ability:
                                 this.characterMemorize = go;
                                 this.NeedTweenAndHideSubMenu = false;
-                                this.submenuTransition.ShiftContentClip = new Vector2(0f, 107f);
+                                this.submenuTransition.ShiftContentClip = new Vector2(0f, 9f + shiftFactor * 98f);
                                 this.AbilitySubMenu.GetComponent<UIButton>().SetState(UIButtonColor.State.Normal, false);
                                 this.Hide(delegate
                                 {
@@ -223,7 +239,7 @@ public class MainMenuUI : UIScene
                             case MainMenuUI.SubMenu.Equip:
                                 this.characterMemorize = go;
                                 this.NeedTweenAndHideSubMenu = false;
-                                this.submenuTransition.ShiftContentClip = new Vector2(0f, 205f);
+                                this.submenuTransition.ShiftContentClip = new Vector2(0f, 9f + shiftFactor * 196f);
                                 this.EquipSubMenu.GetComponent<UIButton>().SetState(UIButtonColor.State.Normal, false);
                                 this.Hide(delegate
                                 {
@@ -234,7 +250,7 @@ public class MainMenuUI : UIScene
                             case MainMenuUI.SubMenu.Status:
                                 this.characterMemorize = go;
                                 this.NeedTweenAndHideSubMenu = false;
-                                this.submenuTransition.ShiftContentClip = new Vector2(0f, 303f);
+                                this.submenuTransition.ShiftContentClip = new Vector2(0f, 9f + shiftFactor * 294f);
                                 this.StatusSubMenu.GetComponent<UIButton>().SetState(UIButtonColor.State.Normal, false);
                                 this.Hide(delegate
                                 {
@@ -306,13 +322,9 @@ public class MainMenuUI : UIScene
             {
                 FF9Sfx.FF9SFX_Play(101);
                 if (this.currentMenu == MainMenuUI.SubMenu.Order)
-                {
                     this.characterOrderMemorize = go;
-                }
                 else
-                {
                     this.characterMemorize = go;
-                }
                 ButtonGroupState.ActiveGroup = MainMenuUI.SubMenuGroupButton;
             }
             else if (ButtonGroupState.ActiveGroup == MainMenuUI.OrderGroupButton)
@@ -330,19 +342,15 @@ public class MainMenuUI : UIScene
         {
             if (ButtonGroupState.ActiveGroup == MainMenuUI.CharacterGroupButton)
             {
-                Int32 siblingIndex = go.transform.GetSiblingIndex();
-                if (this.currentCharacterIndex != siblingIndex)
-                {
-                    this.currentCharacterIndex = siblingIndex;
-                }
+                Int32 selectedIndex = go.transform.GetSiblingIndex();
+                if (this.currentCharacterIndex != selectedIndex)
+                    this.currentCharacterIndex = selectedIndex;
             }
             else if (ButtonGroupState.ActiveGroup == MainMenuUI.OrderGroupButton)
             {
-                Int32 siblingIndex2 = go.transform.parent.GetSiblingIndex();
-                if (this.currentOrder != siblingIndex2)
-                {
-                    this.currentOrder = siblingIndex2;
-                }
+                Int32 selectedIndex = go.transform.parent.GetSiblingIndex();
+                if (this.currentOrder != selectedIndex)
+                    this.currentOrder = selectedIndex;
             }
         }
         return true;
@@ -546,6 +554,8 @@ public class MainMenuUI : UIScene
                 return this.CardSubMenu;
             case MainMenuUI.SubMenu.Config:
                 return this.ConfigSubMenu;
+            case MainMenuUI.SubMenu.Party:
+                return this.PartySubMenu;
             default:
                 return this.ItemSubMenu;
         }
@@ -567,6 +577,8 @@ public class MainMenuUI : UIScene
             return MainMenuUI.SubMenu.Status;
         if (go == this.OrderSubMenu)
             return MainMenuUI.SubMenu.Order;
+        if (go == this.PartySubMenu)
+            return MainMenuUI.SubMenu.Party;
         return MainMenuUI.SubMenu.None;
     }
 
@@ -662,6 +674,33 @@ public class MainMenuUI : UIScene
         this.OrderSubMenu = this.SubMenuPanel.GetChild(0).GetChild(0).GetChild(4);
         this.CardSubMenu = this.SubMenuPanel.GetChild(0).GetChild(0).GetChild(5);
         this.ConfigSubMenu = this.SubMenuPanel.GetChild(0).GetChild(0).GetChild(6);
+        if (Configuration.Hacks.AllCharactersAvailable > 0 && this.PartySubMenu == null)
+        {
+            UITable table = this.SubMenuPanel.GetChild(0).GetChild(0).GetComponent<UITable>();
+            this.PartySubMenu = UnityEngine.Object.Instantiate(this.CardSubMenu);
+            UILocalize partyLocalize = this.PartySubMenu.GetChild(0).GetComponent<UILocalize>();
+            ButtonGroupState.HelpDetail partyHelp = this.PartySubMenu.GetComponent<ButtonGroupState>().Help;
+            partyLocalize.key = "Party";
+            partyHelp.TextKey = "Party";
+            this.ConfigSubMenu.transform.parent = null;
+            this.PartySubMenu.transform.parent = table.transform;
+            this.ConfigSubMenu.transform.parent = table.transform;
+            this.CardSubMenu.GetComponent<UIKeyNavigation>().onDown = this.PartySubMenu;
+            this.PartySubMenu.GetComponent<UIKeyNavigation>().onDown = this.ConfigSubMenu;
+            this.ConfigSubMenu.GetComponent<UIKeyNavigation>().onUp = this.PartySubMenu;
+            this.PartySubMenu.GetComponent<UIKeyNavigation>().onUp = this.CardSubMenu;
+            Vector3 buttonScale = new Vector3(1f, 7f / 8f, 1f);
+            this.ItemSubMenu.transform.localScale = buttonScale;
+            this.AbilitySubMenu.transform.localScale = buttonScale;
+            this.EquipSubMenu.transform.localScale = buttonScale;
+            this.StatusSubMenu.transform.localScale = buttonScale;
+            this.OrderSubMenu.transform.localScale = buttonScale;
+            this.CardSubMenu.transform.localScale = buttonScale;
+            this.PartySubMenu.transform.localScale = buttonScale;
+            this.ConfigSubMenu.transform.localScale = buttonScale;
+            //this.PartySubMenu.active = true;
+            table.repositionNow = true;
+        }
 
         UIEventListener.Get(this.ItemSubMenu).Click += onClick;
         UIEventListener.Get(this.AbilitySubMenu).Click += onClick;
@@ -670,6 +709,8 @@ public class MainMenuUI : UIScene
         UIEventListener.Get(this.OrderSubMenu).Click += onClick;
         UIEventListener.Get(this.CardSubMenu).Click += onClick;
         UIEventListener.Get(this.ConfigSubMenu).Click += onClick;
+        if (this.PartySubMenu != null)
+            UIEventListener.Get(this.PartySubMenu).Click += onClick;
 
         foreach (Transform tr in this.CharacterListPanel.transform)
         {
@@ -705,19 +746,12 @@ public class MainMenuUI : UIScene
     }
 
     public GameObject SubMenuPanel;
-
     public GameObject TransitionGroup;
-
     public GameObject CharacterListPanel;
-
     public GameObject GenericInfoPanel;
-
     public GameObject LocationInfoPanel;
-
     public GameObject HelpDespLabelGameObject;
-
     public GameObject ScreenFadeGameObject;
-
     public GameObject SubMenuTransitionGameObject;
 
     public HashSet<String> EnabledSubMenus = new HashSet<String>();
@@ -725,59 +759,41 @@ public class MainMenuUI : UIScene
     public Int32 ImpactfulActionCount;
 
     private static String SubMenuGroupButton = "MainMenu.SubMenu";
-
     private static String CharacterGroupButton = "MainMenu.Character";
-
     private static String OrderGroupButton = "MainMenu.Order";
 
     private GameObject ItemSubMenu;
-
     private GameObject AbilitySubMenu;
-
     private GameObject EquipSubMenu;
-
     private GameObject StatusSubMenu;
-
     private GameObject OrderSubMenu;
-
     private GameObject CardSubMenu;
-
     private GameObject ConfigSubMenu;
+    [NonSerialized]
+    private GameObject PartySubMenu;
 
     private UILabel gilLabel;
-
     private UILabel hourLabel;
-
     private UILabel minuteLabel;
-
     private UILabel secondLabel;
-
     private UILabel[] colonLabel;
-
     private UILabel locationNameLabel;
 
     private UIPanel screenFadePanel;
-
     private HonoTweenPosition characterTransition;
-
     private HonoTweenClipping submenuTransition;
 
     private Boolean isNeedCharacterTween = true;
-
     private Boolean isNeedHideSubMenu = true;
 
     private MainMenuUI.SubMenu currentMenu;
-
     private Int32 currentCharacterIndex = -1;
-
     private Int32 currentOrder = -1;
 
     private List<CharacterDetailHUD> CharacterHUDList = new List<CharacterDetailHUD>();
-
     private List<GameObject> CharacterOrderGameObjectList = new List<GameObject>();
 
     private GameObject characterMemorize;
-
     private GameObject characterOrderMemorize;
 
     public enum SubMenu
@@ -789,6 +805,7 @@ public class MainMenuUI : UIScene
         Order,
         Card,
         Config,
+        Party,
         None
     }
 }

--- a/Assembly-CSharp/Global/MainMenuUI.cs
+++ b/Assembly-CSharp/Global/MainMenuUI.cs
@@ -201,8 +201,6 @@ public class MainMenuUI : UIScene
                             {
                                 PersistenSingleton<UIManager>.Instance.PartySettingScene.AccessFromMenu = true;
                                 PersistenSingleton<UIManager>.Instance.PartySettingScene.Info = UISceneHelper.GetCurrentPartyForMenu();
-                                if (PersistenSingleton<UIManager>.Instance.UnityScene == UIManager.Scene.Battle)
-                                    PersistenSingleton<UIManager>.Instance.PartySettingScene.ExactPartyCount = FF9StateSystem.Common.FF9.party.MemberCount;
                                 PersistenSingleton<UIManager>.Instance.ChangeUIState(UIManager.UIState.PartySetting);
                                 base.Loading = true;
                             });
@@ -674,7 +672,7 @@ public class MainMenuUI : UIScene
         this.OrderSubMenu = this.SubMenuPanel.GetChild(0).GetChild(0).GetChild(4);
         this.CardSubMenu = this.SubMenuPanel.GetChild(0).GetChild(0).GetChild(5);
         this.ConfigSubMenu = this.SubMenuPanel.GetChild(0).GetChild(0).GetChild(6);
-        if (Configuration.Hacks.AllCharactersAvailable > 0 && this.PartySubMenu == null)
+        if (this.PartySubMenu == null && (Configuration.Hacks.AllCharactersAvailable > 0 || Configuration.Battle.IsMenuEnabledInBattle(SubMenu.Party)))
         {
             UITable table = this.SubMenuPanel.GetChild(0).GetChild(0).GetComponent<UITable>();
             this.PartySubMenu = UnityEngine.Object.Instantiate(this.CardSubMenu);

--- a/Assembly-CSharp/Global/PARTY_DATA.cs
+++ b/Assembly-CSharp/Global/PARTY_DATA.cs
@@ -1,6 +1,7 @@
 ﻿using Memoria;
 using Memoria.Data;
 using System;
+using System.Linq;
 
 public class PARTY_DATA
 {
@@ -17,4 +18,10 @@ public class PARTY_DATA
     public Int32 battle_no;
 
     public CharacterId GetCharacterId(Int32 index) => index < 0 || index >= member.Length || member[index] == null ? CharacterId.NONE : member[index].info.slot_no;
+    public Int32 MemberCount => member.Count(p => p != null);
+
+    public Boolean IsInParty(CharacterId charId)
+    {
+        return charId != CharacterId.NONE && member.Any(p => p?.Index == charId);
+    }
 }

--- a/Assembly-CSharp/Global/PartySettingUI.cs
+++ b/Assembly-CSharp/Global/PartySettingUI.cs
@@ -75,8 +75,6 @@ public class PartySettingUI : UIScene
 
     [NonSerialized]
     public Boolean AccessFromMenu = false;
-    [NonSerialized]
-    public Int32 ExactPartyCount = -1;
 
     public GameObject HelpDespLabelGameObject;
     public GameObject CurrentPartyPanel;
@@ -204,33 +202,39 @@ public class PartySettingUI : UIScene
 
         if (ButtonGroupState.ActiveGroup == SelectCharGroupButton)
         {
-            FF9Sfx.FF9SFX_Play(103);
-            this.currentCharacterSelect = this.GetCurrentSelect(go);
-            this.currentCharacterId = this.GetCurrentId(go);
-            ButtonGroupState.SetCursorStartSelect((this.currentCharacterSelect.Group != Mode.Menu) ? go.GetChild(0) : go.GetChild(2), MoveCharGroupButton);
-            ButtonGroupState.RemoveCursorMemorize(MoveCharGroupButton);
-            ButtonGroupState.ActiveGroup = MoveCharGroupButton;
-            ButtonGroupState.HoldActiveStateOnGroup(SelectCharGroupButton);
-            foreach (CharacterOutsidePartyHud current in this.outsidePartyHudList)
-                ButtonGroupState.SetButtonEnable(current.MoveButton, this.currentCharacterId == CharacterId.NONE || !this.info.fix.Contains(this.currentCharacterId));
-        }
-        else if (ButtonGroupState.ActiveGroup == MoveCharGroupButton)
-        {
-            PartySelect currentSelect = this.GetCurrentSelect(go);
             CharacterId currentId = this.GetCurrentId(go);
-            if (this.currentCharacterSelect.Group == Mode.Select && currentId != CharacterId.NONE && this.info.fix.Contains(currentId))
+            if (currentId != CharacterId.NONE && this.info.fix.Contains(currentId))
             {
                 FF9Sfx.FF9SFX_Play(102);
             }
             else
             {
                 FF9Sfx.FF9SFX_Play(103);
-                this.SwapCharacter(this.currentCharacterSelect, currentSelect);
+                this.currentCharacterSelect = this.GetCurrentSelect(go);
+                this.currentCharacterId = this.GetCurrentId(go);
+                ButtonGroupState.SetCursorStartSelect((this.currentCharacterSelect.Group != Mode.Menu) ? go.GetChild(0) : go.GetChild(2), MoveCharGroupButton);
+                ButtonGroupState.RemoveCursorMemorize(MoveCharGroupButton);
+                ButtonGroupState.ActiveGroup = MoveCharGroupButton;
+                ButtonGroupState.HoldActiveStateOnGroup(SelectCharGroupButton);
+                foreach (CharacterOutsidePartyHud current in this.outsidePartyHudList)
+                    ButtonGroupState.SetButtonEnable(current.MoveButton, this.currentCharacterId == CharacterId.NONE || !this.info.fix.Contains(this.currentCharacterId));
+            }
+        }
+        else if (ButtonGroupState.ActiveGroup == MoveCharGroupButton)
+        {
+            CharacterId currentId = this.GetCurrentId(go);
+            if (currentId != CharacterId.NONE && this.info.fix.Contains(currentId))
+            {
+                FF9Sfx.FF9SFX_Play(102);
+            }
+            else
+            {
+                FF9Sfx.FF9SFX_Play(103);
+                this.SwapCharacter(this.currentCharacterSelect, this.GetCurrentSelect(go));
                 this.DisplayCharacters();
                 this.DisplayCharacterInfo(this.currentCharacterId);
                 ButtonGroupState.SetCursorMemorize(go.transform.parent.gameObject, SelectCharGroupButton);
                 ButtonGroupState.ActiveGroup = SelectCharGroupButton;
-                PersistenSingleton<UIManager>.Instance.MainMenuScene.ImpactfulActionCount++;
             }
         }
         return true;
@@ -254,7 +258,6 @@ public class PartySettingUI : UIScene
                         else
                             PersistenSingleton<UIManager>.Instance.ChangeUIState(PersistenSingleton<UIManager>.Instance.HUDState);
                         this.AccessFromMenu = false;
-                        this.ExactPartyCount = -1;
                     });
                 }
                 else
@@ -413,8 +416,8 @@ public class PartySettingUI : UIScene
                     healthyCnt++;
             }
         }
-        if (this.ExactPartyCount >= 0)
-            return charCnt == this.ExactPartyCount && healthyCnt != 0;
+        if (this.info.exact_party_ct >= 0)
+            return charCnt == this.info.exact_party_ct && healthyCnt != 0;
         return charCnt >= this.info.party_ct && healthyCnt != 0;
     }
 
@@ -462,6 +465,8 @@ public class PartySettingUI : UIScene
             this.info.menu[oldSelect.Index] = char2;
         else if (oldSelect.Group == Mode.Select)
             this.info.select[4 * currentFloor + oldSelect.Index] = char2;
+        if (oldSelect.Group == Mode.Menu || newSelect.Group == Mode.Menu)
+            PersistenSingleton<UIManager>.Instance.MainMenuScene.ImpactfulActionCount++;
     }
 
     private void Awake()

--- a/Assembly-CSharp/Global/PartySettingUI.cs
+++ b/Assembly-CSharp/Global/PartySettingUI.cs
@@ -73,6 +73,11 @@ public class PartySettingUI : UIScene
     private static String SelectCharGroupButton = "Party.Select";
     private static String MoveCharGroupButton = "Party.Move";
 
+    [NonSerialized]
+    public Boolean AccessFromMenu = false;
+    [NonSerialized]
+    public Int32 ExactPartyCount = -1;
+
     public GameObject HelpDespLabelGameObject;
     public GameObject CurrentPartyPanel;
     public GameObject OutsidePartyPanel;
@@ -150,8 +155,10 @@ public class PartySettingUI : UIScene
             SceneDirector.FF9Wipe_FadeInEx(12);
         };
         if (afterFinished != null)
-            sceneVoidDelegate = (SceneVoidDelegate)Delegate.Combine(sceneVoidDelegate, afterFinished);
+            sceneVoidDelegate += afterFinished;
         base.Hide(sceneVoidDelegate);
+        if (this.AccessFromMenu)
+            PersistenSingleton<UIManager>.Instance.MainMenuScene.StartSubmenuTweenIn();
         BattleAchievement.UpdateParty();
         this.RemoveCursorMemorize();
     }
@@ -223,6 +230,7 @@ public class PartySettingUI : UIScene
                 this.DisplayCharacterInfo(this.currentCharacterId);
                 ButtonGroupState.SetCursorMemorize(go.transform.parent.gameObject, SelectCharGroupButton);
                 ButtonGroupState.ActiveGroup = SelectCharGroupButton;
+                PersistenSingleton<UIManager>.Instance.MainMenuScene.ImpactfulActionCount++;
             }
         }
         return true;
@@ -241,7 +249,12 @@ public class PartySettingUI : UIScene
                     FF9Sfx.FF9SFX_Play(103);
                     this.Hide(delegate
                     {
-                        PersistenSingleton<UIManager>.Instance.ChangeUIState(PersistenSingleton<UIManager>.Instance.HUDState);
+                        if (this.AccessFromMenu)
+                            PersistenSingleton<UIManager>.Instance.ChangeUIState(UIManager.UIState.MainMenu);
+                        else
+                            PersistenSingleton<UIManager>.Instance.ChangeUIState(PersistenSingleton<UIManager>.Instance.HUDState);
+                        this.AccessFromMenu = false;
+                        this.ExactPartyCount = -1;
                     });
                 }
                 else
@@ -400,6 +413,8 @@ public class PartySettingUI : UIScene
                     healthyCnt++;
             }
         }
+        if (this.ExactPartyCount >= 0)
+            return charCnt == this.ExactPartyCount && healthyCnt != 0;
         return charCnt >= this.info.party_ct && healthyCnt != 0;
     }
 

--- a/Assembly-CSharp/Global/UI/UIFollowTarget.cs
+++ b/Assembly-CSharp/Global/UI/UIFollowTarget.cs
@@ -64,4 +64,9 @@ public class UIFollowTarget : MonoBehaviour
 
     [NonSerialized]
     public Boolean clampToScreen;
+
+    [NonSerialized]
+    public BTL_DATA targetBtl;
+    [NonSerialized]
+    public Int32 iconPosition;
 }

--- a/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
+++ b/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
@@ -925,6 +925,7 @@ namespace Memoria
                 if (p.info.party != 0)
                     selectList.Add(p.info.slot_no);
             party.party_ct = Math.Min(4, selectList.Count);
+            party.exact_party_ct = -1;
 
             for (Int32 memberIndex = 0; memberIndex < 4; ++memberIndex)
             {
@@ -939,8 +940,13 @@ namespace Memoria
                     party.menu[memberIndex] = CharacterId.NONE;
                 }
             }
-
             party.select = selectList.ToArray();
+
+            if (PersistenSingleton<UIManager>.Instance.UnityScene == UIManager.Scene.Battle)
+            {
+                party.exact_party_ct = FF9StateSystem.Common.FF9.party.MemberCount;
+                party.fix = UIManager.Battle.GetNonSwappableCharacters();
+            }
             return party;
         }
 

--- a/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
+++ b/Assembly-CSharp/Global/UI/UIKey/UIKeyTrigger.cs
@@ -126,33 +126,40 @@ public class UIKeyTrigger : MonoBehaviour
 
     private void Update()
     {
-        GameLoopManager.RaiseUpdateEvent();
+        try
+        {
+            GameLoopManager.RaiseUpdateEvent();
 
-        if (UnityXInput.Input.GetAxis("Mouse X") < 1.0 / 1000.0 && UnityXInput.Input.GetAxis("Mouse Y") < 1.0 / 1000.0)
-        {
-            disableMouseCounter += Time.deltaTime;
+            if (UnityXInput.Input.GetAxis("Mouse X") < 1.0 / 1000.0 && UnityXInput.Input.GetAxis("Mouse Y") < 1.0 / 1000.0)
+            {
+                disableMouseCounter += Time.deltaTime;
+            }
+            else
+            {
+                disableMouseCounter = 0.0f;
+                if (!UICamera.list[0].useMouse)
+                    UICamera.list[0].useMouse = true;
+            }
+            if (UnityXInput.Input.GetMouseButton(0) || UnityXInput.Input.GetMouseButton(1) || (UnityXInput.Input.GetMouseButton(2) || Mathf.Abs(UnityXInput.Input.GetAxis("Mouse ScrollWheel")) > 0.00999999977648258))
+            {
+                disableMouseCounter = 0.0f;
+                if (!UICamera.list[0].useMouse)
+                    UICamera.list[0].useMouse = true;
+            }
+            if (disableMouseCounter > 1.0 && UICamera.list[0].useMouse)
+                UICamera.list[0].useMouse = false;
+            if (!UnityXInput.Input.anyKey && !isLockLazyInput)
+                ResetKeyCode();
+            AccelerateKeyNavigation();
+            if (HandleMenuControlKeyPressCustomInput())
+                return;
+            HandleBoosterButton();
+            HandleDialogControlKeyPressCustomInput();
         }
-        else
+        catch (Exception err)
         {
-            disableMouseCounter = 0.0f;
-            if (!UICamera.list[0].useMouse)
-                UICamera.list[0].useMouse = true;
+            Log.Error(err);
         }
-        if (UnityXInput.Input.GetMouseButton(0) || UnityXInput.Input.GetMouseButton(1) || (UnityXInput.Input.GetMouseButton(2) || Mathf.Abs(UnityXInput.Input.GetAxis("Mouse ScrollWheel")) > 0.00999999977648258))
-        {
-            disableMouseCounter = 0.0f;
-            if (!UICamera.list[0].useMouse)
-                UICamera.list[0].useMouse = true;
-        }
-        if (disableMouseCounter > 1.0 && UICamera.list[0].useMouse)
-            UICamera.list[0].useMouse = false;
-        if (!UnityXInput.Input.anyKey && !isLockLazyInput)
-            ResetKeyCode();
-        AccelerateKeyNavigation();
-        if (HandleMenuControlKeyPressCustomInput())
-            return;
-        HandleBoosterButton();
-        HandleDialogControlKeyPressCustomInput();
     }
 
     private void AccelerateKeyNavigation()
@@ -909,7 +916,7 @@ namespace Memoria
 {
     public static class UISceneHelper
     {
-        public static void OpenPartyMenu()
+        public static FF9PARTY_INFO GetCurrentPartyForMenu()
         {
             FF9PARTY_INFO party = new FF9PARTY_INFO();
             List<CharacterId> selectList = new List<CharacterId>();
@@ -934,7 +941,12 @@ namespace Memoria
             }
 
             party.select = selectList.ToArray();
-            EventService.OpenPartyMenu(party);
+            return party;
+        }
+
+        public static void OpenPartyMenu()
+        {
+            EventService.OpenPartyMenu(GetCurrentPartyForMenu());
         }
     }
 }

--- a/Assembly-CSharp/Global/UI/UITable.cs
+++ b/Assembly-CSharp/Global/UI/UITable.cs
@@ -92,93 +92,84 @@ public class UITable : UIWidgetContainer
 
     protected void RepositionVariableSize(List<Transform> children)
     {
-        Single num = 0f;
-        Single num2 = 0f;
-        Int32 num3 = (Int32)((this.columns <= 0) ? 1 : (children.Count / this.columns + 1));
-        Int32 num4 = (Int32)((this.columns <= 0) ? children.Count : this.columns);
-        Bounds[,] array = new Bounds[num3, num4];
-        Bounds[] array2 = new Bounds[num4];
-        Bounds[] array3 = new Bounds[num3];
-        Int32 num5 = 0;
-        Int32 num6 = 0;
-        Int32 i = 0;
-        Int32 count = children.Count;
-        while (i < count)
+        Single posX = 0f;
+        Single posY = 0f;
+        Int32 rowCount = this.columns <= 0 ? 1 : children.Count / this.columns + 1;
+        Int32 colCount = this.columns <= 0 ? children.Count : this.columns;
+        Bounds[,] allItemBounds = new Bounds[rowCount, colCount];
+        Bounds[] colBounds = new Bounds[colCount];
+        Bounds[] rowBounds = new Bounds[rowCount];
+        Int32 rowIndex = 0;
+        Int32 colIndex = 0;
+        for (Int32 i = 0; i < children.Count; i++)
         {
-            Transform transform = children[i];
-            Bounds bounds = NGUIMath.CalculateRelativeWidgetBounds(transform, !this.hideInactive);
-            Vector3 localScale = transform.localScale;
+            Transform item = children[i];
+            Bounds bounds = NGUIMath.CalculateRelativeWidgetBounds(item, !this.hideInactive);
+            Vector3 localScale = item.localScale;
             bounds.min = Vector3.Scale(bounds.min, localScale);
             bounds.max = Vector3.Scale(bounds.max, localScale);
-            array[num6, num5] = bounds;
-            array2[num5].Encapsulate(bounds);
-            array3[num6].Encapsulate(bounds);
-            if (++num5 >= this.columns && this.columns > 0)
+            allItemBounds[rowIndex, colIndex] = bounds;
+            colBounds[colIndex].Encapsulate(bounds);
+            rowBounds[rowIndex].Encapsulate(bounds);
+            if (++colIndex >= this.columns && this.columns > 0)
             {
-                num5 = 0;
-                num6++;
+                colIndex = 0;
+                rowIndex++;
             }
-            i++;
         }
-        num5 = 0;
-        num6 = 0;
+        colIndex = 0;
+        rowIndex = 0;
         Vector2 pivotOffset = NGUIMath.GetPivotOffset(this.cellAlignment);
-        Int32 j = 0;
-        Int32 count2 = children.Count;
-        while (j < count2)
+        for (Int32 i = 0; i < children.Count; i++)
         {
-            Transform transform2 = children[j];
-            Bounds bounds2 = array[num6, num5];
-            Bounds bounds3 = array2[num5];
-            Bounds bounds4 = array3[num6];
-            Vector3 localPosition = transform2.localPosition;
-            localPosition.x = num + bounds2.extents.x - bounds2.center.x;
-            localPosition.x -= Mathf.Lerp(0f, bounds2.max.x - bounds2.min.x - bounds3.max.x + bounds3.min.x, pivotOffset.x) - this.padding.x;
+            Transform item = children[i];
+            Bounds childBound = allItemBounds[rowIndex, colIndex];
+            Bounds colBound = colBounds[colIndex];
+            Bounds rowBound = rowBounds[rowIndex];
+            Vector3 itemPos = item.localPosition;
+            itemPos.x = posX + childBound.extents.x - childBound.center.x;
+            itemPos.x -= Mathf.Lerp(0f, childBound.max.x - childBound.min.x - colBound.max.x + colBound.min.x, pivotOffset.x) - this.padding.x;
             if (this.direction == UITable.Direction.Down)
             {
-                localPosition.y = -num2 - bounds2.extents.y - bounds2.center.y;
-                localPosition.y += Mathf.Lerp(bounds2.max.y - bounds2.min.y - bounds4.max.y + bounds4.min.y, 0f, pivotOffset.y) - this.padding.y;
+                itemPos.y = -posY - childBound.extents.y - childBound.center.y;
+                itemPos.y += Mathf.Lerp(childBound.max.y - childBound.min.y - rowBound.max.y + rowBound.min.y, 0f, pivotOffset.y) - this.padding.y;
             }
             else
             {
-                localPosition.y = num2 + bounds2.extents.y - bounds2.center.y;
-                localPosition.y -= Mathf.Lerp(0f, bounds2.max.y - bounds2.min.y - bounds4.max.y + bounds4.min.y, pivotOffset.y) - this.padding.y;
+                itemPos.y = posY + childBound.extents.y - childBound.center.y;
+                itemPos.y -= Mathf.Lerp(0f, childBound.max.y - childBound.min.y - rowBound.max.y + rowBound.min.y, pivotOffset.y) - this.padding.y;
             }
-            num += bounds3.size.x + this.padding.x * 2f;
-            transform2.localPosition = localPosition;
-            if (++num5 >= this.columns && this.columns > 0)
+            posX += colBound.size.x + this.padding.x * 2f;
+            item.localPosition = itemPos;
+            if (++colIndex >= this.columns && this.columns > 0)
             {
-                num5 = 0;
-                num6++;
-                num = 0f;
-                num2 += bounds4.size.y + this.padding.y * 2f;
+                colIndex = 0;
+                rowIndex++;
+                posX = 0f;
+                posY += rowBound.size.y + this.padding.y * 2f;
             }
-            j++;
         }
         if (this.pivot != UIWidget.Pivot.TopLeft)
         {
             pivotOffset = NGUIMath.GetPivotOffset(this.pivot);
-            Bounds bounds5 = NGUIMath.CalculateRelativeWidgetBounds(base.transform);
-            Single num7 = Mathf.Lerp(0f, bounds5.size.x, pivotOffset.x);
-            Single num8 = Mathf.Lerp(-bounds5.size.y, 0f, pivotOffset.y);
-            Transform transform3 = base.transform;
-            for (Int32 k = 0; k < transform3.childCount; k++)
+            Bounds fullBound = NGUIMath.CalculateRelativeWidgetBounds(base.transform);
+            Single pivotOffsetX = Mathf.Lerp(0f, fullBound.size.x, pivotOffset.x);
+            Single pivotOffsetY = Mathf.Lerp(-fullBound.size.y, 0f, pivotOffset.y);
+            for (Int32 i = 0; i < base.transform.childCount; i++)
             {
-                Transform child = transform3.GetChild(k);
-                SpringPosition component = child.GetComponent<SpringPosition>();
-                if (component != (UnityEngine.Object)null)
+                Transform child = base.transform.GetChild(i);
+                SpringPosition spring = child.GetComponent<SpringPosition>();
+                if (spring != null)
                 {
-                    SpringPosition springPosition = component;
-                    springPosition.target.x = springPosition.target.x - num7;
-                    SpringPosition springPosition2 = component;
-                    springPosition2.target.y = springPosition2.target.y - num8;
+                    spring.target.x -= pivotOffsetX;
+                    spring.target.y -= pivotOffsetY;
                 }
                 else
                 {
-                    Vector3 localPosition2 = child.localPosition;
-                    localPosition2.x -= num7;
-                    localPosition2.y -= num8;
-                    child.localPosition = localPosition2;
+                    Vector3 childPos = child.localPosition;
+                    childPos.x -= pivotOffsetX;
+                    childPos.y -= pivotOffsetY;
+                    child.localPosition = childPos;
                 }
             }
         }

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Nested.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Nested.cs
@@ -54,7 +54,7 @@ public partial class BattleHUD : UIScene
         Ability,
         Item,
         Throw,
-        Slide,
+        Instant,
     }
 
     [Flags]

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Scene.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Scene.cs
@@ -607,14 +607,16 @@ public partial class BattleHUD : UIScene
                 ButtonGroupState.ActiveButton = ButtonGroupState.GetCursorStartSelect(TargetGroupButton);
             }
             _cursorType = CursorGroup.Individual;
-            _targetPanel.ActivateButtons(false);
+            _targetPanel.Buttons.Player.IsActive = false;
+            _targetPanel.Buttons.Enemy.IsActive = false;
         }
         else
         {
             ButtonGroupState.SetButtonAnimation(ButtonGroupState.ActiveButton, false);
             Singleton<PointerManager>.Instance.RemovePointerFromGameObject(ButtonGroupState.ActiveButton);
             _cursorType = _currentTargetIndex >= HonoluluBattleMain.EnemyStartIndex ? CursorGroup.AllEnemy : CursorGroup.AllPlayer;
-            _targetPanel.ActivateButtons(true);
+            _targetPanel.Buttons.Player.IsActive = _targetCursor != TargetType.ManyEnemy;
+            _targetPanel.Buttons.Enemy.IsActive = _targetCursor != TargetType.ManyAlly;
         }
         UpdateTargetStates();
         SetTargetHelp();

--- a/Assembly-CSharp/Global/battle/BattlePlayerCharacter.cs
+++ b/Assembly-CSharp/Global/battle/BattlePlayerCharacter.cs
@@ -72,6 +72,8 @@ public class BattlePlayerCharacter : MonoBehaviour
 
     public static void CreatePlayer(BTL_DATA btl, PLAYER p)
     {
+        if (btl.gameObject != null)
+            UnityEngine.Object.Destroy(btl.gameObject);
         CharacterBattleParameter btlParam = btl_mot.BattleParameterList[p.info.serial_no];
         p.wep_bone = btlParam.WeaponBone;
         btl.gameObject = ModelFactory.CreateModel(btlParam.ModelId, true, true, Configuration.Graphics.ElementsSmoothTexture);
@@ -86,6 +88,8 @@ public class BattlePlayerCharacter : MonoBehaviour
 
     private static void CreateTranceModel(BTL_DATA btl, String path)
     {
+        if (btl.tranceGo != null)
+            UnityEngine.Object.Destroy(btl.tranceGo);
         btl.tranceGo = ModelFactory.CreateModel(path, true, true, Configuration.Graphics.ElementsSmoothTexture);
         btl.tranceGo.transform.localPosition = new Vector3(btl.tranceGo.transform.localPosition.x, -10000f, btl.tranceGo.transform.localPosition.z);
         // Set custom trance texture, if they exist

--- a/Assembly-CSharp/Global/btl2d.cs
+++ b/Assembly-CSharp/Global/btl2d.cs
@@ -359,7 +359,19 @@ public static class btl2d
     public static void ShowMessages(Boolean show = true)
     {
         foreach (HUDMessageChild message in btl2d.StatusMessages)
+        {
             message.gameObject.SetActive(show);
+            if (show && message.Follower.targetBtl != null && message.Follower.iconPosition >= 0)
+            {
+                // Check if the follow is still valid or needs update
+                btl2d.GetIconPosition(message.Follower.targetBtl, message.Follower.iconPosition, out Transform attach, out Vector3 off);
+                if (attach != message.Follower.target)
+                {
+                    message.Follower.target = attach;
+                    message.Follower.targetTransformOffset = off;
+                }
+            }
+        }
     }
 
     public static void GetIconPosition(BTL_DATA btl, out Byte[] iconBone, out SByte[] iconOffY, out SByte[] iconOffZ)

--- a/Assembly-CSharp/Global/btl_cmd.cs
+++ b/Assembly-CSharp/Global/btl_cmd.cs
@@ -56,6 +56,7 @@ public class btl_cmd
         cmd.next = null;
         cmd.aa = null;
         cmd.tar_id = 0;
+        cmd.magic_caster_id = 0;
         cmd.cmd_no = BattleCommandId.None;
         cmd.sub_no = 0;
         cmd.info.Reset();
@@ -244,6 +245,13 @@ public class btl_cmd
             return;
         }
 
+        BattleAbilityId aaIndex = btl_util.GetCommandMainActionIndex(cmd);
+        if (caster != null && aaIndex != BattleAbilityId.Void)
+        {
+            BattleMagicSwordSet magicSet = UIManager.Battle.GetMagicSwordOfAbility(new BattleUnit(caster), ff9abil.GetAbilityIdFromActiveAbility(aaIndex));
+            if (magicSet != null)
+                cmd.magic_caster_id = BattleState.GetPlayerUnit(magicSet.Supporter)?.Id ?? 0;
+        }
         cmd.tar_id = tar_id;
         cmd.info.cursor = (Byte)cursor;
         cmd.info.cover = 0;
@@ -1115,9 +1123,8 @@ public class btl_cmd
     {
         if (btl.bi.player == 0 || btl.bi.slot_no != (Byte)CharacterId.Garnet)
             return;
-        FF9StateBattleSystem stateBattleSystem = FF9StateSystem.Battle.FF9Battle;
         KillSpecificCommand(btl, BattleCommandId.SysPhantom);
-        stateBattleSystem.cmd_status &= 0xFFF3;
+        FF9StateSystem.Battle.FF9Battle.cmd_status &= 0xFFF3;
     }
 
     public static void ManageDequeueCommand(CMD_DATA cp, CMD_DATA ncp)

--- a/Assembly-CSharp/Global/btl_init.cs
+++ b/Assembly-CSharp/Global/btl_init.cs
@@ -21,8 +21,7 @@ public static class btl_init
         CharacterBattleParameter param = btl_mot.BattleParameterList[characterModelIndex];
         String modelId = isTrance ? param.TranceModelId : param.ModelId;
 
-        Int32 geoId;
-        if (FF9BattleDB.GEO.TryGetKey(modelId, out geoId))
+        if (FF9BattleDB.GEO.TryGetKey(modelId, out Int32 geoId))
             return (Int16)geoId;
 
         Log.Warning("[btl_init] Unknown model id: {0}", modelId);
@@ -324,50 +323,54 @@ public static class btl_init
             if (FF9StateSystem.Common.FF9.party.member[i] != null)
                 playerCount++;
         Int32 gap = 632;
-        Int32 bposFrontBack = btl_init.PLAYER_ORIGINAL_Z;
         Int32 posLeftRight = (Int16)((playerCount - 1) * gap / 2);
-        Int32 baseAngle = (Int16)((btl_scene.Info.StartType != battle_start_type_tags.BTL_START_BACK_ATTACK) ? 180 : 0);
         for (BTL_DATA btl = FF9StateSystem.Battle.FF9Battle.btl_list.next; btl != null; btl = btl.next)
         {
             if (btl.bi.player == 0)
                 break;
-            CharacterId charId = (CharacterId)btl.bi.slot_no;
-            btl.bi.row = FF9StateSystem.Common.FF9.player[charId].info.row;
-            if (btl_scene.Info.StartType == battle_start_type_tags.BTL_START_BACK_ATTACK)
-                btl.bi.row ^= 1;
-            btl.original_pos[0] = posLeftRight;
-            btl.evt.posBattle[0] = posLeftRight;
-            btl.base_pos[0] = posLeftRight;
-            btl.pos[0] = posLeftRight;
-            Single posHeight = 0; // btl_stat.CheckStatus(btl, BattleStatus.Float) ? -200 : 0;
-            btl.original_pos[1] = 0;
-            btl.evt.posBattle[1] = posHeight;
-            btl.base_pos[1] = posHeight;
-            btl.pos[1] = posHeight;
-            Single posz = bposFrontBack + ((btl.bi.row == 0) ? -400 : 0);
-            btl.original_pos[2] = bposFrontBack;
-            btl.evt.posBattle[2] = posz;
-            btl.base_pos[2] = posz;
-            btl.pos[2] = posz;
-            btl.evt.rotBattle = Quaternion.Euler(new Vector3(0f, 180f, 180f));
-            btl.rot = Quaternion.Euler(new Vector3(0f, baseAngle, 180f));
-            //next.rot = (next.evt.rotBattle = Quaternion.Euler(new Vector3(0f, baseAngle, 180f)));
-            btl.gameObject.transform.localPosition = btl.pos;
-            btl.gameObject.transform.localRotation = btl.rot;
-            CharacterBattleParameter btlParam = btl_mot.BattleParameterList[FF9StateSystem.Common.FF9.player[charId].info.serial_no];
-            btl.shadow_bone[0] = btlParam.ShadowData[0];
-            btl.shadow_bone[1] = btlParam.ShadowData[1];
-            btl_util.SetShadow(btl, btlParam.ShadowData[2], btlParam.ShadowData[3]);
-            btl.geo_scale_x = btl.geo_scale_y = btl.geo_scale_z = btl.geo_scale_default = 4096;
-            GameObject shadowObj = FF9StateSystem.Battle.FF9Battle.map.shadowArray[btl];
-            Vector3 shadowPos = shadowObj.transform.localPosition;
-            shadowPos.z = btlParam.ShadowData[4];
-            shadowObj.transform.localPosition = shadowPos;
+            SetupBattlePlayerSingle(btl, posLeftRight, btl_scene.Info.StartType);
             posLeftRight -= gap;
         }
     }
 
-    public static void OrganizePlayerData(PLAYER p, BTL_DATA btl, UInt16 cnt, UInt16 btl_no)
+    public static void SetupBattlePlayerSingle(BTL_DATA btl, Int32 posLeftRight, battle_start_type_tags startType)
+    {
+        Int32 baseAngle = (Int16)((startType != battle_start_type_tags.BTL_START_BACK_ATTACK) ? 180 : 0);
+        CharacterId charId = (CharacterId)btl.bi.slot_no;
+        btl.bi.row = FF9StateSystem.Common.FF9.player[charId].info.row;
+        if (startType == battle_start_type_tags.BTL_START_BACK_ATTACK)
+            btl.bi.row ^= 1;
+        btl.original_pos[0] = posLeftRight;
+        btl.evt.posBattle[0] = posLeftRight;
+        btl.base_pos[0] = posLeftRight;
+        btl.pos[0] = posLeftRight;
+        Single posHeight = 0; // btl_stat.CheckStatus(btl, BattleStatus.Float) ? -200 : 0;
+        btl.original_pos[1] = 0;
+        btl.evt.posBattle[1] = posHeight;
+        btl.base_pos[1] = posHeight;
+        btl.pos[1] = posHeight;
+        Single posz = btl_init.PLAYER_ORIGINAL_Z + ((btl.bi.row == 0) ? -400 : 0);
+        btl.original_pos[2] = btl_init.PLAYER_ORIGINAL_Z;
+        btl.evt.posBattle[2] = posz;
+        btl.base_pos[2] = posz;
+        btl.pos[2] = posz;
+        btl.evt.rotBattle = Quaternion.Euler(new Vector3(0f, 180f, 180f));
+        btl.rot = Quaternion.Euler(new Vector3(0f, baseAngle, 180f));
+        //next.rot = (next.evt.rotBattle = Quaternion.Euler(new Vector3(0f, baseAngle, 180f)));
+        btl.gameObject.transform.localPosition = btl.pos;
+        btl.gameObject.transform.localRotation = btl.rot;
+        CharacterBattleParameter btlParam = btl_mot.BattleParameterList[FF9StateSystem.Common.FF9.player[charId].info.serial_no];
+        btl.shadow_bone[0] = btlParam.ShadowData[0];
+        btl.shadow_bone[1] = btlParam.ShadowData[1];
+        btl_util.SetShadow(btl, btlParam.ShadowData[2], btlParam.ShadowData[3]);
+        btl.geo_scale_x = btl.geo_scale_y = btl.geo_scale_z = btl.geo_scale_default = 4096;
+        GameObject shadowObj = FF9StateSystem.Battle.FF9Battle.map.shadowArray[btl];
+        Vector3 shadowPos = shadowObj.transform.localPosition;
+        shadowPos.z = btlParam.ShadowData[4];
+        shadowObj.transform.localPosition = shadowPos;
+    }
+
+    public static void OrganizePlayerData(PLAYER p, BTL_DATA btl, UInt16 cnt, UInt16 btl_no, Boolean reinit = false)
     {
         BattleUnit unit = new BattleUnit(btl);
         CharacterBattleParameter btlParam = btl_mot.BattleParameterList[p.info.serial_no];
@@ -409,23 +412,34 @@ public static class btl_init
         btl.uiLabelMP = null;
         btl.uiSpriteATB = BattleHUD.ATENormal;
         btl.uiSpriteATB = BattleHUD.ATENormal;
-        FF9Char ff9Char = new FF9Char();
+        FF9Char ff9Char = reinit ? FF9StateSystem.Common.FF9.charArray.Values.FirstOrDefault(ch => ch.btl == btl) : new FF9Char();
+        if (ff9Char == null)
+            ff9Char = new FF9Char();
         ff9Char.btl = btl;
         ff9Char.evt = btl.evt;
         if (ff9play.CharacterIDToEventId(p.Index) >= 0)
-            FF9StateSystem.Common.FF9.charArray.Add(ff9play.CharacterIDToEventId(p.Index), ff9Char);
+            FF9StateSystem.Common.FF9.charArray[ff9play.CharacterIDToEventId(p.Index)] = ff9Char;
         else
-            FF9StateSystem.Common.FF9.charArray.Add(9 + (Int32)p.Index, ff9Char);
+            FF9StateSystem.Common.FF9.charArray[9 + (Int32)p.Index] = ff9Char;
         btl_init.InitBattleData(btl, ff9Char);
         btl.mesh_banish = UInt16.MaxValue;
-        btl.max.at = btl_para.GetMaxATB(unit);
         btl_para.SetupATBCoef(btl, btl_para.GetATBCoef());
-        if (FF9StateSystem.Battle.FF9Battle.btl_scene.Info.StartType == battle_start_type_tags.BTL_START_BACK_ATTACK)
-            btl.cur.at = 0;
-        else if (FF9StateSystem.Battle.FF9Battle.btl_scene.Info.StartType == battle_start_type_tags.BTL_START_FIRST_ATTACK)
-            btl.cur.at = (Int16)(btl.max.at - 1);
+        if (reinit)
+        {
+            Single atbProgress = (Single)btl.cur.at / btl.max.at;
+            btl.max.at = btl_para.GetMaxATB(unit);
+            btl.cur.at = (Int16)Math.Min(btl.max.at - 1, Math.Round(atbProgress * btl.max.at));
+        }
         else
-            btl.cur.at = (Int16)(Comn.random16() % btl.max.at);
+        {
+            btl.max.at = btl_para.GetMaxATB(unit);
+            if (FF9StateSystem.Battle.FF9Battle.btl_scene.Info.StartType == battle_start_type_tags.BTL_START_BACK_ATTACK)
+                btl.cur.at = 0;
+            else if (FF9StateSystem.Battle.FF9Battle.btl_scene.Info.StartType == battle_start_type_tags.BTL_START_FIRST_ATTACK)
+                btl.cur.at = (Int16)(btl.max.at - 1);
+            else
+                btl.cur.at = (Int16)(Comn.random16() % btl.max.at);
+        }
         btl.geoScaleStatus = Vector3.one;
         btl.animSpeedStatusFactor = 1f;
         btl_mot.SetPlayerDefMotion(btl, p.info.serial_no, btl_no);
@@ -444,6 +458,8 @@ public static class btl_init
         btl.stat.permanent = p.permanent_status;
         btl.stat.cur = p.status;
         btl_abil.CheckStatusAbility(unit);
+        if (reinit)
+            btl.stat.cur = p.status;
         BattleStatus resist_stat = btl.stat.invalid;
         BattleStatus permanent_stat = btl.stat.permanent;
         BattleStatus current_stat = btl.stat.cur;
@@ -594,6 +610,40 @@ public static class btl_init
         GEOTEXHEADER tranceTextureAnim = new GEOTEXHEADER();
         tranceTextureAnim.ReadTranceTextureAnim(btl, tranceModelName);
         btl.tranceTexanimptr = tranceTextureAnim;
+    }
+
+    public static void SwapPlayerCharacter(BattleUnit unit, PLAYER newChar)
+    {
+        BTL_DATA btl = unit.Data;
+        // HonoluluBattleMain.CreateBattleData
+        BattlePlayerCharacter.CreatePlayer(btl, newChar);
+        Int32 meshCount = 0;
+        foreach (Transform transform in btl.gameObject.transform)
+            if (transform.name.Contains("mesh"))
+                meshCount++;
+        btl.meshCount = meshCount;
+        btl.meshIsRendering = new Boolean[meshCount];
+        for (Int32 i = 0; i < meshCount; ++i)
+            btl.meshIsRendering[i] = true;
+        btl.animation = btl.gameObject.GetComponent<Animation>();
+        // InitPlayerData
+        btl.dms_geo_id = GetModelID(newChar.info.serial_no);
+        OrganizePlayerData(newChar, btl, btl.bi.line_no, (UInt16)unit.GetIndex(), true);
+        SetBattleModel(btl);
+        if (btl_stat.CheckStatus(btl, BattleStatus.Death))
+        {
+            GeoTexAnim.geoTexAnimStop(btl.texanimptr, 2);
+            GeoTexAnim.geoTexAnimPlayOnce(btl.texanimptr, 0);
+            GeoTexAnim.geoTexAnimStop(btl.tranceTexanimptr, 2);
+            GeoTexAnim.geoTexAnimPlayOnce(btl.tranceTexanimptr, 0);
+        }
+        else
+        {
+            GeoTexAnim.geoTexAnimPlay(btl.texanimptr, 2);
+        }
+        btl_sys.AddCharacter(btl);
+        // Part of SetupBattlePlayer
+        SetupBattlePlayerSingle(btl, (Int32)btl.original_pos[0], battle_start_type_tags.BTL_START_NORMAL_ATTACK);
     }
 
     public const Int32 PLAYER_ORIGINAL_Z = -1560;

--- a/Assembly-CSharp/Global/btl_init.cs
+++ b/Assembly-CSharp/Global/btl_init.cs
@@ -402,6 +402,7 @@ public static class btl_init
         btl.elem.mgc = p.elem.mgc;
         btl.elem.wpr = p.elem.wpr;
         btl.level = p.level;
+        Single atbProgress = reinit ? (Single)btl.cur.at / btl.max.at : 0f;
         btl_init.CopyPoints(btl.max, p.max);
         btl_init.CopyPoints(btl.cur, p.cur);
         btl.maxDamageLimit = p.maxDamageLimit;
@@ -426,9 +427,8 @@ public static class btl_init
         btl_para.SetupATBCoef(btl, btl_para.GetATBCoef());
         if (reinit)
         {
-            Single atbProgress = (Single)btl.cur.at / btl.max.at;
             btl.max.at = btl_para.GetMaxATB(unit);
-            btl.cur.at = (Int16)Math.Min(btl.max.at - 1, Math.Round(atbProgress * btl.max.at));
+            btl.cur.at = (Int16)Math.Floor(atbProgress * btl.max.at);
         }
         else
         {

--- a/Assembly-CSharp/Global/btl_vfx.cs
+++ b/Assembly-CSharp/Global/btl_vfx.cs
@@ -210,6 +210,7 @@ public static class btl_vfx
         }
         geo.geoAttach(btl.weapon_geo, btl.gameObject, btl.weapon_bone);
         AnimationFactory.AddAnimToGameObject(btl.gameObject, btl_mot.BattleParameterList[serialNo].ModelId, true);
+        btl2d.ShowMessages(true);
     }
 
     public static SpecialEffect GetPlayerAttackVfx(BTL_DATA btl)

--- a/Assembly-CSharp/Global/btlshadow.cs
+++ b/Assembly-CSharp/Global/btlshadow.cs
@@ -6,7 +6,15 @@ public class btlshadow
 {
     public static void ff9battleShadowInit(BTL_DATA btl)
     {
-        GameObject shadow = new GameObject("shadow" + btl.bi.slot_no.ToString("D3"));
+        if (FF9StateSystem.Battle.FF9Battle.map.shadowArray.TryGetValue(btl, out GameObject shadow))
+        {
+            // Re-init
+            shadow.transform.localScale = new Vector3(224f, 0f, 192f);
+            shadow.GetComponent<MeshRenderer>().material.SetColor("_TintColor", new Color32(64, 64, 64, Byte.MaxValue));
+            shadow.SetActive(false);
+            return;
+        }
+        shadow = new GameObject("shadow" + btl.bi.slot_no.ToString("D3"));
         FF9StateSystem.Battle.FF9Battle.map.shadowArray[btl] = shadow;
         List<Vector3> vertList = new List<Vector3>();
         List<Color> colList = new List<Color>();

--- a/Assembly-CSharp/Global/ff9/FF9PARTY_INFO.cs
+++ b/Assembly-CSharp/Global/ff9/FF9PARTY_INFO.cs
@@ -5,10 +5,8 @@ using System.Collections.Generic;
 public class FF9PARTY_INFO
 {
     public Int32 party_ct;
-
+    public Int32 exact_party_ct;
     public CharacterId[] menu = new CharacterId[4];
-
     public CharacterId[] select = null;
-
     public HashSet<CharacterId> fix = new HashSet<CharacterId>();
 }

--- a/Assembly-CSharp/Global/ff9/State/Battle/FF9StateBattleSystem.cs
+++ b/Assembly-CSharp/Global/ff9/State/Battle/FF9StateBattleSystem.cs
@@ -119,7 +119,7 @@ public class FF9StateBattleSystem
 
     public IEnumerable<BattleUnit> EnumerateBattleUnits()
     {
-        for (BTL_DATA data = FF9StateSystem.Battle.FF9Battle.btl_list.next; data != null; data = data.next)
+        for (BTL_DATA data = btl_list.next; data != null; data = data.next)
             yield return new BattleUnit(data);
     }
 
@@ -127,5 +127,15 @@ public class FF9StateBattleSystem
     {
         BTL_DATA data = btl_data[index];
         return new BattleUnit(data);
+    }
+
+    public IEnumerable<BattleUnit> EnumerateDeletedUnits()
+    {
+        HashSet<UInt16> presentList = new HashSet<UInt16>();
+        for (BTL_DATA btl = btl_list.next; btl != null; btl = btl.next)
+            presentList.Add(btl.btl_id);
+        for (Int32 i = 0; i < 8; i++)
+            if (btl_data[i].btl_id != 0 && !presentList.Contains(btl_data[i].btl_id))
+                yield return new BattleUnit(btl_data[i]);
     }
 }

--- a/Assembly-CSharp/Memoria/Battle/Calculator/BattleUnit.cs
+++ b/Assembly-CSharp/Memoria/Battle/Calculator/BattleUnit.cs
@@ -937,6 +937,7 @@ namespace Memoria
             btl_stat.AlterStatuses(this, current_added);
             btl_stat.MakeStatusesPermanent(this, monsterTransform.auto_added, true);
             // TODO: handle "partialResist" and "durationFactor" properly (now, they are most likely applied but persist after "ReleaseChangeToMonster")
+            btl2d.ShowMessages(true);
         }
 
         private void ChangeToMonster_SetClip(String[] array, String animName, BattlePlayerCharacter.PlayerMotionIndex motion)

--- a/Assembly-CSharp/Memoria/Battle/SFX/UnifiedBattleSequencer.cs
+++ b/Assembly-CSharp/Memoria/Battle/SFX/UnifiedBattleSequencer.cs
@@ -330,7 +330,10 @@ public static class UnifiedBattleSequencer
                             sfxArg[3] |= 4;
                         customRequest.SetupVfxRequest(cmd, sfxArg, caster, tmpChar);
                         if (mcasterId != 0)
+                        {
+                            cmd.magic_caster_id |= mcasterId;
                             customRequest.mexe = btl_scrp.FindBattleUnit(mcasterId).Data;
+                        }
                         if (code.TryGetArgVector("TargetPosition", out tmpVec))
                         {
                             customRequest.trgcpos.vx = (Int32)tmpVec.x;

--- a/Assembly-CSharp/Memoria/Configuration/Access/Battle.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Access/Battle.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 namespace Memoria
 {
@@ -62,6 +63,11 @@ namespace Memoria
                 Instance._battle.Enabled.Value = true;
                 SaveValue(Instance._battle.Name, Instance._battle.Enabled);
                 SaveValue(Instance._battle.Name, Instance._battle.Speed);
+            }
+
+            public static Boolean IsMenuEnabledInBattle(MainMenuUI.SubMenu subMenu)
+            {
+                return AccessMenus > 0 && (AvailableMenus.Length == 0 || AvailableMenus.Contains(subMenu.ToString()));
             }
         }
     }

--- a/Assembly-CSharp/Memoria/Data/Characters/CharacterCommand.cs
+++ b/Assembly-CSharp/Memoria/Data/Characters/CharacterCommand.cs
@@ -18,6 +18,7 @@ namespace Memoria.Data
             {
                 case CharacterCommandType.Throw:
                 case CharacterCommandType.Normal:
+                case CharacterCommandType.Instant:
                     yield return (BattleAbilityId)MainEntry;
                     yield break;
                 case CharacterCommandType.Ability:
@@ -33,6 +34,7 @@ namespace Memoria.Data
             {
                 case CharacterCommandType.Throw:
                 case CharacterCommandType.Normal:
+                case CharacterCommandType.Instant:
                     return (BattleAbilityId)MainEntry;
                 case CharacterCommandType.Ability:
                     if (index < 0 || index >= ListEntry.Length)

--- a/Assembly-CSharp/Memoria/Data/Characters/CharacterCommandType.cs
+++ b/Assembly-CSharp/Memoria/Data/Characters/CharacterCommandType.cs
@@ -5,6 +5,7 @@ namespace Memoria.Data
         Normal = 0,
         Ability = 1,
         Item = 2,
-        Throw = 3
+        Throw = 3,
+        Instant = 4
     }
 }

--- a/Assembly-CSharp/Memoria/Scripts/DefaultStatus/DoomStatusScript.cs
+++ b/Assembly-CSharp/Memoria/Scripts/DefaultStatus/DoomStatusScript.cs
@@ -15,10 +15,9 @@ namespace Memoria.DefaultScripts
         public override UInt32 Apply(BattleUnit target, BattleUnit inflicter, params Object[] parameters)
         {
             base.Apply(target, inflicter, parameters);
-            btl2d.GetIconPosition(target, btl2d.ICON_POS_NUMBER, out Transform attachTransf, out Vector3 iconOff);
             InitialCounter = parameters.Length > 0 ? Convert.ToInt32(parameters[0]) : 10;
             Counter = InitialCounter;
-            Message = Singleton<HUDMessage>.Instance.Show(attachTransf, $"{Counter}", HUDMessage.MessageStyle.DEATH_SENTENCE, new Vector3(0f, iconOff.y), 0);
+            Message = Singleton<HUDMessage>.Instance.Show(target, btl2d.ICON_POS_NUMBER, $"{Counter}", HUDMessage.MessageStyle.DEATH_SENTENCE);
             btl2d.StatusMessages.Add(Message);
             return btl_stat.ALTER_SUCCESS;
         }

--- a/Assembly-CSharp/Memoria/Scripts/DefaultStatus/GradualPetrifyStatusScript.cs
+++ b/Assembly-CSharp/Memoria/Scripts/DefaultStatus/GradualPetrifyStatusScript.cs
@@ -16,10 +16,9 @@ namespace Memoria.DefaultScripts
         public override UInt32 Apply(BattleUnit target, BattleUnit inflicter, params Object[] parameters)
         {
             base.Apply(target, inflicter, parameters);
-            btl2d.GetIconPosition(target, btl2d.ICON_POS_NUMBER, out Transform attachTransf, out Vector3 iconOff);
             InitialCounter = parameters.Length > 0 ? Convert.ToInt32(parameters[0]) : 10;
             Counter = InitialCounter;
-            Message = Singleton<HUDMessage>.Instance.Show(attachTransf, $"{Counter}", HUDMessage.MessageStyle.DEATH_SENTENCE, new Vector3(0f, iconOff.y), 0);
+            Message = Singleton<HUDMessage>.Instance.Show(target, btl2d.ICON_POS_NUMBER, $"{Counter}", HUDMessage.MessageStyle.DEATH_SENTENCE);
             btl2d.StatusMessages.Add(Message);
             UpdateLabel();
             return btl_stat.ALTER_SUCCESS;

--- a/Assembly-CSharp/Memoria/Scripts/DefaultStatus/TranceStatusScript.cs
+++ b/Assembly-CSharp/Memoria/Scripts/DefaultStatus/TranceStatusScript.cs
@@ -88,12 +88,13 @@ namespace Memoria.DefaultScripts
                 return true;
             }
             BattleAbilityId eidolon = (BattleAbilityId?)btl_util.GetBtlCurrentCommands(garnet).Find(cmd => cmd.cmd_no == BattleCommandId.Phantom)?.sub_no ?? BattleAbilityId.Void;
-            if (eidolon != BattleAbilityId.Void && eidolon != PhantomAbility)
+            if (PhantomCommandSent && eidolon != BattleAbilityId.Void && eidolon != PhantomAbility)
             {
                 CMD_DATA phantomCmd = garnet.Data.cmd[3];
-                if (PhantomCommandSent && phantomCmd.info.mode == command_mode_index.CMD_MODE_INSPECTION)
+                if (phantomCmd.info.mode == command_mode_index.CMD_MODE_INSPECTION)
                 {
                     PhantomAbility = EidolonToPhantom(eidolon);
+                    phantomCmd.sub_no = (Int32)PhantomAbility;
                     phantomCmd.SetAAData(FF9StateSystem.Battle.FF9Battle.aa_data[PhantomAbility]);
                     phantomCmd.ScriptId = btl_util.GetCommandScriptId(phantomCmd);
                     phantomCmd.IsShortRange = btl_util.IsAttackShortRange(phantomCmd);

--- a/Assembly-CSharp/NCalc/NCalcUtility.cs
+++ b/Assembly-CSharp/NCalc/NCalcUtility.cs
@@ -106,10 +106,7 @@ namespace NCalc
                     args.Result = 0;
             }
             else if (name == "IsCharacterInParty" && args.Parameters.Length == 1)
-            {
-                CharacterId index = (CharacterId)NCalcUtility.ConvertNCalcResult(args.Parameters[0].Evaluate(), Byte.MaxValue);
-                args.Result = index != CharacterId.NONE && FF9StateSystem.Common.FF9.party.member.Any(p => p?.Index == index);
-            }
+                args.Result = FF9StateSystem.Common.FF9.party.IsInParty((CharacterId)NCalcUtility.ConvertNCalcResult(args.Parameters[0].Evaluate(), (Int64)CharacterId.NONE));
             else if (name == "GetCategoryKillCount" && args.Parameters.Length == 1)
             {
                 Int32 index = (Int32)NCalcUtility.ConvertNCalcResult(args.Parameters[0].Evaluate(), -1);


### PR DESCRIPTION
I added a button in the main menu to change the party when ``AllCharactersAvailable`` is activated, in order to fix #783
<img width="406" alt="FF9FormParty" src="https://github.com/user-attachments/assets/903243f3-4895-43fc-bf5d-6c7229a02366">

But then, with the option ``[Battle] AccessMenus``, that button still appears and lets you change the party during battle (of course it was very buggy at first). So I try to make it work for good in this PR. That's a very old goal; it was already mentioned in #235
It looks like I will not be able to make character swaps work buglessly in all possible situations. In particular, I'm afraid it is dangerous to swap a character out of the team in the middle of that character's action; I think that situation cannot be totally fixed easily.

https://github.com/user-attachments/assets/5936da16-7ade-46a3-8f52-a6871186fe5b

Also in this PR:
- Fix #787 and #792
- Add a couple of ``try / catch`` again to catch more exceptions and make debugging easier
- Fix a bug in which Doom / Gradual Petrify countdown get hidden if the character's model changes (most likely because Trance ended)
- Add a command type ``Instant`` (4) that is similar to command type ``Normal`` (corresponds to 1 ability) except that the targeting is automatic and instant, much like the Defend and Change command (and unlike the command Focus that requires an extra input compared to those). It can be used only with abilities that have a target type that doesn't give any choice to the player, like ``Self``, ``AllEnemies`` etc...

**EDIT:**
Characters can no longer be swapped in/out if they are busy (ie. currently acting or being the target of an ability) or if they have a crippling status (``NoInput`` to be precise). The current decision is to have the character swap be instant after closing the menu and returning to the battle. In the future, it might become a delayed swapping with eg. the character fading out, let their place and the new character fading in. That will depend on how this feature evolves if it ever evolves at some point.
Also:
- Fix #788
- Improve "Magic Caster" identification, for knowing if a character is busy supporting an ally's Magic Sword-like ability
- Fix menu in battle when a character is technically inside the battle but hidden (which happens for example with Blank against Plant Brain or with many characters during the "You're not alone" sequence); now these characters don't appear in the menu until they are shown in the battle
- Fix a bug in which Garnet's Eidolon replica were sometimes off (if Garnet casted a different eidolon while a replica was already queued, the replica would be a strange mix between the two eidolons)