### PR TITLE
More support for translation mods

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -339,6 +339,8 @@
     <Compile Include="Memoria\Assets\FieldCreator\FieldCreatorScene.cs" />
     <Compile Include="Memoria\Assets\FieldCreator\PointScreenAnchor.cs" />
     <Compile Include="Memoria\Assets\FieldCreator\WavefrontObject.cs" />
+    <Compile Include="Memoria\Assets\Text\Dialogs\FFIXTextModifier.cs" />
+    <Compile Include="Memoria\Assets\Text\Strings\UnicodeBIDI.cs" />
     <Compile Include="Memoria\Assets\TIMUtils.cs" />
     <Compile Include="Memoria\Assets\Text\Strings\ITextReader.cs" />
     <Compile Include="Memoria\Assets\Text\Strings\ITextWriter.cs" />

--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -336,6 +336,7 @@
     <Compile Include="Global\Sound\SoLoud\WavStream.cs" />
     <Compile Include="Global\SPS\CommonSPSSystem.cs" />
     <Compile Include="Global\SPS\SHPEffect.cs" />
+    <Compile Include="Memoria\Assets\Export\TranslationExporter.cs" />
     <Compile Include="Memoria\Assets\FieldCreator\FieldCreatorScene.cs" />
     <Compile Include="Memoria\Assets\FieldCreator\PointScreenAnchor.cs" />
     <Compile Include="Memoria\Assets\FieldCreator\WavefrontObject.cs" />

--- a/Assembly-CSharp/Assets/Scripts/Common/SceneDirector.cs
+++ b/Assembly-CSharp/Assets/Scripts/Common/SceneDirector.cs
@@ -1,9 +1,9 @@
-﻿using Assets.Sources.Scripts.Common;
+﻿using Assets.Sources.Scripts.UI.Common;
 using Memoria;
 using Memoria.Assets;
 using Memoria.Prime;
 using Memoria.Speedrun;
-using SiliconStudio;
+using Memoria.Prime.Threading;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -771,8 +771,22 @@ namespace Assets.Scripts.Common
         {
             if (Interlocked.CompareExchange(ref _initialized, 1, 0) == 0)
             {
-                ResourceExporter.ExportSafe();
-                ResourceImporter.Initialize();
+                if (Configuration.Import.Enabled && Configuration.Export.Enabled)
+                {
+                    Thread importerThread = new Thread(ResourceImporter.Initialize);
+                    importerThread.Start();
+                    while (importerThread.ThreadState == ThreadState.Running || (FF9TextTool.BattleImporter.InitializationTask != null && FF9TextTool.BattleImporter.InitializationTask.State == TaskState.Running) || (FF9TextTool.FieldImporter.InitializationTask != null && FF9TextTool.FieldImporter.InitializationTask.State == TaskState.Running))
+                        Thread.Sleep(100);
+                    ResourceExporter.ExportSafe();
+                }
+                else if (Configuration.Import.Enabled)
+                {
+                    ResourceImporter.Initialize();
+                }
+                else if (Configuration.Export.Enabled)
+                {
+                    ResourceExporter.ExportSafe();
+                }
             }
         }
     }

--- a/Assembly-CSharp/Assets/Sources/Scripts/UI/Common/FF9TextTool.cs
+++ b/Assembly-CSharp/Assets/Sources/Scripts/UI/Common/FF9TextTool.cs
@@ -107,7 +107,7 @@ namespace Assets.Sources.Scripts.UI.Common
 
         public static IEnumerator InitializeCharacterNamesText()
         {
-            Log.Message(nameof(InitializeEtcText));
+            Log.Message(nameof(InitializeCharacterNamesText));
             return InitializeCharacterNamesTextInternal().GetEnumerator();
         }
 
@@ -352,9 +352,7 @@ namespace Assets.Sources.Scripts.UI.Common
             yield return base.StartCoroutine(FF9TextTool.InitializeEtcText());
             yield return base.StartCoroutine(FF9TextTool.InitializeCharacterNamesText());
             if (setMenuLanguageCallback != null)
-            {
                 setMenuLanguageCallback();
-            }
             yield break;
         }
 
@@ -366,12 +364,24 @@ namespace Assets.Sources.Scripts.UI.Common
             yield break;
         }
 
+        public Boolean UpdateFieldTextNow(Int32 _zoneId)
+        {
+            FF9TextTool.fieldZoneId = _zoneId;
+            return FF9TextTool.FieldImporter.LoadSync();
+        }
+
         public IEnumerator UpdateBattleText(Int32 _zoneId)
         {
             FF9TextTool.battleZoneId = _zoneId;
             PersistenSingleton<UIManager>.Instance.SetEventEnable(false);
             yield return base.StartCoroutine(FF9TextTool.InitializeBattleText());
             yield break;
+        }
+
+        public Boolean UpdateBattleTextNow(Int32 _zoneId)
+        {
+            FF9TextTool.battleZoneId = _zoneId;
+            return FF9TextTool.BattleImporter.LoadSync();
         }
 
         public static String ItemName(RegularItem id)
@@ -526,43 +536,40 @@ namespace Assets.Sources.Scripts.UI.Common
         public static event Action FieldTextUpdated;
 
         private static Int32 fieldZoneId = -1;
-
         private static Int32 battleZoneId = -1;
+        public static String[] fieldText;
+        public static String[] battleText;
 
-        private static String[] fieldText;
+        public static Dictionary<RegularItem, String> itemName = new Dictionary<RegularItem, String>();
+        public static Dictionary<RegularItem, String> itemBattleDesc = new Dictionary<RegularItem, String>();
+        public static Dictionary<RegularItem, String> itemHelpDesc = new Dictionary<RegularItem, String>();
 
-        private static String[] battleText;
+        public static Dictionary<Int32, String> importantSkinDesc = new Dictionary<Int32, String>();
+        public static Dictionary<Int32, String> importantItemHelpDesc = new Dictionary<Int32, String>();
+        public static Dictionary<Int32, String> importantItemName = new Dictionary<Int32, String>();
 
-        private static Dictionary<RegularItem, String> itemName = new Dictionary<RegularItem, String>();
-        private static Dictionary<RegularItem, String> itemBattleDesc = new Dictionary<RegularItem, String>();
-        private static Dictionary<RegularItem, String> itemHelpDesc = new Dictionary<RegularItem, String>();
+        public static Dictionary<SupportAbility, String> supportAbilityHelpDesc = new Dictionary<SupportAbility, String>();
+        public static Dictionary<SupportAbility, String> supportAbilityName = new Dictionary<SupportAbility, String>();
 
-        private static Dictionary<Int32, String> importantSkinDesc = new Dictionary<Int32, String>();
-        private static Dictionary<Int32, String> importantItemHelpDesc = new Dictionary<Int32, String>();
-        private static Dictionary<Int32, String> importantItemName = new Dictionary<Int32, String>();
+        public static Dictionary<BattleAbilityId, String> actionAbilityName = new Dictionary<BattleAbilityId, String>();
+        public static Dictionary<BattleAbilityId, String> actionAbilityHelpDesc = new Dictionary<BattleAbilityId, String>();
 
-        private static Dictionary<SupportAbility, String> supportAbilityHelpDesc = new Dictionary<SupportAbility, String>();
-        private static Dictionary<SupportAbility, String> supportAbilityName = new Dictionary<SupportAbility, String>();
+        public static Dictionary<CharacterId, String> characterNames;
 
-        private static Dictionary<BattleAbilityId, String> actionAbilityName = new Dictionary<BattleAbilityId, String>();
-        private static Dictionary<BattleAbilityId, String> actionAbilityHelpDesc = new Dictionary<BattleAbilityId, String>();
+        public static Dictionary<BattleCommandId, String> commandName = new Dictionary<BattleCommandId, String>();
+        public static Dictionary<BattleCommandId, String> commandHelpDesc = new Dictionary<BattleCommandId, String>();
 
-        private static Dictionary<CharacterId, String> characterNames;
-
-        private static Dictionary<BattleCommandId, String> commandName = new Dictionary<BattleCommandId, String>();
-        private static Dictionary<BattleCommandId, String> commandHelpDesc = new Dictionary<BattleCommandId, String>();
-
-        private static Dictionary<TetraMasterCardId, String> cardName = new Dictionary<TetraMasterCardId, String>();
-        private static String[] chocoUIText;
-        private static String[] cardLvName;
-        private static String[] followText;
-        private static String[] cmdTitleText;
-        private static String[] libraText;
-        private static String[] worldLocationText;
+        public static Dictionary<TetraMasterCardId, String> cardName = new Dictionary<TetraMasterCardId, String>();
+        public static String[] chocoUIText;
+        public static String[] cardLvName;
+        public static String[] followText;
+        public static String[] cmdTitleText;
+        public static String[] libraText;
+        public static String[] worldLocationText;
 
         private static String[][] tableText;
 
-        private static Dictionary<Int32, String> locationName = new Dictionary<Int32, String>();
+        public static Dictionary<Int32, String> locationName = new Dictionary<Int32, String>();
 
         public static Boolean IsLoading = false;
         public static Byte ChocographNameStartIndex = 10;

--- a/Assembly-CSharp/Assets/Sources/Scripts/UI/Common/FF9UIDataTool.cs
+++ b/Assembly-CSharp/Assets/Sources/Scripts/UI/Common/FF9UIDataTool.cs
@@ -750,12 +750,26 @@ namespace Assets.Sources.Scripts.UI.Common
 
         public static Sprite LoadWorldTitle(SByte titleId, Boolean isShadow)
         {
-            Sprite sprite = null;
-            String langSymbol;
-            if (FF9StateSystem.Settings.CurrentLanguage == "English(UK)")
-                langSymbol = "US";
+            String langSymbol = Localization.GetSymbol();
+            String spriteName = GetWorldTitleSpriteName(titleId, isShadow, langSymbol);
+            Sprite sprite;
+            if (FF9UIDataTool.worldTitleSpriteList.ContainsKey(spriteName))
+            {
+                sprite = FF9UIDataTool.worldTitleSpriteList[spriteName];
+            }
             else
-                langSymbol = Localization.GetSymbol();
+            {
+                String path = "EmbeddedAsset/UI/Sprites/" + langSymbol + "/" + spriteName;
+                sprite = AssetManager.Load<Sprite>(path, false);
+                FF9UIDataTool.worldTitleSpriteList.Add(spriteName, sprite);
+            }
+            return sprite;
+        }
+
+        public static String GetWorldTitleSpriteName(SByte titleId, Boolean isShadow, String langSymbol)
+        {
+            if (langSymbol == "UK")
+                langSymbol = "US";
             String spriteName;
             if (titleId == FF9UIDataTool.WorldTitleMistContinent)
             {
@@ -776,20 +790,10 @@ namespace Assets.Sources.Scripts.UI.Common
             else
             {
                 global::Debug.LogError("World Continent Title: Could not found resource from titleId:" + titleId);
-                return sprite;
+                return null;
             }
             spriteName += isShadow ? "_shadow_" + langSymbol.ToLower() : "_" + langSymbol.ToLower();
-            if (FF9UIDataTool.worldTitleSpriteList.ContainsKey(spriteName))
-            {
-                sprite = FF9UIDataTool.worldTitleSpriteList[spriteName];
-            }
-            else
-            {
-                String path = "EmbeddedAsset/UI/Sprites/" + langSymbol + "/" + spriteName;
-                sprite = AssetManager.Load<Sprite>(path, false);
-                FF9UIDataTool.worldTitleSpriteList.Add(spriteName, sprite);
-            }
-            return sprite;
+            return spriteName;
         }
 
         public static readonly Int32 NewIconId = 400;

--- a/Assembly-CSharp/Assets/Sources/Scripts/UI/Common/FF9UIDataTool.cs
+++ b/Assembly-CSharp/Assets/Sources/Scripts/UI/Common/FF9UIDataTool.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using XInputDotNetPure;
-using static Memoria.Assets.DataResources;
 
 namespace Assets.Sources.Scripts.UI.Common
 {
@@ -341,7 +340,7 @@ namespace Assets.Sources.Scripts.UI.Common
             if (id == FF9UIDataTool.NewIconId)
                 spriteSize = new Vector2(115f, 64f);
             else if (FF9UIDataTool.IconSpriteName.ContainsKey(id))
-                spriteSize = FF9UIDataTool.GetSpriteSize(FF9UIDataTool.IconSpriteName[id]);
+                spriteSize = FF9UIDataTool.GetSpriteSize("IconAtlas", FF9UIDataTool.IconSpriteName[id]);
             return spriteSize;
         }
 
@@ -455,12 +454,38 @@ namespace Assets.Sources.Scripts.UI.Common
             if (!checkFromConfig && (FF9StateSystem.PCPlatform || FF9StateSystem.AndroidPlatform))
                 if (!global::GamePad.GetState(PlayerIndex.One).IsConnected && key == Control.Pause)
                     spriteName = "keyboard_button_backspace";
-            return FF9UIDataTool.GetSpriteSize(spriteName);
+            return FF9UIDataTool.GetSpriteSize("IconAtlas", spriteName);
         }
 
-        private static Vector2 GetSpriteSize(String spriteName)
+        public static GameObject SpriteGameObject(String atlasName, String spriteName)
         {
-            UISpriteData sprite = FF9UIDataTool.IconAtlas.GetSprite(spriteName);
+            switch (atlasName)
+            {
+                default:
+                case "IconAtlas":         return FF9UIDataTool.DrawButton(BitmapIconType.Sprite, FF9UIDataTool.IconAtlas, spriteName);
+                case "WindowAtlas":       return FF9UIDataTool.DrawButton(BitmapIconType.Sprite, FF9UIDataTool.WindowAtlas, spriteName);
+                case "GrayAtlas":         return FF9UIDataTool.DrawButton(BitmapIconType.Sprite, FF9UIDataTool.GrayAtlas, spriteName);
+                case "BlueAtlas":         return FF9UIDataTool.DrawButton(BitmapIconType.Sprite, FF9UIDataTool.BlueAtlas, spriteName);
+                case "GeneralAtlas":      return FF9UIDataTool.DrawButton(BitmapIconType.Sprite, FF9UIDataTool.GeneralAtlas, spriteName);
+                case "ScreenButtonAtlas": return FF9UIDataTool.DrawButton(BitmapIconType.Sprite, FF9UIDataTool.ScreenButtonAtlas, spriteName);
+                case "TutorialAtlas":     return FF9UIDataTool.DrawButton(BitmapIconType.Sprite, FF9UIDataTool.TutorialAtlas, spriteName);
+            }
+        }
+
+        public static Vector2 GetSpriteSize(String atlasName, String spriteName)
+        {
+            UISpriteData sprite;
+            switch (atlasName)
+            {
+                default:
+                case "IconAtlas":         sprite = FF9UIDataTool.IconAtlas.GetSprite(spriteName);         break;
+                case "WindowAtlas":       sprite = FF9UIDataTool.WindowAtlas.GetSprite(spriteName);       break;
+                case "GrayAtlas":         sprite = FF9UIDataTool.GrayAtlas.GetSprite(spriteName);         break;
+                case "BlueAtlas":         sprite = FF9UIDataTool.BlueAtlas.GetSprite(spriteName);         break;
+                case "GeneralAtlas":      sprite = FF9UIDataTool.GeneralAtlas.GetSprite(spriteName);      break;
+                case "ScreenButtonAtlas": sprite = FF9UIDataTool.ScreenButtonAtlas.GetSprite(spriteName); break;
+                case "TutorialAtlas":     sprite = FF9UIDataTool.TutorialAtlas.GetSprite(spriteName);     break;
+            }
             if (sprite == null)
                 return new Vector2(64f, 64f);
             return new Vector2(sprite.width + sprite.paddingLeft + sprite.paddingRight, sprite.height + sprite.paddingTop + sprite.paddingBottom);
@@ -770,236 +795,78 @@ namespace Assets.Sources.Scripts.UI.Common
         public static readonly Int32 NewIconId = 400;
 
         private static UIAtlas generalAtlas;
-
         private static UIAtlas iconAtlas;
-
         private static UIAtlas grayAtlas;
-
         private static UIAtlas blueAtlas;
-
         private static UIAtlas screenButtonAtlas;
-
         private static UIAtlas tutorialAtlas;
 
         private static GameObject controllerSpritePrefab = null;
-
         private static GameObject controllerKeyboardPrefab = null;
-
         private static GameObject newIconPrefab = null;
 
         private static List<GameObject> bitmapKeyboardPool = new List<GameObject>();
-
         private static List<GameObject> bitmapSpritePool = new List<GameObject>();
-
         private static List<GameObject> bitmapNewIconPool = new List<GameObject>();
-
         private static List<GameObject> activeBitmapKeyboardList = new List<GameObject>();
-
         private static List<GameObject> activeBitmapSpriteList = new List<GameObject>();
-
         private static List<GameObject> activeBitmapNewIconList = new List<GameObject>();
-
-        public static Int32[] status_id = new Int32[]
-        {
-            154,
-            153,
-            152,
-            151,
-            150,
-            149,
-            148
-        };
 
         private static Dictionary<String, String> buttonSpriteNameiOSJoystick = new Dictionary<String, String>
         {
-            {
-                "JoystickButton14",
-                "joystick_button_a"
-            },
-            {
-                "JoystickButton13",
-                "joystick_button_b"
-            },
-            {
-                "JoystickButton15",
-                "joystick_button_x"
-            },
-            {
-                "JoystickButton12",
-                "joystick_button_y"
-            },
-            {
-                "JoystickButton8",
-                "joystick_l1"
-            },
-            {
-                "JoystickButton9",
-                "joystick_r1"
-            },
-            {
-                "JoystickButton10",
-                "joystick_l2"
-            },
-            {
-                "JoystickButton11",
-                "joystick_r2"
-            },
-            {
-                "JoystickButton0",
-                "joystick_start"
-            },
-            {
-                "Empty",
-                "joystick_analog_r"
-            },
-            {
-                "Up",
-                "ps_dpad_up"
-            },
-            {
-                "Down",
-                "ps_dpad_down"
-            },
-            {
-                "Left",
-                "ps_dpad_left"
-            },
-            {
-                "Right",
-                "ps_dpad_right"
-            },
-            {
-                "DPad",
-                "ps_dpad"
-            }
+            { "JoystickButton14",   "joystick_button_a" },
+            { "JoystickButton13",   "joystick_button_b" },
+            { "JoystickButton15",   "joystick_button_x" },
+            { "JoystickButton12",   "joystick_button_y" },
+            { "JoystickButton8",    "joystick_l1" },
+            { "JoystickButton9",    "joystick_r1" },
+            { "JoystickButton10",   "joystick_l2" },
+            { "JoystickButton11",   "joystick_r2" },
+            { "JoystickButton0",    "joystick_start" },
+            { "Empty",              "joystick_analog_r" },
+            { "Up",                 "ps_dpad_up" },
+            { "Down",               "ps_dpad_down" },
+            { "Left",               "ps_dpad_left" },
+            { "Right",              "ps_dpad_right" },
+            { "DPad",               "ps_dpad" }
         };
 
         private static Dictionary<String, String> buttonSpriteNameAndroidJoystick = new Dictionary<String, String>
         {
-            {
-                "JoystickButton0",
-                "joystick_button_a"
-            },
-            {
-                "JoystickButton1",
-                "joystick_button_b"
-            },
-            {
-                "JoystickButton2",
-                "joystick_button_x"
-            },
-            {
-                "JoystickButton3",
-                "joystick_button_y"
-            },
-            {
-                "JoystickButton4",
-                "joystick_l1"
-            },
-            {
-                "JoystickButton5",
-                "joystick_r1"
-            },
-            {
-                "LeftTrigger Android",
-                "joystick_l2"
-            },
-            {
-                "RightTrigger Android",
-                "joystick_r2"
-            },
-            {
-                "JoystickButton10",
-                "joystick_start"
-            },
-            {
-                "Empty",
-                "joystick_analog_r"
-            },
-            {
-                "Up",
-                "ps_dpad_up"
-            },
-            {
-                "Down",
-                "ps_dpad_down"
-            },
-            {
-                "Left",
-                "ps_dpad_left"
-            },
-            {
-                "Right",
-                "ps_dpad_right"
-            },
-            {
-                "DPad",
-                "ps_dpad"
-            }
+            { "JoystickButton0",        "joystick_button_a" },
+            { "JoystickButton1",        "joystick_button_b" },
+            { "JoystickButton2",        "joystick_button_x" },
+            { "JoystickButton3",        "joystick_button_y" },
+            { "JoystickButton4",        "joystick_l1" },
+            { "JoystickButton5",        "joystick_r1" },
+            { "LeftTrigger Android",    "joystick_l2" },
+            { "RightTrigger Android",   "joystick_r2" },
+            { "JoystickButton10",       "joystick_start" },
+            { "Empty",                  "joystick_analog_r" },
+            { "Up",                     "ps_dpad_up" },
+            { "Down",                   "ps_dpad_down" },
+            { "Left",                   "ps_dpad_left" },
+            { "Right",                  "ps_dpad_right" },
+            { "DPad",                   "ps_dpad" }
         };
 
         private static Dictionary<String, String> buttonSpriteNameJoystick = new Dictionary<String, String>
         {
-            {
-                "JoystickButton0",
-                "joystick_button_a"
-            },
-            {
-                "JoystickButton1",
-                "joystick_button_b"
-            },
-            {
-                "JoystickButton2",
-                "joystick_button_x"
-            },
-            {
-                "JoystickButton3",
-                "joystick_button_y"
-            },
-            {
-                "JoystickButton4",
-                "joystick_l1"
-            },
-            {
-                "JoystickButton5",
-                "joystick_r1"
-            },
-            {
-                "LeftTrigger",
-                "joystick_l2"
-            },
-            {
-                "RightTrigger",
-                "joystick_r2"
-            },
-            {
-                "JoystickButton6",
-                "joystick_start"
-            },
-            {
-                "JoystickButton7",
-                "joystick_select"
-            },
-            {
-                "Up",
-                "ps_dpad_up"
-            },
-            {
-                "Down",
-                "ps_dpad_down"
-            },
-            {
-                "Left",
-                "ps_dpad_left"
-            },
-            {
-                "Right",
-                "ps_dpad_right"
-            },
-            {
-                "DPad",
-                "ps_dpad"
-            }
+            { "JoystickButton0",    "joystick_button_a" },
+            { "JoystickButton1",    "joystick_button_b" },
+            { "JoystickButton2",    "joystick_button_x" },
+            { "JoystickButton3",    "joystick_button_y" },
+            { "JoystickButton4",    "joystick_l1" },
+            { "JoystickButton5",    "joystick_r1" },
+            { "LeftTrigger",        "joystick_l2" },
+            { "RightTrigger",       "joystick_r2" },
+            { "JoystickButton6",    "joystick_start" },
+            { "JoystickButton7",    "joystick_select" },
+            { "Up",                 "ps_dpad_up" },
+            { "Down",               "ps_dpad_down" },
+            { "Left",               "ps_dpad_left" },
+            { "Right",              "ps_dpad_right" },
+            { "DPad",               "ps_dpad" }
         };
 
         public static readonly Dictionary<Int32, String> IconSpriteName = new Dictionary<Int32, String>
@@ -1502,30 +1369,12 @@ namespace Assets.Sources.Scripts.UI.Common
 
         private static readonly Dictionary<String, String> iconLocalizeList = new Dictionary<String, String>
         {
-            {
-                "keyboard_button_enter#French",
-                "keyboard_button_enter_fr_gr"
-            },
-            {
-                "keyboard_button_enter#German",
-                "keyboard_button_enter_fr_gr"
-            },
-            {
-                "keyboard_button_enter#Italian",
-                "keyboard_button_enter_it"
-            },
-            {
-                "keyboard_button_backspace#French",
-                "keyboard_button_backspace_fr_gr_it"
-            },
-            {
-                "keyboard_button_backspace#German",
-                "keyboard_button_backspace_fr_gr_it"
-            },
-            {
-                "keyboard_button_backspace#Italian",
-                "keyboard_button_backspace_fr_gr_it"
-            }
+            { "keyboard_button_enter#French",       "keyboard_button_enter_fr_gr" },
+            { "keyboard_button_enter#German",       "keyboard_button_enter_fr_gr" },
+            { "keyboard_button_enter#Italian",      "keyboard_button_enter_it" },
+            { "keyboard_button_backspace#French",   "keyboard_button_backspace_fr_gr_it" },
+            { "keyboard_button_backspace#German",   "keyboard_button_backspace_fr_gr_it" },
+            { "keyboard_button_backspace#Italian",  "keyboard_button_backspace_fr_gr_it" }
         };
     }
 }

--- a/Assembly-CSharp/Global/BitmapIconManager.cs
+++ b/Assembly-CSharp/Global/BitmapIconManager.cs
@@ -16,23 +16,29 @@ internal class BitmapIconManager : Singleton<BitmapIconManager>
 
     public GameObject InsertBitmapIcon(Dialog.DialogImage dialogImg, GameObject label)
     {
-        GameObject gameObject;
-        if (dialogImg.IsButton)
-        {
-            gameObject = FF9UIDataTool.ButtonGameObject((Control)dialogImg.Id, dialogImg.checkFromConfig, dialogImg.tag);
-        }
+        GameObject imgGo;
+        if (!String.IsNullOrEmpty(dialogImg.SpriteName))
+            imgGo = FF9UIDataTool.SpriteGameObject(dialogImg.AtlasName, dialogImg.SpriteName);
+        else if (dialogImg.IsButton)
+            imgGo = FF9UIDataTool.ButtonGameObject((Control)dialogImg.Id, dialogImg.checkFromConfig, dialogImg.tag);
         else
+            imgGo = FF9UIDataTool.IconGameObject(dialogImg.Id);
+        if (imgGo != null)
         {
-            gameObject = FF9UIDataTool.IconGameObject(dialogImg.Id);
+            imgGo.transform.parent = label.transform;
+            if (dialogImg.Rescale)
+            {
+                Vector2 defaultSize = FF9UIDataTool.GetSpriteSize(dialogImg.AtlasName, dialogImg.SpriteName);
+                imgGo.transform.localScale = new Vector3(dialogImg.Size.x / defaultSize.x, dialogImg.Size.y / defaultSize.y, 1f);
+            }
+            else
+            {
+                imgGo.transform.localScale = Vector3.one;
+            }
+            imgGo.transform.localPosition = new Vector3(dialogImg.LocalPosition.x, dialogImg.LocalPosition.y, 0f);
+            imgGo.SetActive(true);
         }
-        if (gameObject != (UnityEngine.Object)null)
-        {
-            gameObject.transform.parent = label.transform;
-            gameObject.transform.localScale = Vector3.one;
-            gameObject.transform.localPosition = new Vector3(dialogImg.LocalPosition.x, dialogImg.LocalPosition.y, 0f);
-            gameObject.SetActive(true);
-        }
-        return gameObject;
+        return imgGo;
     }
 
     public void RemoveBitmapIcon(GameObject bitmap)

--- a/Assembly-CSharp/Global/Dialog/Dialog.cs
+++ b/Assembly-CSharp/Global/Dialog/Dialog.cs
@@ -1993,6 +1993,13 @@ public class Dialog : MonoBehaviour
         public Boolean checkFromConfig = true;
         public Boolean IsButton = true;
         public String tag = String.Empty;
+
+        [NonSerialized]
+        public String AtlasName = null;
+        [NonSerialized]
+        public String SpriteName = null;
+        [NonSerialized]
+        public Boolean Rescale = false;
     }
 
     public enum TailPosition

--- a/Assembly-CSharp/Global/Dialog/DialogManager.cs
+++ b/Assembly-CSharp/Global/Dialog/DialogManager.cs
@@ -23,9 +23,8 @@ public class DialogManager : Singleton<DialogManager>
         Int32 currentOffset = 0;
         Int32 length = fullText.Length;
         Single nextCharTime = 0f;
-        Int32 ff9Signal = 0;
-        Dialog.DialogImage insertImage = null;
         Single charsPerSecond = 0f;
+        Int32 ff9Signal = 0;
         while (currentOffset < length)
         {
             while (nextCharTime <= RealTime.time)
@@ -37,18 +36,14 @@ public class DialogManager : Singleton<DialogManager>
                     break;
                 }
                 if (label.supportEncoding)
-                {
-                    while (NGUIText.ParseSymbol(fullText, ref currentOffset, ref ff9Signal, ref insertImage))
-                    {
-                    }
-                }
+                    ff9Signal = NGUIText.GetNextFF9Signal(fullText, ref currentOffset);
                 currentOffset++;
                 Single delay = HonoBehaviorSystem.Instance.IsFastForwardModeActive() ? 1f / (charsPerSecond * FF9StateSystem.Settings.FastForwardFactor) : 1f / charsPerSecond;
                 if (nextCharTime == 0f || nextCharTime + delay > RealTime.time)
                     nextCharTime = RealTime.time + delay;
                 else
                     nextCharTime += delay;
-                NGUIText.ProcessFF9Signal(ref ff9Signal);
+                NGUIText.ProcessFF9Signal(ff9Signal);
             }
             yield return new WaitForEndOfFrame();
         }

--- a/Assembly-CSharp/Global/NGUIText.cs
+++ b/Assembly-CSharp/Global/NGUIText.cs
@@ -14,8 +14,8 @@ public static class NGUIText
     static NGUIText()
     {
         // Note: this type is marked as 'beforefieldinit'.
-        NGUIText.RenderOpcodeSymbols = new String[]
-        {
+        NGUIText.RenderOpcodeSymbols =
+        [
             NGUIText.StartSentense,
             NGUIText.DialogId,
             NGUIText.Choose,
@@ -68,33 +68,26 @@ public static class NGUIText
             NGUIText.MobileIcon,
             NGUIText.SpacingY,
             NGUIText.JoyStickButtonIcon,
-            NGUIText.KeyboardButtonIcon
-        };
-        NGUIText.TextOffsetOpcodeSymbols = new String[]
-        {
+            NGUIText.KeyboardButtonIcon,
+            NGUIText.IconSprite
+        ];
+        NGUIText.TextOffsetOpcodeSymbols =
+        [
             NGUIText.TextOffset,
             NGUIText.MessageFeed,
             NGUIText.MessageTab
-        };
-        NGUIText.IconIdException = new List<Int32>
-        {
-            255,
-            254,
-            20,
-            19,
-            192
-        };
-        NGUIText.CharException = new List<Char>
-        {
-            ' ',
-            'p',
-            '-',
-            'y',
-            ',',
-            '一'
-        };
-        NGUIText.nameKeywordList = new List<String>(new String[]
-        {
+        ];
+        NGUIText.IconIdException =
+        [
+            19,  // arrow_up
+            20,  // arrow_down
+            192, // ap_bar_complete_star
+            254, // ap_bar_full
+            255  // ap_bar_half
+        ];
+        NGUIText.CharException = [' ', 'p', '-', 'y', ',', '一' ];
+        NGUIText.nameKeywordList =
+        [
             NGUIText.Zidane,
             NGUIText.Vivi,
             NGUIText.Dagger,
@@ -107,7 +100,7 @@ public static class NGUIText
             NGUIText.Party2,
             NGUIText.Party3,
             NGUIText.Party4
-        });
+        ];
         NGUIText.nameCustomKeywords = new Dictionary<String, CharacterId>();
         NGUIText.FF9WhiteColor = "[C8C8C8]";
         NGUIText.FF9YellowColor = "[C8B040]";
@@ -121,20 +114,13 @@ public static class NGUIText
     public static void RegisterCustomNameKeywork(String keyword, CharacterId charId)
     {
         NGUIText.nameCustomKeywords[keyword] = charId;
-        if (!NGUIText.nameKeywordList.Contains(keyword))
-            NGUIText.nameKeywordList.Add(keyword);
+        NGUIText.nameKeywordList.Add(keyword);
     }
 
     public static Boolean ForceShowButton
     {
-        get
-        {
-            return NGUIText.forceShowButton;
-        }
-        set
-        {
-            NGUIText.forceShowButton = value;
-        }
+        get => NGUIText.forceShowButton;
+        set => NGUIText.forceShowButton = value;
     }
 
     public static Single GetTextWidthFromFF9Font(UILabel phraseLabel, String text)
@@ -142,153 +128,118 @@ public static class NGUIText
         phraseLabel.ProcessText();
         phraseLabel.UpdateNGUIText();
         NGUIText.Prepare(text);
-        Single num = NGUIText.finalSpacingX;
-        Single num2 = (Single)phraseLabel.fontSize * NGUIText.fontScale;
-        Single num3 = 0f;
+        Single defaultCharacterSize = phraseLabel.fontSize * NGUIText.fontScale;
+        Single textWidth = 0f;
         foreach (Char ch in text)
         {
-            Single glyphWidth = NGUIText.GetGlyphWidth((Int32)ch, 0);
-            num3 += ((glyphWidth <= 0f) ? (num2 + num) : (glyphWidth + num));
+            Single glyphWidth = NGUIText.GetGlyphWidth(ch, 0);
+            textWidth += (glyphWidth <= 0f ? defaultCharacterSize : glyphWidth) + NGUIText.finalSpacingX;
         }
-        return num3 / UIManager.ResourceXMultipier + 1f;
+        return textWidth / UIManager.ResourceXMultipier + 1f;
     }
 
     public static Single GetDialogWidthFromSpecialOpcode(List<Int32> specialCodeList, ETb eTb, UILabel phraseLabel)
     {
-        Single num = 0f;
+        Single extraWidth = 0f;
         FF9StateGlobal ff = FF9StateSystem.Common.FF9;
         PLAYER[] member = ff.party.member;
         for (Int32 i = 0; i < specialCodeList.Count; i++)
         {
-            Int32 num2 = specialCodeList[i];
-            Int32 num3 = num2;
-            switch (num3)
+            Int32 specialCode = specialCodeList[i];
+            switch (specialCode)
             {
-                case 6:
+                case 6: // [TEXT=TABLE,SCRIPTID]
                 {
-                    UInt32 num4 = Convert.ToUInt32(specialCodeList[i + 1]);
-                    if (num4 > 255u)
+                    // TODO: that code seems fishy
+                    UInt32 tableId = Convert.ToUInt32(specialCodeList[i + 1]);
+                    if (tableId > Byte.MaxValue)
                     {
-                        UInt32 num5 = Convert.ToUInt32(specialCodeList[i + 2]);
+                        UInt32 textId = Convert.ToUInt32(specialCodeList[i + 2]);
                         String[] tableText = FF9TextTool.GetTableText(0u);
-                        String text = tableText[(Int32)((UIntPtr)num5)];
-                        num += NGUIText.GetTextWidthFromFF9Font(phraseLabel, text);
+                        extraWidth += NGUIText.GetTextWidthFromFF9Font(phraseLabel, tableText[textId]);
                         i += 2;
                     }
                     else
                     {
-                        num += NGUIText.GetTextWidthFromFF9Font(phraseLabel, eTb.GetStringFromTable(num4 >> 4 & 3u, num4 & 7u));
+                        extraWidth += NGUIText.GetTextWidthFromFF9Font(phraseLabel, eTb.GetStringFromTable(tableId >> 4 & 3u, tableId & 7u));
                         i++;
                     }
                     break;
                 }
-                case 7:
-                case 8:
-                case 9:
-                case 10:
-                case 11:
-                case 12:
-                case 13:
-                case 15:
-                IL_A0:
-                    if (num3 != 64)
-                    {
-                        if (num3 == 112)
-                        {
-                            if ((eTb.gMesValue[0] & 1 << specialCodeList[++i]) > 0)
-                            {
-                                num += 30f;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        Int32 num6 = specialCodeList[i + 1];
-                        Int32 num7 = eTb.gMesValue[num6];
-                        num += NGUIText.GetTextWidthFromFF9Font(phraseLabel, num7.ToString());
-                        i++;
-                    }
-                    break;
-                case 14:
+                case 14: // [ITEM=SCRIPTID]
                 {
-                    Int32 num8 = specialCodeList[i + 1];
-                    String itemName = ETb.GetItemName(eTb.gMesValue[num8]);
-                    num += NGUIText.GetTextWidthFromFF9Font(phraseLabel, itemName);
+                    Int32 scriptId = specialCodeList[i + 1];
+                    String itemName = ETb.GetItemName(eTb.gMesValue[scriptId]);
+                    extraWidth += NGUIText.GetTextWidthFromFF9Font(phraseLabel, itemName);
                     i++;
                     break;
                 }
-                case 16:
-                    num += NGUIText.GetTextWidthFromFF9Font(phraseLabel, ff.GetPlayer(CharacterId.Zidane).Name);
+                case 16: // [ZDNE]
+                    extraWidth += NGUIText.GetTextWidthFromFF9Font(phraseLabel, ff.GetPlayer(CharacterId.Zidane).Name);
                     break;
-                case 17:
-                    num += NGUIText.GetTextWidthFromFF9Font(phraseLabel, ff.GetPlayer(CharacterId.Vivi).Name);
+                case 17: // [VIVI]
+                    extraWidth += NGUIText.GetTextWidthFromFF9Font(phraseLabel, ff.GetPlayer(CharacterId.Vivi).Name);
                     break;
-                case 18:
-                    num += NGUIText.GetTextWidthFromFF9Font(phraseLabel, ff.GetPlayer(CharacterId.Garnet).Name);
+                case 18: // [DGGR]
+                    extraWidth += NGUIText.GetTextWidthFromFF9Font(phraseLabel, ff.GetPlayer(CharacterId.Garnet).Name);
                     break;
-                case 19:
-                    num += NGUIText.GetTextWidthFromFF9Font(phraseLabel, ff.GetPlayer(CharacterId.Steiner).Name);
+                case 19: // [STNR]
+                    extraWidth += NGUIText.GetTextWidthFromFF9Font(phraseLabel, ff.GetPlayer(CharacterId.Steiner).Name);
                     break;
-                case 20:
-                    num += NGUIText.GetTextWidthFromFF9Font(phraseLabel, ff.GetPlayer(CharacterId.Freya).Name);
+                case 20: // [FRYA]
+                    extraWidth += NGUIText.GetTextWidthFromFF9Font(phraseLabel, ff.GetPlayer(CharacterId.Freya).Name);
                     break;
-                case 21:
-                    num += NGUIText.GetTextWidthFromFF9Font(phraseLabel, ff.GetPlayer(CharacterId.Quina).Name);
+                case 21: // [QUIN]
+                    extraWidth += NGUIText.GetTextWidthFromFF9Font(phraseLabel, ff.GetPlayer(CharacterId.Quina).Name);
                     break;
-                case 22:
-                    num += NGUIText.GetTextWidthFromFF9Font(phraseLabel, ff.GetPlayer(CharacterId.Eiko).Name);
+                case 22: // [EIKO]
+                    extraWidth += NGUIText.GetTextWidthFromFF9Font(phraseLabel, ff.GetPlayer(CharacterId.Eiko).Name);
                     break;
-                case 23:
-                    num += NGUIText.GetTextWidthFromFF9Font(phraseLabel, ff.GetPlayer(CharacterId.Amarant).Name);
+                case 23: // [AMRT]
+                    extraWidth += NGUIText.GetTextWidthFromFF9Font(phraseLabel, ff.GetPlayer(CharacterId.Amarant).Name);
                     break;
-                case 24:
-                case 25:
-                case 26:
-                case 27:
+                case 24: // [PTY1]
+                case 25: // [PTY2]
+                case 26: // [PTY3]
+                case 27: // [PTY4]
                 {
-                    PLAYER player2 = member[num2 - 24];
-                    num += NGUIText.GetTextWidthFromFF9Font(phraseLabel, player2.Name);
+                    extraWidth += NGUIText.GetTextWidthFromFF9Font(phraseLabel, member[specialCode - 24]?.Name);
                     break;
                 }
-                default:
-                    goto IL_A0;
+                case 64: // [NUMB=SCRIPTID]
+                {
+                    Int32 scriptId = specialCodeList[i + 1];
+                    extraWidth += NGUIText.GetTextWidthFromFF9Font(phraseLabel, eTb.gMesValue[scriptId].ToString());
+                    i++;
+                    break;
+                }
+                case 112: // [PNEW=SCRIPTID]
+                    if ((eTb.gMesValue[0] & (1 << specialCodeList[++i])) != 0)
+                        extraWidth += 30f;
+                    break;
             }
         }
-        return num;
+        return extraWidth;
     }
 
     public static void ProcessFF9Signal(ref Int32 ff9Signal, ref Int32 newSignal)
     {
-        if (ff9Signal == 1)
-        {
+        if (ff9Signal == 0)
+            return;
+        if (ff9Signal == 1 || (ff9Signal == 2 && newSignal != ETb.gMesSignal))
             ETb.gMesSignal = newSignal;
-        }
-        else if (ff9Signal == 2)
-        {
-            if (newSignal != ETb.gMesSignal)
-            {
-                ETb.gMesSignal = newSignal;
-            }
-            else
-            {
-                ETb.gMesSignal++;
-            }
-        }
+        else
+            ETb.gMesSignal++;
         ff9Signal = 0;
         newSignal = 0;
     }
 
-    public static void ProcessFF9Signal(ref Int32 ff9Signal)
+    public static void ProcessFF9Signal(Int32 ff9Signal)
     {
         if (ff9Signal >= 10)
-        {
             ETb.gMesSignal = ff9Signal % 10;
-        }
         else if (ff9Signal == 2)
-        {
             ETb.gMesSignal++;
-        }
-        ff9Signal = 0;
     }
 
     public static Dialog.DialogImage CreateButtonImage(String parameterStr, Boolean checkConfig, String tag)
@@ -373,19 +324,49 @@ public static class NGUIText
         return dialogImage;
     }
 
+    public static Dialog.DialogImage CreateSpriteImage(String spriteCode)
+    {
+        Dialog.DialogImage dialogImage = new Dialog.DialogImage();
+        String[] args = spriteCode.Split(',');
+        if (args.Length == 1)
+        {
+            dialogImage.AtlasName = "IconAtlas";
+            dialogImage.SpriteName = args[0];
+            dialogImage.Size = FF9UIDataTool.GetSpriteSize(dialogImage.AtlasName, dialogImage.SpriteName);
+        }
+        else if (args.Length == 2)
+        {
+            dialogImage.AtlasName = args[0];
+            dialogImage.SpriteName = args[1];
+            dialogImage.Size = FF9UIDataTool.GetSpriteSize(dialogImage.AtlasName, dialogImage.SpriteName);
+        }
+        else if (args.Length == 3)
+        {
+            dialogImage.AtlasName = "IconAtlas";
+            dialogImage.SpriteName = args[0];
+            dialogImage.Size = new Vector2();
+            Single.TryParse(args[1], out dialogImage.Size.x);
+            Single.TryParse(args[2], out dialogImage.Size.y);
+            dialogImage.Rescale = true;
+        }
+        else if (args.Length == 4)
+        {
+            dialogImage.AtlasName = args[0];
+            dialogImage.SpriteName = args[1];
+            dialogImage.Size = new Vector2();
+            Single.TryParse(args[2], out dialogImage.Size.x);
+            Single.TryParse(args[3], out dialogImage.Size.y);
+            dialogImage.Rescale = true;
+        }
+        dialogImage.Offset = new Vector3(0f, -10f);
+        dialogImage.Id = -1;
+        dialogImage.IsButton = false;
+        return dialogImage;
+    }
+
     public static Int32 GetOneParameterFromTag(String fullText, Int32 currentIndex, ref Int32 closingBracket)
     {
-        Int32 result = 0;
-        try
-        {
-            closingBracket = fullText.IndexOf(']', currentIndex + 4);
-            String value = fullText.Substring(currentIndex + 6, closingBracket - currentIndex - 6);
-            result = Convert.ToInt32(value);
-        }
-        catch
-        {
-        }
-        return result;
+        return GetOneParameterFromTag(fullText.ToCharArray(), currentIndex, ref closingBracket);
     }
 
     public static Int32 GetOneParameterFromTag(Char[] fullText, Int32 currentIndex, ref Int32 closingBracket)
@@ -405,50 +386,36 @@ public static class NGUIText
 
     public static Single[] GetAllParameters(String fullText, Int32 currentIndex, ref Int32 closingBracket)
     {
-        closingBracket = fullText.IndexOf(']', currentIndex + 4);
-        String text = fullText.Substring(currentIndex + 6, closingBracket - currentIndex - 6);
-        String[] array = text.Split(new Char[]
-        {
-            ','
-        });
-        return Array.ConvertAll<String, Single>(array, new Converter<String, Single>(Single.Parse));
+        return GetAllParameters(fullText.ToCharArray(), currentIndex, ref closingBracket);
     }
 
     public static Single[] GetAllParameters(Char[] fullText, Int32 currentIndex, ref Int32 closingBracket)
     {
         closingBracket = Array.IndexOf(fullText, ']', currentIndex + 4);
-        String text = new string(fullText, currentIndex + 6, closingBracket - currentIndex - 6);
-        String[] array = text.Split(new Char[]
-        {
-            ','
-        });
-        return Array.ConvertAll<String, Single>(array, new Converter<String, Single>(Single.Parse));
+        String paramText = new String(fullText, currentIndex + 6, closingBracket - currentIndex - 6);
+        return Array.ConvertAll(paramText.Split(','), Single.Parse);
     }
 
     public static String ReplaceNumberValue(String phrase, Dialog dialog)
     {
-        String text = phrase;
         foreach (KeyValuePair<Int32, Int32> keyValuePair in dialog.MessageValues)
         {
             String value = keyValuePair.Value.ToString();
-
-            text = text.ReplaceAll(
-                new[]
-                {
+            phrase = phrase.ReplaceAll(
+                [
                     new KeyValuePair<String, TextReplacement>($"[NUMB={keyValuePair.Key}]", value),
                     new KeyValuePair<String, TextReplacement>($"{{Variable {keyValuePair.Key}}}", value)
-                });
+                ]);
         }
-        return text;
+        return phrase;
     }
 
     public static Boolean ContainsTextOffset(String text)
     {
         Int32 offset = 0;
         Int32 left = text.Length;
-
-        FFIXTextTag tag = FFIXTextTag.TryRead(text.ToCharArray(), ref offset, ref left);
-        switch (tag?.Code)
+        FFIXTextTag memoriaTag = FFIXTextTag.TryRead(text.ToCharArray(), ref offset, ref left);
+        switch (memoriaTag?.Code)
         {
             case FFIXTextTagCode.DialogX:
             case FFIXTextTagCode.DialogY:
@@ -456,179 +423,187 @@ public static class NGUIText
                 return true;
         }
 
-        String[] textOffsetOpcodeSymbols = NGUIText.TextOffsetOpcodeSymbols;
-        for (Int32 i = 0; i < (Int32)textOffsetOpcodeSymbols.Length; i++)
-        {
-            String value = textOffsetOpcodeSymbols[i];
-            if (text.Contains(value))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        if (text[0] != '[' || text.Length < 5)
+            return false;
+        return NGUIText.TextOffsetOpcodeSymbols.Contains(text.Substring(1, 4));
     }
 
     public static Vector2 CalculatePrintedSize2(String text)
     {
-        Vector2 zero = Vector2.zero;
-        Int32 num = 0;
-        Boolean flag = false;
-        Boolean flag2 = false;
-        Boolean flag3 = false;
-        Boolean flag4 = false;
-        Boolean flag5 = false;
-        Boolean flag6 = false;
-        Boolean flag7 = false;
-        Boolean flag8 = false;
-        Int32 num2 = 0;
-        Vector3 zero2 = Vector3.zero;
-        Dialog.DialogImage dialogImage = (Dialog.DialogImage)null;
-        Single num3 = 0f;
+        Vector2 printedSize = Vector2.zero;
         if (!String.IsNullOrEmpty(text))
         {
             if (NGUIText.encoding)
-            {
                 text = NGUIText.StripSymbols2(text);
-            }
+            NGUIText.mTextModifiers.Reset();
             NGUIText.Prepare(text);
-            Single num4 = 0f;
-            Single num5 = 0f;
-            Single num6 = 0f;
-            Int32 length = text.Length;
-            Int32 prev = 0;
-            for (Int32 i = 0; i < length; i++)
+            Single currentX = 0f;
+            Single textHeight = 0f;
+            Single maxLineWidth = 0f;
+            Int32 textLength = text.Length;
+            Int32 prevCh = 0;
+            for (Int32 texti = 0; texti < textLength; texti++)
             {
-                Int32 num7 = (Int32)text[i];
-                if (num7 == 10)
+                Int32 ch = text[texti];
+                if (ch == '\n')
                 {
-                    if (num4 > num6)
-                    {
-                        num6 = num4;
-                    }
-                    num4 = 0f;
-                    num5 += NGUIText.finalLineHeight;
-                    zero2 = Vector3.zero;
-                    dialogImage = (Dialog.DialogImage)null;
+                    if (currentX > maxLineWidth)
+                        maxLineWidth = currentX;
+                    currentX = 0f;
+                    textHeight += NGUIText.finalLineHeight;
+                    NGUIText.mTextModifiers.extraOffset = Vector3.zero;
+                    NGUIText.mTextModifiers.insertImage = null;
                 }
-                else if (num7 >= 32)
+                else if (ch >= 32)
                 {
-                    if (NGUIText.encoding && DialogBoxSymbols.ParseSymbol(text, ref i, NGUIText.mColors, NGUIText.premultiply, ref num, ref flag, ref flag2, ref flag3, ref flag4, ref flag5, ref flag6, ref flag7, ref flag8, ref num2, ref zero2, ref num3, ref dialogImage))
+                    if (NGUIText.encoding && DialogBoxSymbols.ParseSymbol(text, ref texti, NGUIText.premultiply, NGUIText.mTextModifiers))
                     {
-                        i--;
+                        texti--;
                     }
                     else
                     {
-                        if (num3 != 0f)
+                        if (NGUIText.mTextModifiers.tabX != 0f)
                         {
-                            zero2.x = 0f;
-                            num4 = num3;
-                            num3 = 0f;
+                            NGUIText.mTextModifiers.extraOffset.x = 0f;
+                            currentX = NGUIText.mTextModifiers.tabX;
+                            NGUIText.mTextModifiers.tabX = 0f;
                         }
-                        if (dialogImage != null)
+                        if (NGUIText.mTextModifiers.insertImage != null)
                         {
-                            num4 += dialogImage.Size.x - 20f;
-                            dialogImage = (Dialog.DialogImage)null;
+                            currentX += NGUIText.mTextModifiers.insertImage.Size.x - 20f;
+                            NGUIText.mTextModifiers.insertImage = null;
                         }
-                        if (zero2 != Vector3.zero)
+                        if (NGUIText.mTextModifiers.extraOffset != Vector3.zero)
                         {
-                            num4 += zero2.x;
-                            zero2 = Vector3.zero;
+                            currentX += NGUIText.mTextModifiers.extraOffset.x;
+                            NGUIText.mTextModifiers.extraOffset = Vector3.zero;
                         }
-                        BMSymbol bmsymbol = (!NGUIText.useSymbols) ? null : NGUIText.GetSymbol(text, i, length);
+                        BMSymbol bmsymbol = NGUIText.useSymbols ? NGUIText.GetSymbol(text, texti, textLength) : null;
                         if (bmsymbol == null)
                         {
-                            Single num8 = NGUIText.GetGlyphWidth(num7, prev);
-                            if (num8 != 0f)
+                            Single glyphWidth = NGUIText.GetGlyphWidth(ch, prevCh);
+                            if (glyphWidth != 0f)
                             {
-                                num8 += NGUIText.finalSpacingX;
-                                if (Mathf.RoundToInt(num4 + num8) > NGUIText.regionWidth)
+                                glyphWidth += NGUIText.finalSpacingX;
+                                if (Mathf.RoundToInt(currentX + glyphWidth) > NGUIText.regionWidth)
                                 {
-                                    if (num4 > num6)
-                                    {
-                                        num6 = num4 - NGUIText.finalSpacingX;
-                                    }
-                                    num4 = num8;
-                                    num5 += NGUIText.finalLineHeight;
-                                    zero2 = Vector3.zero;
+                                    if (currentX > maxLineWidth)
+                                        maxLineWidth = currentX - NGUIText.finalSpacingX;
+                                    currentX = glyphWidth;
+                                    textHeight += NGUIText.finalLineHeight;
+                                    NGUIText.mTextModifiers.extraOffset = Vector3.zero;
                                 }
                                 else
                                 {
-                                    num4 += num8;
+                                    currentX += glyphWidth;
                                 }
-                                prev = num7;
+                                prevCh = ch;
                             }
                         }
                         else
                         {
-                            Single num9 = NGUIText.finalSpacingX + (Single)bmsymbol.advance * NGUIText.fontScale;
-                            if (Mathf.RoundToInt(num4 + num9) > NGUIText.regionWidth)
+                            Single advanceX = NGUIText.finalSpacingX + bmsymbol.advance * NGUIText.fontScale;
+                            if (Mathf.RoundToInt(currentX + advanceX) > NGUIText.regionWidth)
                             {
-                                if (num4 > num6)
-                                {
-                                    num6 = num4 - NGUIText.finalSpacingX;
-                                }
-                                num4 = num9;
-                                num5 += NGUIText.finalLineHeight;
-                                zero2 = Vector3.zero;
+                                if (currentX > maxLineWidth)
+                                    maxLineWidth = currentX - NGUIText.finalSpacingX;
+                                currentX = advanceX;
+                                textHeight += NGUIText.finalLineHeight;
+                                NGUIText.mTextModifiers.extraOffset = Vector3.zero;
                             }
                             else
                             {
-                                num4 += num9;
+                                currentX += advanceX;
                             }
-                            i += bmsymbol.sequence.Length - 1;
-                            prev = 0;
+                            texti += bmsymbol.sequence.Length - 1;
+                            prevCh = 0;
                         }
                     }
                 }
             }
-            zero.x = ((num4 <= num6) ? num6 : (num4 - NGUIText.finalSpacingX));
-            zero.y = num5 + NGUIText.finalLineHeight;
+            printedSize.x = currentX <= maxLineWidth ? maxLineWidth : currentX - NGUIText.finalSpacingX;
+            printedSize.y = textHeight + NGUIText.finalLineHeight;
         }
-        return zero;
+        return printedSize;
+    }
+
+    public static Single[] CalculateAllCharacterAdvances(String text)
+    {
+        NGUIText.Prepare(text);
+        NGUIText.mTextModifiers.Reset();
+        Int32 textLength = text.Length;
+        Int32 prevCh = 0;
+        Int32 nexti;
+        Single[] charAdvances = new Single[textLength];
+        for (Int32 texti = 0; texti < textLength; texti++)
+        {
+            Int32 ch = text[texti];
+            if (ch == '\n')
+            {
+                NGUIText.mTextModifiers.extraOffset = Vector3.zero;
+                NGUIText.mTextModifiers.insertImage = null;
+            }
+            else if (ch >= 32)
+            {
+                nexti = texti;
+                if (NGUIText.encoding && DialogBoxSymbols.ParseSymbol(text, ref nexti, NGUIText.premultiply, NGUIText.mTextModifiers))
+                {
+                    charAdvances[texti] = NGUIText.mTextModifiers.extraOffset.x;
+                    if (NGUIText.mTextModifiers.insertImage != null)
+                        charAdvances[texti] += NGUIText.mTextModifiers.insertImage.Size.x - 20f;
+                    texti = nexti - 1;
+                }
+                else
+                {
+                    BMSymbol bmsymbol = NGUIText.useSymbols ? NGUIText.GetSymbol(text, texti, textLength) : null;
+                    if (bmsymbol == null)
+                    {
+                        Single glyphWidth = NGUIText.GetGlyphWidth(ch, prevCh);
+                        if (glyphWidth != 0f)
+                        {
+                            glyphWidth += NGUIText.finalSpacingX;
+                            charAdvances[texti] = NGUIText.mTextModifiers.sub != 0 ? glyphWidth * 0.75f : glyphWidth;
+                            prevCh = ch;
+                        }
+                    }
+                    else
+                    {
+                        charAdvances[texti] = NGUIText.finalSpacingX + bmsymbol.advance * NGUIText.fontScale;
+                        texti += bmsymbol.sequence.Length - 1;
+                        prevCh = 0;
+                    }
+                }
+            }
+        }
+        return charAdvances;
     }
 
     public static String StripSymbols2(String text)
     {
         if (text != null)
         {
-            Int32 i = 0;
-            Int32 length = text.Length;
-            while (i < length)
+            Int32 textLength = text.Length;
+            for (Int32 texti = 0; texti < textLength; texti++)
             {
-                Char c = text[i];
-                if (c == '[' || c == '{')
+                Char ch = text[texti];
+                if (ch == '[' || ch == '{')
                 {
-                    Int32 num = 0;
-                    Boolean flag = false;
-                    Boolean flag2 = false;
-                    Boolean flag3 = false;
-                    Boolean flag4 = false;
-                    Boolean flag5 = false;
-                    Boolean flag6 = false;
-                    Boolean flag7 = false;
-                    Boolean flag8 = false;
-                    Int32 num2 = i;
-                    Int32 num3 = 0;
-                    Vector3 zero = Vector3.zero;
-                    Single num4 = 0f;
-                    Dialog.DialogImage dialogImage = (Dialog.DialogImage)null;
-                    if (DialogBoxSymbols.ParseSymbol(text, ref num2, null, false, ref num, ref flag, ref flag2, ref flag3, ref flag4, ref flag5, ref flag6, ref flag7, ref flag8, ref num3, ref zero, ref num4, ref dialogImage))
+                    NGUIText.mTextModifiers.Reset();
+                    Int32 endOfSymbol = texti;
+                    if (DialogBoxSymbols.ParseSymbol(text, ref endOfSymbol, false, NGUIText.mTextModifiers))
                     {
-                        String text2 = text.Substring(i, num2 - i);
-                        if (!NGUIText.ContainsTextOffset(text2) && dialogImage == null)
+                        String opcodeText = text.Substring(texti, endOfSymbol - texti);
+                        if (!NGUIText.ContainsTextOffset(opcodeText) && NGUIText.mTextModifiers.insertImage == null)
                         {
-                            text = text.Remove(i, num2 - i);
-                            length = text.Length;
+                            text = text.Remove(texti, endOfSymbol - texti);
+                            textLength = text.Length;
                         }
                         else
                         {
-                            i = num2 - 1;
+                            texti = endOfSymbol - 1;
                         }
-                        continue;
                     }
                 }
-                i++;
             }
         }
         return text;
@@ -637,13 +612,10 @@ public static class NGUIText
     public static void SetIconDepth(GameObject phaseLabel, GameObject iconObject, Boolean isLowerPhrase = true)
     {
         Int32 depth = phaseLabel.GetComponent<UIWidget>().depth;
-        Int32 num = (Int32)((!isLowerPhrase) ? (depth + 1) : (depth - iconObject.transform.childCount - 1));
-        iconObject.GetComponent<UIWidget>().depth = num++;
-        foreach (Object obj in iconObject.transform)
-        {
-            Transform transform = (Transform)obj;
-            transform.GetComponent<UIWidget>().depth = num++;
-        }
+        depth = isLowerPhrase ? depth - iconObject.transform.childCount - 1 : depth + 1;
+        iconObject.GetComponent<UIWidget>().depth = depth++;
+        foreach (Transform transform in iconObject.transform)
+            transform.GetComponent<UIWidget>().depth = depth++;
     }
 
     private static void AlignImageWithLastChar(ref BetterList<Dialog.DialogImage> specialImages, BetterList<Int32> imageAlignmentList, BetterList<Vector3> verts, Int32 printedLine)
@@ -678,13 +650,16 @@ public static class NGUIText
 
     private static void AlignImage(BetterList<Vector3> verts, Int32 indexOffset, Single printedWidth, BetterList<Dialog.DialogImage> imageList, Int32 printedLine)
     {
-        switch (NGUIText.alignment)
+        Alignment bidiAlignement = NGUIText.alignment;
+        if (NGUIText.readingDirection == UnicodeBIDI.LanguageReadingDirection.RightToLeft && bidiAlignement == Alignment.Left)
+            bidiAlignement = Alignment.Right;
+        switch (bidiAlignement)
         {
             case NGUIText.Alignment.Left:
             {
-                if (verts.size == 0 || verts.size <= indexOffset)
+                /*if (verts.size == 0 || verts.size <= indexOffset)
                     return;
-                /*if (verts.buffer != null)
+                if (verts.buffer != null)
                 {
                     Single halfEmptySpace = (NGUIText.rectWidth - printedWidth) * 0.5f;
                     Int32 emptySpace = Mathf.RoundToInt(NGUIText.rectWidth - printedWidth);
@@ -720,17 +695,12 @@ public static class NGUIText
     {
         if (insertImage != null)
         {
-            insertImage.LocalPosition = new Vector3(currentX, currentY);
-            Dialog.DialogImage dialogImage = insertImage;
-            dialogImage.LocalPosition.x = dialogImage.LocalPosition.x + extraOffset.x;
-            Dialog.DialogImage dialogImage2 = insertImage;
-            dialogImage2.LocalPosition.y = dialogImage2.LocalPosition.y - extraOffset.y;
-            insertImage.LocalPosition.y = -insertImage.LocalPosition.y;
+            insertImage.LocalPosition = new Vector3(currentX + extraOffset.x, extraOffset.y - currentY);
             insertImage.PrintedLine = printedLine;
+            imageAlignmentList.Add(specialImages.size);
             specialImages.Add(insertImage);
-            imageAlignmentList.Add(specialImages.size - 1);
             currentX += insertImage.Size.x - 20f;
-            insertImage = (Dialog.DialogImage)null;
+            insertImage = null;
         }
     }
 
@@ -746,14 +716,14 @@ public static class NGUIText
 
     public static void Update(Boolean request)
     {
-        NGUIText.finalSize = Mathf.RoundToInt((Single)NGUIText.fontSize / NGUIText.pixelDensity);
+        NGUIText.finalSize = Mathf.RoundToInt(NGUIText.fontSize / NGUIText.pixelDensity);
         NGUIText.finalSpacingX = NGUIText.spacingX * NGUIText.fontScale;
-        NGUIText.finalLineHeight = ((Single)NGUIText.fontSize + NGUIText.spacingY) * NGUIText.fontScale;
-        NGUIText.useSymbols = (NGUIText.bitmapFont != (UnityEngine.Object)null && NGUIText.bitmapFont.hasSymbols && NGUIText.encoding && NGUIText.symbolStyle != NGUIText.SymbolStyle.None);
-        if (NGUIText.dynamicFont != (UnityEngine.Object)null && request)
+        NGUIText.finalLineHeight = (NGUIText.fontSize + NGUIText.spacingY) * NGUIText.fontScale;
+        NGUIText.useSymbols = NGUIText.bitmapFont != null && NGUIText.bitmapFont.hasSymbols && NGUIText.encoding && NGUIText.symbolStyle != NGUIText.SymbolStyle.None;
+        if (request && NGUIText.dynamicFont != null)
         {
             NGUIText.dynamicFont.RequestCharactersInTexture(")_-", NGUIText.finalSize, NGUIText.fontStyle);
-            if (!NGUIText.dynamicFont.GetCharacterInfo(')', out NGUIText.mTempChar, NGUIText.finalSize, NGUIText.fontStyle) || (Single)NGUIText.mTempChar.maxY == 0f)
+            if (!NGUIText.dynamicFont.GetCharacterInfo(')', out NGUIText.mTempChar, NGUIText.finalSize, NGUIText.fontStyle) || NGUIText.mTempChar.maxY == 0f)
             {
                 NGUIText.dynamicFont.RequestCharactersInTexture("A", NGUIText.finalSize, NGUIText.fontStyle);
                 if (!NGUIText.dynamicFont.GetCharacterInfo('A', out NGUIText.mTempChar, NGUIText.finalSize, NGUIText.fontStyle))
@@ -762,49 +732,43 @@ public static class NGUIText
                     return;
                 }
             }
-            Single num = (Single)NGUIText.mTempChar.maxY;
-            Single num2 = (Single)NGUIText.mTempChar.minY;
-            NGUIText.baseline = Mathf.Round(num + ((Single)NGUIText.finalSize - num + num2) * 0.5f);
+            NGUIText.baseline = Mathf.Round((NGUIText.mTempChar.minY + NGUIText.mTempChar.maxY + NGUIText.finalSize) * 0.5f);
         }
     }
 
     public static void Prepare(String text)
     {
-        if (NGUIText.dynamicFont != (UnityEngine.Object)null)
-        {
+        if (NGUIText.dynamicFont != null)
             NGUIText.dynamicFont.RequestCharactersInTexture(text, NGUIText.finalSize, NGUIText.fontStyle);
-        }
     }
 
     public static BMSymbol GetSymbol(String text, Int32 index, Int32 textLength)
     {
-        return (!(NGUIText.bitmapFont != (UnityEngine.Object)null)) ? null : NGUIText.bitmapFont.MatchSymbol(text, index, textLength);
+        return NGUIText.bitmapFont == null ? null : NGUIText.bitmapFont.MatchSymbol(text, index, textLength);
     }
 
     public static Single GetGlyphWidth(Int32 ch, Int32 prev)
     {
-        if (NGUIText.bitmapFont != (UnityEngine.Object)null)
+        if (NGUIText.bitmapFont != null)
         {
-            Boolean flag = false;
-            if (ch == 8201)
+            Boolean isThinSpace = false;
+            if (ch == 0x2009) // Thin space
             {
-                flag = true;
-                ch = 32;
+                isThinSpace = true;
+                ch = ' ';
             }
             BMGlyph bmglyph = NGUIText.bitmapFont.bmFont.GetGlyph(ch);
             if (bmglyph != null)
             {
-                Int32 num = bmglyph.advance;
-                if (flag)
-                {
-                    num >>= 1;
-                }
-                return NGUIText.fontScale * (Single)((prev == 0) ? bmglyph.advance : (num + bmglyph.GetKerning(prev)));
+                Int32 chAdvance = bmglyph.advance;
+                if (isThinSpace)
+                    chAdvance >>= 1;
+                return NGUIText.fontScale * (prev == 0 ? bmglyph.advance : chAdvance + bmglyph.GetKerning(prev));
             }
         }
-        else if (NGUIText.dynamicFont != (UnityEngine.Object)null && NGUIText.dynamicFont.GetCharacterInfo((Char)ch, out NGUIText.mTempChar, NGUIText.finalSize, NGUIText.fontStyle))
+        else if (NGUIText.dynamicFont != null && NGUIText.dynamicFont.GetCharacterInfo((Char)ch, out NGUIText.mTempChar, NGUIText.finalSize, NGUIText.fontStyle))
         {
-            return (Single)NGUIText.mTempChar.advance * NGUIText.fontScale * NGUIText.pixelDensity;
+            return NGUIText.mTempChar.advance * NGUIText.fontScale * NGUIText.pixelDensity;
         }
         return 0f;
     }
@@ -881,8 +845,8 @@ public static class NGUIText
     [DebuggerHidden]
     public static Single ParseAlpha(String text, Int32 index)
     {
-        Int32 num = NGUIMath.HexToDecimal(text[index + 1]) << 4 | NGUIMath.HexToDecimal(text[index + 2]);
-        return Mathf.Clamp01((Single)num / 255f);
+        Int32 alpha = NGUIMath.HexToDecimal(text[index + 1]) << 4 | NGUIMath.HexToDecimal(text[index + 2]);
+        return Mathf.Clamp01(alpha / 255f);
     }
 
     [DebuggerStepThrough]
@@ -896,23 +860,23 @@ public static class NGUIText
     [DebuggerStepThrough]
     public static Color ParseColor24(String text, Int32 offset)
     {
-        Int32 num = NGUIMath.HexToDecimal(text[offset]) << 4 | NGUIMath.HexToDecimal(text[offset + 1]);
-        Int32 num2 = NGUIMath.HexToDecimal(text[offset + 2]) << 4 | NGUIMath.HexToDecimal(text[offset + 3]);
-        Int32 num3 = NGUIMath.HexToDecimal(text[offset + 4]) << 4 | NGUIMath.HexToDecimal(text[offset + 5]);
-        Single num4 = 0.003921569f;
-        return new Color(num4 * (Single)num, num4 * (Single)num2, num4 * (Single)num3);
+        Int32 r = NGUIMath.HexToDecimal(text[offset]) << 4 | NGUIMath.HexToDecimal(text[offset + 1]);
+        Int32 g = NGUIMath.HexToDecimal(text[offset + 2]) << 4 | NGUIMath.HexToDecimal(text[offset + 3]);
+        Int32 b = NGUIMath.HexToDecimal(text[offset + 4]) << 4 | NGUIMath.HexToDecimal(text[offset + 5]);
+        Single f = 0.003921569f; // 1/255
+        return new Color(f * r, f * g, f * b);
     }
 
     [DebuggerHidden]
     [DebuggerStepThrough]
     public static Color ParseColor32(String text, Int32 offset)
     {
-        Int32 num = NGUIMath.HexToDecimal(text[offset]) << 4 | NGUIMath.HexToDecimal(text[offset + 1]);
-        Int32 num2 = NGUIMath.HexToDecimal(text[offset + 2]) << 4 | NGUIMath.HexToDecimal(text[offset + 3]);
-        Int32 num3 = NGUIMath.HexToDecimal(text[offset + 4]) << 4 | NGUIMath.HexToDecimal(text[offset + 5]);
-        Int32 num4 = NGUIMath.HexToDecimal(text[offset + 6]) << 4 | NGUIMath.HexToDecimal(text[offset + 7]);
-        Single num5 = 0.003921569f;
-        return new Color(num5 * (Single)num, num5 * (Single)num2, num5 * (Single)num3, num5 * (Single)num4);
+        Int32 r = NGUIMath.HexToDecimal(text[offset]) << 4 | NGUIMath.HexToDecimal(text[offset + 1]);
+        Int32 g = NGUIMath.HexToDecimal(text[offset + 2]) << 4 | NGUIMath.HexToDecimal(text[offset + 3]);
+        Int32 b = NGUIMath.HexToDecimal(text[offset + 4]) << 4 | NGUIMath.HexToDecimal(text[offset + 5]);
+        Int32 a = NGUIMath.HexToDecimal(text[offset + 6]) << 4 | NGUIMath.HexToDecimal(text[offset + 7]);
+        Single f = 0.003921569f; // 1/255
+        return new Color(f * r, f * g, f * b, f * a);
     }
 
     [DebuggerStepThrough]
@@ -926,54 +890,50 @@ public static class NGUIText
     [DebuggerHidden]
     public static String EncodeColor(String text, Color c)
     {
-        return String.Concat(new String[]
-        {
-            "[c][",
-            NGUIText.EncodeColor24(c),
-            "]",
-            text,
-            "[-][/c]"
-        });
+        return $"[c][{NGUIText.EncodeColor24(c)}]{text}[-][/c]";
     }
 
     [DebuggerStepThrough]
     [DebuggerHidden]
     public static String EncodeAlpha(Single a)
     {
-        Int32 num = Mathf.Clamp(Mathf.RoundToInt(a * 255f), 0, 255);
-        return NGUIMath.DecimalToHex8(num);
+        Int32 alpha = Mathf.Clamp(Mathf.RoundToInt(a * 255f), 0, 255);
+        return NGUIMath.DecimalToHex8(alpha);
     }
 
     [DebuggerStepThrough]
     [DebuggerHidden]
     public static String EncodeColor24(Color c)
     {
-        Int32 num = 16777215 & NGUIMath.ColorToInt(c) >> 8;
-        return NGUIMath.DecimalToHex24(num);
+        Int32 colorCode = 0xFFFFFF & NGUIMath.ColorToInt(c) >> 8;
+        return NGUIMath.DecimalToHex24(colorCode);
     }
 
     [DebuggerHidden]
     [DebuggerStepThrough]
     public static String EncodeColor32(Color c)
     {
-        Int32 num = NGUIMath.ColorToInt(c);
-        return NGUIMath.DecimalToHex32(num);
+        Int32 colorCode = NGUIMath.ColorToInt(c);
+        return NGUIMath.DecimalToHex32(colorCode);
     }
 
-    public static Boolean ParseSymbol(String text, ref Int32 index, ref Int32 ff9Signal, ref Dialog.DialogImage insertImage)
+    private static Boolean ParseSymbol(String text, ref Int32 index, FFIXTextModifier modifiers)
     {
-        Int32 num = 1;
-        Boolean flag = false;
-        Boolean flag2 = false;
-        Boolean flag3 = false;
-        Boolean flag4 = false;
-        Boolean flag5 = false;
-        Boolean flag6 = false;
-        Boolean flag7 = false;
-        Boolean flag8 = false;
-        Vector3 zero = Vector3.zero;
-        Single num2 = 0f;
-        return DialogBoxSymbols.ParseSymbol(text, ref index, null, false, ref num, ref flag, ref flag2, ref flag3, ref flag4, ref flag5, ref flag6, ref flag7, ref flag8, ref ff9Signal, ref zero, ref num2, ref insertImage);
+        return DialogBoxSymbols.ParseSymbol(text, ref index, false, modifiers);
+    }
+
+    public static Dialog.DialogImage GetNextDialogImage(String text, ref Int32 index)
+    {
+        NGUIText.mTextModifiers.Reset();
+        while (DialogBoxSymbols.ParseSymbol(text, ref index, false, NGUIText.mTextModifiers)) { }
+        return NGUIText.mTextModifiers.insertImage;
+    }
+
+    public static Int32 GetNextFF9Signal(String text, ref Int32 index)
+    {
+        NGUIText.mTextModifiers.Reset();
+        while (DialogBoxSymbols.ParseSymbol(text, ref index, false, NGUIText.mTextModifiers)) { }
+        return NGUIText.mTextModifiers.ff9Signal;
     }
 
     [DebuggerHidden]
@@ -987,35 +947,20 @@ public static class NGUIText
     {
         if (text != null)
         {
-            Int32 i = 0;
-            Int32 length = text.Length;
-            while (i < length)
+            Int32 textLength = text.Length;
+            for (Int32 texti = 0; texti < textLength; texti++)
             {
-                Char c = text[i];
-                if (c == '[' || c == '{')
+                Char ch = text[texti];
+                if (ch == '[' || ch == '{')
                 {
-                    Int32 num = 0;
-                    Boolean flag = false;
-                    Boolean flag2 = false;
-                    Boolean flag3 = false;
-                    Boolean flag4 = false;
-                    Boolean flag5 = false;
-                    Boolean flag6 = false;
-                    Boolean flag7 = false;
-                    Boolean flag8 = false;
-                    Int32 num2 = i;
-                    Int32 num3 = 0;
-                    Vector3 zero = Vector3.zero;
-                    Single num4 = 0f;
-                    Dialog.DialogImage dialogImage = (Dialog.DialogImage)null;
-                    if (DialogBoxSymbols.ParseSymbol(text, ref num2, null, false, ref num, ref flag, ref flag2, ref flag3, ref flag4, ref flag5, ref flag6, ref flag7, ref flag8, ref num3, ref zero, ref num4, ref dialogImage))
+                    Int32 endOfSymbol = texti;
+                    NGUIText.mTextModifiers.Reset();
+                    if (DialogBoxSymbols.ParseSymbol(text, ref endOfSymbol, false, NGUIText.mTextModifiers))
                     {
-                        text = text.Remove(i, num2 - i);
-                        length = text.Length;
-                        continue;
+                        text = text.Remove(texti, endOfSymbol - texti);
+                        textLength = text.Length;
                     }
                 }
-                i++;
             }
         }
         return text;
@@ -1025,7 +970,10 @@ public static class NGUIText
     {
         if (verts.size == 0 || verts.size <= indexOffset)
             return;
-        switch (NGUIText.alignment)
+        Alignment bidiAlignement = NGUIText.alignment;
+        if (NGUIText.readingDirection == UnicodeBIDI.LanguageReadingDirection.RightToLeft && bidiAlignement == Alignment.Left)
+            bidiAlignement = Alignment.Right;
+        switch (bidiAlignement)
         {
             case NGUIText.Alignment.Left:
             {
@@ -1072,7 +1020,11 @@ public static class NGUIText
             case NGUIText.Alignment.Justified:
             {
                 if (printedWidth < NGUIText.rectWidth * 0.65f)
+                {
+                    if (NGUIText.readingDirection == UnicodeBIDI.LanguageReadingDirection.RightToLeft)
+                        goto case NGUIText.Alignment.Right;
                     return;
+                }
                 Single margin = (NGUIText.rectWidth - printedWidth) * 0.5f;
                 if (margin < 1f)
                     return;
@@ -1126,54 +1078,39 @@ public static class NGUIText
     {
         for (Int32 i = 0; i < indices.size; i++)
         {
-            Int32 num = i << 1;
-            Int32 i2 = num + 1;
-            Single x = verts[num].x;
-            if (pos.x >= x)
-            {
-                Single x2 = verts[i2].x;
-                if (pos.x <= x2)
-                {
-                    Single y = verts[num].y;
-                    if (pos.y >= y)
-                    {
-                        Single y2 = verts[i2].y;
-                        if (pos.y <= y2)
-                        {
-                            return indices[i];
-                        }
-                    }
-                }
-            }
+            Int32 vmin = i << 1;
+            Int32 vmax = vmin + 1;
+            if (pos.x >= verts[vmin].x && pos.x <= verts[vmax].x && pos.y >= verts[vmin].y && pos.y <= verts[vmax].y)
+                return indices[i];
         }
         return 0;
     }
 
     public static Int32 GetApproximateCharacterIndex(BetterList<Vector3> verts, BetterList<Int32> indices, Vector2 pos)
     {
-        Single num = Single.MaxValue;
-        Single num2 = Single.MaxValue;
-        Int32 i = 0;
-        for (Int32 j = 0; j < verts.size; j++)
+        Single closestRowDist = Single.MaxValue;
+        Single closestLineDist = Single.MaxValue;
+        Int32 closestIndex = 0;
+        for (Int32 i = 0; i < verts.size; i++)
         {
-            Single num3 = Mathf.Abs(pos.y - verts[j].y);
-            if (num3 <= num2)
+            Single lineDist = Mathf.Abs(pos.y - verts[i].y);
+            if (lineDist <= closestLineDist)
             {
-                Single num4 = Mathf.Abs(pos.x - verts[j].x);
-                if (num3 < num2)
+                Single rowDist = Mathf.Abs(pos.x - verts[i].x);
+                if (lineDist < closestLineDist)
                 {
-                    num2 = num3;
-                    num = num4;
-                    i = j;
+                    closestLineDist = lineDist;
+                    closestRowDist = rowDist;
+                    closestIndex = i;
                 }
-                else if (num4 < num)
+                else if (rowDist < closestRowDist)
                 {
-                    num = num4;
-                    i = j;
+                    closestRowDist = rowDist;
+                    closestIndex = i;
                 }
             }
         }
-        return indices[i];
+        return indices[closestIndex];
     }
 
     [DebuggerStepThrough]
@@ -1187,165 +1124,135 @@ public static class NGUIText
     [DebuggerStepThrough]
     public static void EndLine(ref StringBuilder s)
     {
-        Int32 num = s.Length - 1;
-        if (num > 0 && NGUIText.IsSpace((Int32)s[num]))
-        {
-            s[num] = '\n';
-        }
+        Int32 lastPos = s.Length - 1;
+        if (lastPos > 0 && NGUIText.IsSpace(s[lastPos]))
+            s[lastPos] = '\n';
         else
-        {
             s.Append('\n');
-        }
     }
 
     [DebuggerStepThrough]
     [DebuggerHidden]
     private static void ReplaceSpaceWithNewline(ref StringBuilder s)
     {
-        Int32 num = s.Length - 1;
-        if (num > 0 && NGUIText.IsSpace((Int32)s[num]))
-        {
-            s[num] = '\n';
-        }
+        Int32 lastPos = s.Length - 1;
+        if (lastPos > 0 && NGUIText.IsSpace(s[lastPos]))
+            s[lastPos] = '\n';
     }
 
     public static Vector2 CalculatePrintedSize(String text)
     {
-        Vector2 zero = Vector2.zero;
+        Vector2 printedSize = Vector2.zero;
         if (!String.IsNullOrEmpty(text))
         {
             if (NGUIText.encoding)
-            {
                 text = NGUIText.StripSymbols(text);
-            }
             NGUIText.Prepare(text);
-            Single num = 0f;
-            Single num2 = 0f;
-            Single num3 = 0f;
-            Int32 length = text.Length;
-            Int32 prev = 0;
-            for (Int32 i = 0; i < length; i++)
+            Single currentX = 0f;
+            Single textHeight = 0f;
+            Single maxLineWidth = 0f;
+            Int32 textLength = text.Length;
+            Int32 prevCh = 0;
+            for (Int32 texti = 0; texti < textLength; texti++)
             {
-                Int32 num4 = (Int32)text[i];
-                if (num4 == 10)
+                Int32 ch = text[texti];
+                if (ch == '\n')
                 {
-                    if (num > num3)
-                    {
-                        num3 = num;
-                    }
-                    num = 0f;
-                    num2 += NGUIText.finalLineHeight;
+                    if (currentX > maxLineWidth)
+                        maxLineWidth = currentX;
+                    currentX = 0f;
+                    textHeight += NGUIText.finalLineHeight;
                 }
-                else if (num4 >= 32)
+                else if (ch >= 32)
                 {
-                    BMSymbol bmsymbol = (!NGUIText.useSymbols) ? null : NGUIText.GetSymbol(text, i, length);
+                    BMSymbol bmsymbol = NGUIText.useSymbols ? NGUIText.GetSymbol(text, texti, textLength) : null;
                     if (bmsymbol == null)
                     {
-                        Single num5 = NGUIText.GetGlyphWidth(num4, prev);
-                        if (num5 != 0f)
+                        Single glyphWidth = NGUIText.GetGlyphWidth(ch, prevCh);
+                        if (glyphWidth != 0f)
                         {
-                            num5 += NGUIText.finalSpacingX;
-                            if (Mathf.RoundToInt(num + num5) > NGUIText.regionWidth)
+                            glyphWidth += NGUIText.finalSpacingX;
+                            if (Mathf.RoundToInt(currentX + glyphWidth) > NGUIText.regionWidth)
                             {
-                                if (num > num3)
-                                {
-                                    num3 = num - NGUIText.finalSpacingX;
-                                }
-                                num = num5;
-                                num2 += NGUIText.finalLineHeight;
+                                if (currentX > maxLineWidth)
+                                    maxLineWidth = currentX - NGUIText.finalSpacingX;
+                                currentX = glyphWidth;
+                                textHeight += NGUIText.finalLineHeight;
                             }
                             else
                             {
-                                num += num5;
+                                currentX += glyphWidth;
                             }
-                            prev = num4;
+                            prevCh = ch;
                         }
                     }
                     else
                     {
-                        Single num6 = NGUIText.finalSpacingX + (Single)bmsymbol.advance * NGUIText.fontScale;
-                        if (Mathf.RoundToInt(num + num6) > NGUIText.regionWidth)
+                        Single advanceX = NGUIText.finalSpacingX + bmsymbol.advance * NGUIText.fontScale;
+                        if (Mathf.RoundToInt(currentX + advanceX) > NGUIText.regionWidth)
                         {
-                            if (num > num3)
-                            {
-                                num3 = num - NGUIText.finalSpacingX;
-                            }
-                            num = num6;
-                            num2 += NGUIText.finalLineHeight;
+                            if (currentX > maxLineWidth)
+                                maxLineWidth = currentX - NGUIText.finalSpacingX;
+                            currentX = advanceX;
+                            textHeight += NGUIText.finalLineHeight;
                         }
                         else
                         {
-                            num += num6;
+                            currentX += advanceX;
                         }
-                        i += bmsymbol.sequence.Length - 1;
-                        prev = 0;
+                        texti += bmsymbol.sequence.Length - 1;
+                        prevCh = 0;
                     }
                 }
             }
-            zero.x = ((num <= num3) ? num3 : (num - NGUIText.finalSpacingX));
-            zero.y = num2 + NGUIText.finalLineHeight;
+            printedSize.x = currentX <= maxLineWidth ? maxLineWidth : currentX - NGUIText.finalSpacingX;
+            printedSize.y = textHeight + NGUIText.finalLineHeight;
         }
-        return zero;
+        return printedSize;
     }
 
     public static Int32 CalculateOffsetToFit(String text)
     {
         if (String.IsNullOrEmpty(text) || NGUIText.regionWidth < 1)
-        {
             return 0;
-        }
         NGUIText.Prepare(text);
-        Int32 length = text.Length;
-        Int32 prev = 0;
-        Int32 i = 0;
-        Int32 length2 = text.Length;
-        while (i < length2)
+        Int32 textLength = text.Length;
+        Int32 prevCh = 0;
+        for (Int32 texti = 0; texti < textLength; texti++)
         {
-            BMSymbol bmsymbol = (!NGUIText.useSymbols) ? null : NGUIText.GetSymbol(text, i, length);
+            BMSymbol bmsymbol = NGUIText.useSymbols ? NGUIText.GetSymbol(text, texti, textLength) : null;
             if (bmsymbol == null)
             {
-                Int32 num = (Int32)text[i];
-                Single glyphWidth = NGUIText.GetGlyphWidth(num, prev);
+                Int32 ch = text[texti];
+                Single glyphWidth = NGUIText.GetGlyphWidth(ch, prevCh);
                 if (glyphWidth != 0f)
-                {
                     NGUIText.mSizes.Add(NGUIText.finalSpacingX + glyphWidth);
-                }
-                prev = num;
+                prevCh = ch;
             }
             else
             {
-                NGUIText.mSizes.Add(NGUIText.finalSpacingX + (Single)bmsymbol.advance * NGUIText.fontScale);
-                Int32 j = 0;
-                Int32 num2 = bmsymbol.sequence.Length - 1;
-                while (j < num2)
-                {
+                NGUIText.mSizes.Add(NGUIText.finalSpacingX + bmsymbol.advance * NGUIText.fontScale);
+                Int32 symbolSeqLength = bmsymbol.sequence.Length - 1;
+                for (Int32 i = 0; i < symbolSeqLength; i++)
                     NGUIText.mSizes.Add(0f);
-                    j++;
-                }
-                i += bmsymbol.sequence.Length - 1;
-                prev = 0;
+                texti += bmsymbol.sequence.Length - 1;
+                prevCh = 0;
             }
-            i++;
         }
-        Single num3 = (Single)NGUIText.regionWidth;
-        Int32 num4 = NGUIText.mSizes.size;
-        while (num4 > 0 && num3 > 0f)
-        {
-            num3 -= NGUIText.mSizes[--num4];
-        }
+        Single availableWidth = NGUIText.regionWidth;
+        Int32 overlimitCharacters = NGUIText.mSizes.size;
+        while (overlimitCharacters > 0 && availableWidth > 0f)
+            availableWidth -= NGUIText.mSizes[--overlimitCharacters];
         NGUIText.mSizes.Clear();
-        if (num3 < 0f)
-        {
-            num4++;
-        }
-        return num4;
+        if (availableWidth < 0f)
+            overlimitCharacters++;
+        return overlimitCharacters;
     }
 
     public static String GetEndOfLineThatFits(String text)
     {
-        Int32 length = text.Length;
-        Int32 num = NGUIText.CalculateOffsetToFit(text);
-        return text.Substring(num, length - num);
+        Int32 charToRemove = NGUIText.CalculateOffsetToFit(text);
+        return text.Substring(charToRemove, text.Length - charToRemove);
     }
 
     public static Boolean WrapText(String text, out String finalText, Boolean wrapLineColors = false)
@@ -1360,90 +1267,63 @@ public static class NGUIText
             finalText = String.Empty;
             return false;
         }
-        Single num = (NGUIText.maxLines <= 0) ? ((Single)NGUIText.regionHeight) : Mathf.Min((Single)NGUIText.regionHeight, NGUIText.finalLineHeight * (Single)NGUIText.maxLines);
-        Int32 num2 = (Int32)((NGUIText.maxLines <= 0) ? 1000000 : NGUIText.maxLines);
-        num2 = Mathf.FloorToInt(Mathf.Min((Single)num2, num / NGUIText.finalLineHeight) + 0.01f);
-        if (num2 == 0)
+        Single maxHeight = NGUIText.maxLines <= 0 ? NGUIText.regionHeight : Mathf.Min(NGUIText.regionHeight, NGUIText.finalLineHeight * NGUIText.maxLines);
+        Int32 maxLineCount = NGUIText.maxLines <= 0 ? 1000000 : NGUIText.maxLines;
+        maxLineCount = Mathf.FloorToInt(Mathf.Min(maxLineCount, maxHeight / NGUIText.finalLineHeight) + 0.01f);
+        if (maxLineCount == 0)
         {
             finalText = String.Empty;
             return false;
         }
         if (String.IsNullOrEmpty(text))
-        {
             text = " ";
-        }
         NGUIText.Prepare(text);
-        StringBuilder stringBuilder = new StringBuilder();
-        Int32 length = text.Length;
-        Single num3 = (Single)NGUIText.regionWidth;
-        Int32 num4 = 0;
-        Int32 i = 0;
-        Int32 num5 = 1;
-        Int32 prev = 0;
-        Boolean flag = true;
-        Boolean flag2 = true;
-        Boolean flag3 = false;
-        Color item = NGUIText.tint;
-        Int32 num6 = 0;
-        Boolean flag4 = false;
-        Boolean flag5 = false;
-        Boolean flag6 = false;
-        Boolean flag7 = false;
-        Boolean flag8 = false;
-        Boolean flag9 = false;
-        Boolean flag10 = false;
-        Boolean flag15 = false;
-        Int32 num7 = 0;
-        Vector3 zero = Vector3.zero;
-        Single num8 = 0f;
-        Dialog.DialogImage dialogImage = (Dialog.DialogImage)null;
+        StringBuilder finalTextBuilder = new StringBuilder();
+        Int32 textLength = text.Length;
+        Single availableWidth = NGUIText.regionWidth;
+        Int32 lastPossibleBreakPos = 0;
+        Int32 currentLineCount = 1;
+        Int32 prevCh = 0;
+        Boolean canBreakNow = true;
+        Boolean wordsPreserved = true;
+        Boolean isSpecialCharacter = false;
+        Color textColor = NGUIText.tint;
+        NGUIText.mTextModifiers.Reset();
+        BetterList<Color> colorList = NGUIText.mTextModifiers.colors;
         if (!NGUIText.useSymbols)
-        {
             wrapLineColors = false;
-        }
         if (wrapLineColors)
+            colorList.Add(textColor);
+        Int32 texti;
+        for (texti = 0; texti < textLength; texti++)
         {
-            NGUIText.mColors.Add(item);
-        }
-        while (i < length)
-        {
-            Char c = text[i];
-            if (c > '⿿')
+            Char ch = text[texti];
+            if (ch > 0x2FFF)
+                isSpecialCharacter = true;
+            if (ch == '\n')
             {
-                flag3 = true;
-            }
-            if (c == '\n')
-            {
-                if (num5 == num2)
-                {
+                if (currentLineCount == maxLineCount)
                     break;
-                }
-                num3 = (Single)NGUIText.regionWidth;
-                if (num4 < i)
-                {
-                    stringBuilder.Append(text.Substring(num4, i - num4 + 1));
-                }
+                availableWidth = NGUIText.regionWidth;
+                if (lastPossibleBreakPos < texti)
+                    finalTextBuilder.Append(text.Substring(lastPossibleBreakPos, texti - lastPossibleBreakPos + 1));
                 else
-                {
-                    stringBuilder.Append(c);
-                }
+                    finalTextBuilder.Append(ch);
                 if (wrapLineColors)
                 {
-                    for (Int32 j = 0; j < NGUIText.mColors.size; j++)
+                    for (Int32 i = 0; i < colorList.size; i++)
+                        finalTextBuilder.Insert(finalTextBuilder.Length - 1, "[-]");
+                    for (Int32 i = 0; i < colorList.size; i++)
                     {
-                        stringBuilder.Insert(stringBuilder.Length - 1, "[-]");
-                    }
-                    for (Int32 k = 0; k < NGUIText.mColors.size; k++)
-                    {
-                        stringBuilder.Append("[");
-                        stringBuilder.Append(NGUIText.EncodeColor(NGUIText.mColors[k]));
-                        stringBuilder.Append("]");
+                        finalTextBuilder.Append("[");
+                        finalTextBuilder.Append(NGUIText.EncodeColor(colorList[i]));
+                        finalTextBuilder.Append("]");
                     }
                 }
-                flag = true;
-                num5++;
-                num4 = i + 1;
-                prev = 0;
+                canBreakNow = true;
+                currentLineCount++;
+                lastPossibleBreakPos = texti + 1;
+                prevCh = 0;
             }
             else
             {
@@ -1451,177 +1331,140 @@ public static class NGUIText
                 {
                     if (!wrapLineColors)
                     {
-                        if (NGUIText.ParseSymbol(text, ref i, ref num7, ref dialogImage))
+                        if (NGUIText.ParseSymbol(text, ref texti, NGUIText.mTextModifiers))
                         {
-                            i--;
-                            goto IL_69E;
+                            texti--;
+                            continue;
                         }
                     }
-                    else if (DialogBoxSymbols.ParseSymbol(text, ref i, NGUIText.mColors, NGUIText.premultiply, ref num6, ref flag4, ref flag5, ref flag6, ref flag7, ref flag8, ref flag9, ref flag10, ref flag15, ref num7, ref zero, ref num8, ref dialogImage))
+                    else if (DialogBoxSymbols.ParseSymbol(text, ref texti, NGUIText.premultiply, NGUIText.mTextModifiers))
                     {
-                        if (flag8)
+                        if (NGUIText.mTextModifiers.ignoreColor)
                         {
-                            item = NGUIText.mColors[NGUIText.mColors.size - 1];
-                            item.a *= NGUIText.mAlpha * NGUIText.tint.a;
+                            textColor = colorList[colorList.size - 1];
+                            textColor.a *= NGUIText.mAlpha * NGUIText.tint.a;
                         }
                         else
                         {
-                            item = NGUIText.tint * NGUIText.mColors[NGUIText.mColors.size - 1];
-                            item.a *= NGUIText.mAlpha;
+                            textColor = NGUIText.tint * colorList[colorList.size - 1];
+                            textColor.a *= NGUIText.mAlpha;
                         }
-                        Int32 l = 0;
-                        Int32 num9 = NGUIText.mColors.size - 2;
-                        while (l < num9)
-                        {
-                            item.a *= NGUIText.mColors[l].a;
-                            l++;
-                        }
-                        i--;
-                        goto IL_69E;
+                        for (Int32 i = 0; i < colorList.size - 2; i++)
+                            textColor.a *= colorList[i].a;
+                        texti--;
+                        continue;
                     }
                 }
-                BMSymbol bmsymbol = (!NGUIText.useSymbols) ? null : NGUIText.GetSymbol(text, i, length);
-                Single num10;
+                BMSymbol bmsymbol = NGUIText.useSymbols ? NGUIText.GetSymbol(text, texti, textLength) : null;
+                Single advanceX;
                 if (bmsymbol == null)
                 {
-                    Single glyphWidth = NGUIText.GetGlyphWidth((Int32)c, prev);
+                    Single glyphWidth = NGUIText.GetGlyphWidth(ch, prevCh);
                     if (glyphWidth == 0f)
-                    {
-                        goto IL_69E;
-                    }
-                    num10 = NGUIText.finalSpacingX + glyphWidth;
+                        continue;
+                    advanceX = NGUIText.finalSpacingX + glyphWidth;
                 }
                 else
                 {
-                    num10 = NGUIText.finalSpacingX + (Single)bmsymbol.advance * NGUIText.fontScale;
+                    advanceX = NGUIText.finalSpacingX + bmsymbol.advance * NGUIText.fontScale;
                 }
-                num3 -= num10;
-                if (NGUIText.IsSpace((Int32)c) && !flag3 && num4 < i)
+                availableWidth -= advanceX;
+                Boolean isSpace = NGUIText.IsSpace(ch);
+                if (isSpace && !isSpecialCharacter && lastPossibleBreakPos < texti)
                 {
-                    Int32 num11 = i - num4 + 1;
-                    if (num5 == num2 && num3 <= 0f && i < length)
-                    {
-                        Char c2 = text[i];
-                        if (c2 < ' ' || NGUIText.IsSpace((Int32)c2))
-                        {
-                            num11--;
-                        }
-                    }
-                    stringBuilder.Append(text.Substring(num4, num11));
-                    flag = false;
-                    num4 = i + 1;
+                    Int32 copyLength = texti - lastPossibleBreakPos + 1;
+                    if (currentLineCount == maxLineCount && availableWidth <= 0f && texti < textLength && (ch < ' ' || isSpace))
+                        copyLength--;
+                    finalTextBuilder.Append(text.Substring(lastPossibleBreakPos, copyLength));
+                    canBreakNow = false;
+                    lastPossibleBreakPos = texti + 1;
                 }
-                if (Mathf.RoundToInt(num3) < 0)
+                if (Mathf.RoundToInt(availableWidth) < 0)
                 {
-                    if (flag || num5 == num2)
+                    if (canBreakNow || currentLineCount == maxLineCount)
                     {
-                        stringBuilder.Append(text.Substring(num4, Mathf.Max(0, i - num4)));
-                        Boolean flag11 = NGUIText.IsSpace((Int32)c);
-                        if (!flag11 && !flag3)
+                        finalTextBuilder.Append(text.Substring(lastPossibleBreakPos, Mathf.Max(0, texti - lastPossibleBreakPos)));
+                        if (!isSpace && !isSpecialCharacter)
+                            wordsPreserved = false;
+                        if (wrapLineColors && colorList.size > 0)
+                            finalTextBuilder.Append("[-]");
+                        if (currentLineCount++ == maxLineCount)
                         {
-                            flag2 = false;
-                        }
-                        if (wrapLineColors && NGUIText.mColors.size > 0)
-                        {
-                            stringBuilder.Append("[-]");
-                        }
-                        if (num5++ == num2)
-                        {
-                            num4 = i;
+                            lastPossibleBreakPos = texti;
                             break;
                         }
                         if (keepCharCount)
-                        {
-                            NGUIText.ReplaceSpaceWithNewline(ref stringBuilder);
-                        }
+                            NGUIText.ReplaceSpaceWithNewline(ref finalTextBuilder);
                         else
-                        {
-                            NGUIText.EndLine(ref stringBuilder);
-                        }
+                            NGUIText.EndLine(ref finalTextBuilder);
                         if (wrapLineColors)
                         {
-                            for (Int32 m = 0; m < NGUIText.mColors.size; m++)
+                            for (Int32 i = 0; i < colorList.size; i++)
+                                finalTextBuilder.Insert(finalTextBuilder.Length - 1, "[-]");
+                            for (Int32 i = 0; i < colorList.size; i++)
                             {
-                                stringBuilder.Insert(stringBuilder.Length - 1, "[-]");
-                            }
-                            for (Int32 n = 0; n < NGUIText.mColors.size; n++)
-                            {
-                                stringBuilder.Append("[");
-                                stringBuilder.Append(NGUIText.EncodeColor(NGUIText.mColors[n]));
-                                stringBuilder.Append("]");
+                                finalTextBuilder.Append("[");
+                                finalTextBuilder.Append(NGUIText.EncodeColor(colorList[i]));
+                                finalTextBuilder.Append("]");
                             }
                         }
-                        flag = true;
-                        if (flag11)
+                        canBreakNow = true;
+                        if (isSpace)
                         {
-                            num4 = i + 1;
-                            num3 = (Single)NGUIText.regionWidth;
+                            lastPossibleBreakPos = texti + 1;
+                            availableWidth = NGUIText.regionWidth;
                         }
                         else
                         {
-                            num4 = i;
-                            num3 = (Single)NGUIText.regionWidth - num10;
+                            lastPossibleBreakPos = texti;
+                            availableWidth = NGUIText.regionWidth - advanceX;
                         }
-                        prev = 0;
+                        prevCh = 0;
                     }
                     else
                     {
-                        flag = true;
-                        num3 = (Single)NGUIText.regionWidth;
-                        i = num4 - 1;
-                        prev = 0;
-                        if (num5++ == num2)
-                        {
+                        canBreakNow = true;
+                        availableWidth = NGUIText.regionWidth;
+                        texti = lastPossibleBreakPos - 1;
+                        prevCh = 0;
+                        if (currentLineCount++ == maxLineCount)
                             break;
-                        }
                         if (keepCharCount)
-                        {
-                            NGUIText.ReplaceSpaceWithNewline(ref stringBuilder);
-                        }
+                            NGUIText.ReplaceSpaceWithNewline(ref finalTextBuilder);
                         else
-                        {
-                            NGUIText.EndLine(ref stringBuilder);
-                        }
+                            NGUIText.EndLine(ref finalTextBuilder);
                         if (wrapLineColors)
                         {
-                            for (Int32 num12 = 0; num12 < NGUIText.mColors.size; num12++)
+                            for (Int32 i = 0; i < colorList.size; i++)
+                                finalTextBuilder.Insert(finalTextBuilder.Length - 1, "[-]");
+                            for (Int32 i = 0; i < colorList.size; i++)
                             {
-                                stringBuilder.Insert(stringBuilder.Length - 1, "[-]");
-                            }
-                            for (Int32 num13 = 0; num13 < NGUIText.mColors.size; num13++)
-                            {
-                                stringBuilder.Append("[");
-                                stringBuilder.Append(NGUIText.EncodeColor(NGUIText.mColors[num13]));
-                                stringBuilder.Append("]");
+                                finalTextBuilder.Append("[");
+                                finalTextBuilder.Append(NGUIText.EncodeColor(colorList[i]));
+                                finalTextBuilder.Append("]");
                             }
                         }
-                        goto IL_69E;
+                        continue;
                     }
                 }
                 else
                 {
-                    prev = (Int32)c;
+                    prevCh = ch;
                 }
                 if (bmsymbol != null)
                 {
-                    i += bmsymbol.length - 1;
-                    prev = 0;
+                    texti += bmsymbol.length - 1;
+                    prevCh = 0;
                 }
             }
-        IL_69E:
-            i++;
         }
-        if (num4 < i)
-        {
-            stringBuilder.Append(text.Substring(num4, i - num4));
-        }
-        if (wrapLineColors && NGUIText.mColors.size > 0)
-        {
-            stringBuilder.Append("[-]");
-        }
-        finalText = stringBuilder.ToString();
-        NGUIText.mColors.Clear();
-        return flag2 && (i == length || num5 <= Mathf.Min(NGUIText.maxLines, num2));
+        if (lastPossibleBreakPos < texti)
+            finalTextBuilder.Append(text.Substring(lastPossibleBreakPos, texti - lastPossibleBreakPos));
+        if (wrapLineColors && colorList.size > 0)
+            finalTextBuilder.Append("[-]");
+        finalText = finalTextBuilder.ToString();
+        colorList.Clear();
+        return wordsPreserved && (texti == textLength || currentLineCount <= Mathf.Min(NGUIText.maxLines, maxLineCount));
     }
 
     public static void Print(String text, BetterList<Vector3> verts, BetterList<Vector2> uvs, BetterList<Color32> cols, out BetterList<Int32> highShadowVertIndexes, out BetterList<Dialog.DialogImage> specialImages, out BetterList<Int32> vertsLineOffsets)
@@ -1633,37 +1476,22 @@ public static class NGUIText
             return;
         Int32 vIndex = verts.size;
         NGUIText.Prepare(text);
-        NGUIText.mColors.Add(Color.white);
-        NGUIText.mAlpha = 1f;
         Int32 prevCh = 0;
         Int32 currCh = 0;
         Single currentX = 0f;
-        Single lineHeight = 0f;
+        Single textHeight = 0f;
         Single maxLineWidth = 0f;
         Color gradientColorBottom = NGUIText.tint * NGUIText.gradientBottom;
         Color gradientColorTop = NGUIText.tint * NGUIText.gradientTop;
         Color32 textColor = NGUIText.tint;
         Int32 textLength = text.Length;
-        Rect bmUvRect = default(Rect);
+        Rect bmUvRect = default;
         Single bmTextureFactorX = 0f;
         Single bmTextureFactorY = 0f;
         Single ftSize = NGUIText.finalSize * NGUIText.pixelDensity;
         Boolean displacedStrike = false;
-        Int32 sub = 0;
-        Boolean bold = false;
-        Boolean italic = false;
-        Boolean underline = false;
-        Boolean strike = false;
-        Boolean ignoreColor = false;
-        Boolean highShadow = false;
-        Boolean center = false;
-        Boolean justified = false;
         Boolean containCharAlignment = false;
-        Int32 ff9Signal = 0;
-        Vector3 extraOffset = Vector3.zero;
-        Dialog.DialogImage dialogImage = null;
         Int32 printedLine = 0;
-        Single tabX = 0f;
         NGUIText.Alignment defaultAlignment = NGUIText.alignment;
         BetterList<Int32> imgNotYetAligned = new BetterList<Int32>();
         if (NGUIText.bitmapFont != null)
@@ -1674,9 +1502,33 @@ public static class NGUIText
         }
         if (textLength > 0)
             vertsLineOffsets.Add(0);
+
+        Boolean useBIDI = NGUIText.ShouldUseBIDI(text);
+        UnicodeBIDI bidi = null;
+        Single[] allCharAdvances = null;
+        if (useBIDI)
+        {
+            bidi = new UnicodeBIDI(text.ToCharArray(), readingDirection);
+            text = new String(bidi.FullText);
+            allCharAdvances = NGUIText.CalculateAllCharacterAdvances(text); // Sorted according to memory position
+            Single[] reorderedAdvances = new Single[textLength + 1];
+            for (Int32 i = 0; i < textLength; i++)
+                reorderedAdvances[bidi.Reposition[i] + 1] = allCharAdvances[i];
+            allCharAdvances = reorderedAdvances; // Sorted according to display position (+ shifted by 1)
+            for (Int32 i = 2; i <= textLength; i++)
+                if (text[i - 1] != '\n')
+                    allCharAdvances[i] += allCharAdvances[i - 1]; // Cumulative advances per line (ie. vertex left position)
+        }
+        NGUIText.mTextModifiers.Reset();
+        BetterList<Color> colorList = NGUIText.mTextModifiers.colors;
+        colorList.Add(Color.white);
+        NGUIText.mAlpha = 1f;
+
         for (Int32 texti = 0; texti < textLength; texti++)
         {
             Int32 ch = text[texti];
+            if (useBIDI)
+                currentX = allCharAdvances[bidi.Reposition[texti]];
             Single previousX = currentX;
             if (ch == '\n')
             {
@@ -1691,12 +1543,12 @@ public static class NGUIText
                 vIndex = verts.size;
                 vertsLineOffsets.Add(vIndex);
                 NGUIText.alignment = defaultAlignment;
-                center = false;
+                NGUIText.mTextModifiers.center = false;
                 containCharAlignment = false;
-                extraOffset = Vector3.zero;
+                NGUIText.mTextModifiers.extraOffset = Vector3.zero;
                 printedLine++;
                 currentX = 0f;
-                lineHeight += NGUIText.finalLineHeight;
+                textHeight += NGUIText.finalLineHeight;
                 prevCh = 0;
             }
             else if (ch < 32)
@@ -1704,23 +1556,23 @@ public static class NGUIText
                 // Control characters
                 prevCh = ch;
             }
-            else if (NGUIText.encoding && DialogBoxSymbols.ParseSymbol(text, ref texti, NGUIText.mColors, NGUIText.premultiply, ref sub, ref bold, ref italic, ref underline, ref strike, ref ignoreColor, ref highShadow, ref center, ref justified, ref ff9Signal, ref extraOffset, ref tabX, ref dialogImage))
+            else if (NGUIText.encoding && DialogBoxSymbols.ParseSymbol(text, ref texti, NGUIText.premultiply, NGUIText.mTextModifiers))
             {
                 // Opcode / tag
                 Color colorFromOpcode;
-                if (ignoreColor)
+                if (NGUIText.mTextModifiers.ignoreColor)
                 {
-                    colorFromOpcode = NGUIText.mColors[NGUIText.mColors.size - 1];
+                    colorFromOpcode = colorList[colorList.size - 1];
                     colorFromOpcode.a *= NGUIText.mAlpha * NGUIText.tint.a;
                 }
                 else
                 {
-                    colorFromOpcode = NGUIText.tint * NGUIText.mColors[NGUIText.mColors.size - 1];
+                    colorFromOpcode = NGUIText.tint * colorList[colorList.size - 1];
                     colorFromOpcode.a *= NGUIText.mAlpha;
                 }
                 textColor = colorFromOpcode;
-                for (Int32 i = 0; i < NGUIText.mColors.size - 2; i++)
-                    colorFromOpcode.a *= NGUIText.mColors[i].a;
+                for (Int32 i = 0; i < colorList.size - 2; i++)
+                    colorFromOpcode.a *= colorList[i].a;
                 if (NGUIText.gradient)
                 {
                     gradientColorBottom = NGUIText.gradientBottom * colorFromOpcode;
@@ -1731,26 +1583,26 @@ public static class NGUIText
             else
             {
                 // Normal character
-                if (justified)
+                if (NGUIText.mTextModifiers.justified)
                     NGUIText.alignment = NGUIText.Alignment.Justified;
-                else if (center)
+                else if (NGUIText.mTextModifiers.center)
                     NGUIText.alignment = NGUIText.Alignment.Center;
                 else
                     NGUIText.alignment = defaultAlignment;
-                if (tabX != 0f)
+                if (NGUIText.mTextModifiers.tabX != 0f)
                 {
-                    extraOffset.x = 0f;
-                    currentX = tabX;
-                    tabX = 0f;
+                    NGUIText.mTextModifiers.extraOffset.x = 0f;
+                    currentX = NGUIText.mTextModifiers.tabX;
+                    NGUIText.mTextModifiers.tabX = 0f;
                 }
-                NGUIText.AddSpecialIconToList(ref specialImages, ref imgNotYetAligned, ref dialogImage, extraOffset, ref currentX, lineHeight, printedLine);
+                NGUIText.AddSpecialIconToList(ref specialImages, ref imgNotYetAligned, ref NGUIText.mTextModifiers.insertImage, NGUIText.mTextModifiers.extraOffset, ref currentX, textHeight, printedLine);
                 BMSymbol bmsymbol = NGUIText.useSymbols ? NGUIText.GetSymbol(text, texti, textLength) : null;
                 if (bmsymbol != null)
                 {
                     // As a bitmap symbol
                     Single v0x = currentX + bmsymbol.offsetX * NGUIText.fontScale;
                     Single v1x = v0x + bmsymbol.width * NGUIText.fontScale;
-                    Single v0y = -(lineHeight + bmsymbol.offsetY * NGUIText.fontScale);
+                    Single v0y = -(textHeight + bmsymbol.offsetY * NGUIText.fontScale);
                     Single v1y = v0y - bmsymbol.height * NGUIText.fontScale;
                     if (Mathf.RoundToInt(currentX + bmsymbol.advance * NGUIText.fontScale) > NGUIText.regionWidth)
                     {
@@ -1764,15 +1616,15 @@ public static class NGUIText
                             vertsLineOffsets.Add(vIndex);
                         }
                         NGUIText.alignment = defaultAlignment;
-                        center = false;
-                        extraOffset = Vector3.zero;
+                        NGUIText.mTextModifiers.center = false;
+                        NGUIText.mTextModifiers.extraOffset = Vector3.zero;
                         printedLine++;
                         v0x -= currentX;
                         v1x -= currentX;
                         v1y -= NGUIText.finalLineHeight;
                         v0y -= NGUIText.finalLineHeight;
                         currentX = 0f;
-                        lineHeight += NGUIText.finalLineHeight;
+                        textHeight += NGUIText.finalLineHeight;
                     }
                     verts.Add(new Vector3(v0x, v1y));
                     verts.Add(new Vector3(v0x, v0y));
@@ -1819,11 +1671,11 @@ public static class NGUIText
                             containCharAlignment = NGUIText.ContainCharAlignment(ch);
                         prevCh = ch;
                         currCh = ch;
-                        if (sub != 0)
+                        if (NGUIText.mTextModifiers.sub != 0)
                         {
                             glyphInfo.v0 *= 0.75f;
                             glyphInfo.v1 *= 0.75f;
-                            if (sub == 1)
+                            if (NGUIText.mTextModifiers.sub == 1)
                             {
                                 glyphInfo.v0.y -= NGUIText.fontScale * NGUIText.fontSize * 0.4f;
                                 glyphInfo.v1.y -= NGUIText.fontScale * NGUIText.fontSize * 0.4f;
@@ -1835,9 +1687,9 @@ public static class NGUIText
                             }
                         }
                         Single v0x = glyphInfo.v0.x + currentX;
-                        Single v0y = glyphInfo.v0.y - lineHeight;
+                        Single v0y = glyphInfo.v0.y - textHeight;
                         Single v1x = glyphInfo.v1.x + currentX;
-                        Single v1y = glyphInfo.v1.y - lineHeight;
+                        Single v1y = glyphInfo.v1.y - textHeight;
                         Single glyphAdvance = glyphInfo.advance;
                         if (NGUIText.finalSpacingX < 0f)
                             glyphAdvance += NGUIText.finalSpacingX;
@@ -1851,25 +1703,25 @@ public static class NGUIText
                                 vIndex = verts.size;
                                 vertsLineOffsets.Add(vIndex);
                             }
-                            extraOffset = Vector3.zero;
+                            NGUIText.mTextModifiers.extraOffset = Vector3.zero;
                             v0x -= currentX;
                             v1x -= currentX;
                             v0y -= NGUIText.finalLineHeight;
                             v1y -= NGUIText.finalLineHeight;
                             currentX = 0f;
-                            lineHeight += NGUIText.finalLineHeight;
+                            textHeight += NGUIText.finalLineHeight;
                             previousX = 0f;
                             NGUIText.alignment = defaultAlignment;
-                            center = false;
+                            NGUIText.mTextModifiers.center = false;
                         }
                         if (NGUIText.IsSpace(ch))
                         {
-                            if (underline)
+                            if (NGUIText.mTextModifiers.underline)
                                 ch = '_';
-                            else if (strike)
+                            else if (NGUIText.mTextModifiers.strike)
                                 ch = '-';
                         }
-                        currentX += sub != 0 ? (NGUIText.finalSpacingX + glyphInfo.advance) * 0.75f : (NGUIText.finalSpacingX + glyphInfo.advance);
+                        currentX += NGUIText.mTextModifiers.sub != 0 ? (NGUIText.finalSpacingX + glyphInfo.advance) * 0.75f : (NGUIText.finalSpacingX + glyphInfo.advance);
                         if (!NGUIText.IsSpace(ch))
                         {
                             if (uvs != null)
@@ -1885,7 +1737,7 @@ public static class NGUIText
                                     glyphInfo.u3.x = glyphInfo.u2.x;
                                     glyphInfo.u3.y = glyphInfo.u0.y;
                                 }
-                                Int32 uvCopyCount = bold ? 4 : 1;
+                                Int32 uvCopyCount = NGUIText.mTextModifiers.bold ? 4 : 1;
                                 for (Int32 i = 0; i < uvCopyCount; i++)
                                 {
                                     uvs.Add(glyphInfo.u0);
@@ -1906,7 +1758,7 @@ public static class NGUIText
                                         gradientPos1 /= ftSize;
                                         NGUIText.s_c0 = Color.Lerp(gradientColorBottom, gradientColorTop, gradientPos0);
                                         NGUIText.s_c1 = Color.Lerp(gradientColorBottom, gradientColorTop, gradientPos1);
-                                        Int32 colCopyCount = bold ? 4 : 1;
+                                        Int32 colCopyCount = NGUIText.mTextModifiers.bold ? 4 : 1;
                                         for (Int32 i = 0; i < colCopyCount; i++)
                                         {
                                             cols.Add(NGUIText.s_c0);
@@ -1917,7 +1769,7 @@ public static class NGUIText
                                     }
                                     else
                                     {
-                                        Int32 colIndexCount = bold ? 16 : 4;
+                                        Int32 colIndexCount = NGUIText.mTextModifiers.bold ? 16 : 4;
                                         for (Int32 i = 0; i < colIndexCount; i++)
                                             cols.Add(textColor);
                                     }
@@ -1933,14 +1785,14 @@ public static class NGUIText
                                         case 4: adjustedColor.r += 0.51f;   break;
                                         case 8: adjustedColor.a += 0.51f;   break;
                                     }
-                                    Int32 colIndexCount = bold ? 16 : 4;
+                                    Int32 colIndexCount = NGUIText.mTextModifiers.bold ? 16 : 4;
                                     for (Int32 i = 0; i < colIndexCount; i++)
                                         cols.Add(adjustedColor);
                                 }
                             }
-                            if (bold)
+                            if (NGUIText.mTextModifiers.bold)
                             {
-                                Single slantOffset = italic ? 0.1f * (v1y - v0y) : 0f;
+                                Single slantOffset = NGUIText.mTextModifiers.italic ? 0.1f * (v1y - v0y) : 0f;
                                 for (Int32 i = 0; i < 4; i++)
                                 {
                                     Single boldOffsetX = NGUIText.mBoldOffset[i * 2];
@@ -1951,7 +1803,7 @@ public static class NGUIText
                                     verts.Add(new Vector3(v1x + boldOffsetX - slantOffset, v0y + boldOffsetY));
                                 }
                             }
-                            else if (italic)
+                            else if (NGUIText.mTextModifiers.italic)
                             {
                                 Single slantOffset = 0.1f * (v1y - v0y);
                                 verts.Add(new Vector3(v0x - slantOffset, v0y));
@@ -1966,20 +1818,20 @@ public static class NGUIText
                                 verts.Add(new Vector3(v1x, v1y));
                                 verts.Add(new Vector3(v1x, v0y));
                             }
-                            if (highShadow)
+                            if (NGUIText.mTextModifiers.highShadow)
                                 for (Int32 verti = verts.size - 4; verti < verts.size; verti++)
                                     highShadowVertIndexes.Add(verti);
-                            if (extraOffset != Vector3.zero)
+                            if (NGUIText.mTextModifiers.extraOffset != Vector3.zero)
                                 for (Int32 i = verts.size - 4; i < verts.size; i++)
-                                    verts[i] += extraOffset;
+                                    verts[i] += NGUIText.mTextModifiers.extraOffset;
                             if (NGUIText.ContainCharAlignment(ch))
                             {
                                 NGUIText.AlignImageWithLastChar(ref specialImages, imgNotYetAligned, verts, printedLine);
                                 imgNotYetAligned.Clear();
                             }
-                            if (underline || strike)
+                            if (NGUIText.mTextModifiers.underline || NGUIText.mTextModifiers.strike)
                             {
-                                NGUIText.GlyphInfo lineGlyph = NGUIText.GetGlyph(strike ? '-' : '_', prevCh);
+                                NGUIText.GlyphInfo lineGlyph = NGUIText.GetGlyph(NGUIText.mTextModifiers.strike ? '-' : '_', prevCh);
                                 if (lineGlyph != null)
                                 {
                                     if (uvs != null)
@@ -1992,7 +1844,7 @@ public static class NGUIText
                                             lineGlyph.u2.y = bmUvRect.yMax - bmTextureFactorY * lineGlyph.u2.y;
                                         }
                                         Single lineTextureCoordX = (lineGlyph.u0.x + lineGlyph.u2.x) * 0.5f;
-                                        Int32 lineCopyCount = bold ? 4 : 1;
+                                        Int32 lineCopyCount = NGUIText.mTextModifiers.bold ? 4 : 1;
                                         for (Int32 i = 0; i < lineCopyCount; i++)
                                         {
                                             uvs.Add(new Vector2(lineTextureCoordX, lineGlyph.u0.y));
@@ -2001,25 +1853,25 @@ public static class NGUIText
                                             uvs.Add(new Vector2(lineTextureCoordX, lineGlyph.u0.y));
                                         }
                                     }
-                                    if (strike)
+                                    if (NGUIText.mTextModifiers.strike)
                                     {
                                         if (displacedStrike) // Maybe for overlining?
                                         {
-                                            v0y = (-lineHeight + lineGlyph.v0.y) * 0.75f;
-                                            v1y = (-lineHeight + lineGlyph.v1.y) * 0.75f;
+                                            v0y = (-textHeight + lineGlyph.v0.y) * 0.75f;
+                                            v1y = (-textHeight + lineGlyph.v1.y) * 0.75f;
                                         }
                                         else
                                         {
-                                            v0y = -lineHeight + lineGlyph.v0.y;
-                                            v1y = -lineHeight + lineGlyph.v1.y;
+                                            v0y = -textHeight + lineGlyph.v0.y;
+                                            v1y = -textHeight + lineGlyph.v1.y;
                                         }
                                     }
                                     else // underline
                                     {
-                                        v0y = -lineHeight + lineGlyph.v0.y - NGUIText.fontScale * NGUIText.fontSize * 0.3f;
-                                        v1y = -lineHeight + lineGlyph.v1.y - NGUIText.fontScale * NGUIText.fontSize * 0.3f;
+                                        v0y = -textHeight + lineGlyph.v0.y - NGUIText.fontScale * NGUIText.fontSize * 0.3f;
+                                        v1y = -textHeight + lineGlyph.v1.y - NGUIText.fontScale * NGUIText.fontSize * 0.3f;
                                     }
-                                    if (bold)
+                                    if (NGUIText.mTextModifiers.bold)
                                     {
                                         for (Int32 i = 0; i < 4; i++)
                                         {
@@ -2038,7 +1890,7 @@ public static class NGUIText
                                         verts.Add(new Vector3(currentX, v1y));
                                         verts.Add(new Vector3(currentX, v0y));
                                     }
-                                    if (highShadow)
+                                    if (NGUIText.mTextModifiers.highShadow)
                                         for (Int32 verti = verts.size - 4; verti < verts.size; verti++)
                                             highShadowVertIndexes.Add(verti);
                                     if (NGUIText.gradient)
@@ -2049,7 +1901,7 @@ public static class NGUIText
                                         gradientPos1 /= ftSize;
                                         NGUIText.s_c0 = Color.Lerp(gradientColorBottom, gradientColorTop, gradientPos0);
                                         NGUIText.s_c1 = Color.Lerp(gradientColorBottom, gradientColorTop, gradientPos1);
-                                        Int32 colCopyCount = bold ? 4 : 1;
+                                        Int32 colCopyCount = NGUIText.mTextModifiers.bold ? 4 : 1;
                                         for (Int32 i = 0; i < colCopyCount; i++)
                                         {
                                             cols.Add(NGUIText.s_c0);
@@ -2060,7 +1912,7 @@ public static class NGUIText
                                     }
                                     else
                                     {
-                                        Int32 colIndexCount = bold ? 16 : 4;
+                                        Int32 colIndexCount = NGUIText.mTextModifiers.bold ? 16 : 4;
                                         for (Int32 i = 0; i < colIndexCount; i++)
                                             cols.Add(textColor);
                                     }
@@ -2071,451 +1923,417 @@ public static class NGUIText
                 }
             }
         }
-        NGUIText.AddSpecialIconToList(ref specialImages, ref imgNotYetAligned, ref dialogImage, extraOffset, ref currentX, lineHeight, printedLine);
+        NGUIText.AddSpecialIconToList(ref specialImages, ref imgNotYetAligned, ref NGUIText.mTextModifiers.insertImage, NGUIText.mTextModifiers.extraOffset, ref currentX, textHeight, printedLine);
         if (vIndex < verts.size)
         {
+            if (useBIDI)
+                currentX = allCharAdvances[textLength];
             NGUIText.AlignImage(verts, vIndex, currentX - NGUIText.finalSpacingX, specialImages, printedLine);
             NGUIText.Align(verts, vIndex, currentX - NGUIText.finalSpacingX, 4);
             vIndex = verts.size;
             vertsLineOffsets.Add(vIndex);
             NGUIText.alignment = defaultAlignment;
-            center = false;
         }
         if (imgNotYetAligned.size > 0 && containCharAlignment && currCh != '-')
         {
             NGUIText.AlignImageWithLastChar(ref specialImages, imgNotYetAligned, verts, printedLine);
             imgNotYetAligned.Clear();
         }
-        extraOffset = Vector3.zero;
-        NGUIText.mColors.Clear();
+        colorList.Clear();
         NGUIText.alignment = defaultAlignment;
     }
 
     public static void PrintApproximateCharacterPositions(String text, BetterList<Vector3> verts, BetterList<Int32> indices)
     {
         if (String.IsNullOrEmpty(text))
-        {
             text = " ";
-        }
         NGUIText.Prepare(text);
-        Single num = 0f;
-        Single num2 = 0f;
-        Single num3 = 0f;
-        Single num4 = (Single)NGUIText.fontSize * NGUIText.fontScale * 0.5f;
-        Int32 length = text.Length;
-        Int32 size = verts.size;
-        Int32 prev = 0;
-        Int32 num5 = 0;
-        Dialog.DialogImage dialogImage = (Dialog.DialogImage)null;
-        for (Int32 i = 0; i < length; i++)
+        Single currentX = 0f;
+        Single textHeight = 0f;
+        Single maxLineWidth = 0f;
+        Single halfLineHeight = NGUIText.fontSize * NGUIText.fontScale * 0.5f;
+        Int32 textLength = text.Length;
+        Int32 vIndex = verts.size;
+        Int32 prevCh = 0;
+        NGUIText.mTextModifiers.Reset();
+        for (Int32 texti = 0; texti < textLength; texti++)
         {
-            Int32 num6 = (Int32)text[i];
-            verts.Add(new Vector3(num, -num2 - num4));
-            indices.Add(i);
-            if (num6 == 10)
+            Int32 ch = text[texti];
+            verts.Add(new Vector3(currentX, -textHeight - halfLineHeight));
+            indices.Add(texti);
+            if (ch == '\n')
             {
-                if (num > num3)
-                {
-                    num3 = num;
-                }
+                if (currentX > maxLineWidth)
+                    maxLineWidth = currentX;
                 if (NGUIText.alignment != NGUIText.Alignment.Left)
                 {
-                    NGUIText.Align(verts, size, num - NGUIText.finalSpacingX, 1);
-                    size = verts.size;
+                    NGUIText.Align(verts, vIndex, currentX - NGUIText.finalSpacingX, 1);
+                    vIndex = verts.size;
                 }
-                num = 0f;
-                num2 += NGUIText.finalLineHeight;
-                prev = 0;
+                currentX = 0f;
+                textHeight += NGUIText.finalLineHeight;
+                prevCh = 0;
             }
-            else if (num6 < 32)
+            else if (ch < 32)
             {
-                prev = 0;
+                prevCh = 0;
             }
-            else if (NGUIText.encoding && NGUIText.ParseSymbol(text, ref i, ref num5, ref dialogImage))
+            else if (NGUIText.encoding && NGUIText.ParseSymbol(text, ref texti, NGUIText.mTextModifiers))
             {
-                i--;
+                texti--;
             }
             else
             {
-                BMSymbol bmsymbol = (!NGUIText.useSymbols) ? null : NGUIText.GetSymbol(text, i, length);
+                BMSymbol bmsymbol = NGUIText.useSymbols ? NGUIText.GetSymbol(text, texti, textLength) : null;
                 if (bmsymbol == null)
                 {
-                    Single num7 = NGUIText.GetGlyphWidth(num6, prev);
-                    if (num7 != 0f)
+                    Single glyphWidth = NGUIText.GetGlyphWidth(ch, prevCh);
+                    if (glyphWidth != 0f)
                     {
-                        num7 += NGUIText.finalSpacingX;
-                        if (Mathf.RoundToInt(num + num7) > NGUIText.regionWidth)
+                        glyphWidth += NGUIText.finalSpacingX;
+                        if (Mathf.RoundToInt(currentX + glyphWidth) > NGUIText.regionWidth)
                         {
-                            if (num == 0f)
-                            {
+                            if (currentX == 0f)
                                 return;
-                            }
-                            if (NGUIText.alignment != NGUIText.Alignment.Left && size < verts.size)
+                            if (NGUIText.alignment != NGUIText.Alignment.Left && vIndex < verts.size)
                             {
-                                NGUIText.Align(verts, size, num - NGUIText.finalSpacingX, 1);
-                                size = verts.size;
+                                NGUIText.Align(verts, vIndex, currentX - NGUIText.finalSpacingX, 1);
+                                vIndex = verts.size;
                             }
-                            num = num7;
-                            num2 += NGUIText.finalLineHeight;
+                            currentX = glyphWidth;
+                            textHeight += NGUIText.finalLineHeight;
                         }
                         else
                         {
-                            num += num7;
+                            currentX += glyphWidth;
                         }
-                        verts.Add(new Vector3(num, -num2 - num4));
-                        indices.Add(i + 1);
-                        prev = num6;
+                        verts.Add(new Vector3(currentX, -textHeight - halfLineHeight));
+                        indices.Add(texti + 1);
+                        prevCh = ch;
                     }
                 }
                 else
                 {
-                    Single num8 = (Single)bmsymbol.advance * NGUIText.fontScale + NGUIText.finalSpacingX;
-                    if (Mathf.RoundToInt(num + num8) > NGUIText.regionWidth)
+                    Single advanceX = bmsymbol.advance * NGUIText.fontScale + NGUIText.finalSpacingX;
+                    if (Mathf.RoundToInt(currentX + advanceX) > NGUIText.regionWidth)
                     {
-                        if (num == 0f)
-                        {
+                        if (currentX == 0f)
                             return;
-                        }
-                        if (NGUIText.alignment != NGUIText.Alignment.Left && size < verts.size)
+                        if (NGUIText.alignment != NGUIText.Alignment.Left && vIndex < verts.size)
                         {
-                            NGUIText.Align(verts, size, num - NGUIText.finalSpacingX, 1);
-                            size = verts.size;
+                            NGUIText.Align(verts, vIndex, currentX - NGUIText.finalSpacingX, 1);
+                            vIndex = verts.size;
                         }
-                        num = num8;
-                        num2 += NGUIText.finalLineHeight;
+                        currentX = advanceX;
+                        textHeight += NGUIText.finalLineHeight;
                     }
                     else
                     {
-                        num += num8;
+                        currentX += advanceX;
                     }
-                    verts.Add(new Vector3(num, -num2 - num4));
-                    indices.Add(i + 1);
-                    i += bmsymbol.sequence.Length - 1;
-                    prev = 0;
+                    verts.Add(new Vector3(currentX, -textHeight - halfLineHeight));
+                    indices.Add(texti + 1);
+                    texti += bmsymbol.sequence.Length - 1;
+                    prevCh = 0;
                 }
             }
         }
-        if (NGUIText.alignment != NGUIText.Alignment.Left && size < verts.size)
-        {
-            NGUIText.Align(verts, size, num - NGUIText.finalSpacingX, 1);
-        }
+        if (NGUIText.alignment != NGUIText.Alignment.Left && vIndex < verts.size)
+            NGUIText.Align(verts, vIndex, currentX - NGUIText.finalSpacingX, 1);
     }
 
     public static void PrintExactCharacterPositions(String text, BetterList<Vector3> verts, BetterList<Int32> indices)
     {
         if (String.IsNullOrEmpty(text))
-        {
             text = " ";
-        }
         NGUIText.Prepare(text);
-        Single num = (Single)NGUIText.fontSize * NGUIText.fontScale;
-        Single num2 = 0f;
-        Single num3 = 0f;
-        Single num4 = 0f;
-        Int32 length = text.Length;
-        Int32 size = verts.size;
-        Int32 prev = 0;
-        Int32 num5 = 0;
-        Dialog.DialogImage dialogImage = (Dialog.DialogImage)null;
-        for (Int32 i = 0; i < length; i++)
+        Single lineHeight = NGUIText.fontSize * NGUIText.fontScale;
+        Single currentX = 0f;
+        Single textHeight = 0f;
+        Single maxLineWidth = 0f;
+        Int32 textLength = text.Length;
+        Int32 vIndex = verts.size;
+        Int32 prevCh = 0;
+        NGUIText.mTextModifiers.Reset();
+        for (Int32 texti = 0; texti < textLength; texti++)
         {
-            Int32 num6 = (Int32)text[i];
-            if (num6 == 10)
+            Int32 ch = text[texti];
+            if (ch == '\n')
             {
-                if (num2 > num4)
-                {
-                    num4 = num2;
-                }
+                if (currentX > maxLineWidth)
+                    maxLineWidth = currentX;
                 if (NGUIText.alignment != NGUIText.Alignment.Left)
                 {
-                    NGUIText.Align(verts, size, num2 - NGUIText.finalSpacingX, 2);
-                    size = verts.size;
+                    NGUIText.Align(verts, vIndex, currentX - NGUIText.finalSpacingX, 2);
+                    vIndex = verts.size;
                 }
-                num2 = 0f;
-                num3 += NGUIText.finalLineHeight;
-                prev = 0;
+                currentX = 0f;
+                textHeight += NGUIText.finalLineHeight;
+                prevCh = 0;
             }
-            else if (num6 < 32)
+            else if (ch < 32)
             {
-                prev = 0;
+                prevCh = 0;
             }
-            else if (NGUIText.encoding && NGUIText.ParseSymbol(text, ref i, ref num5, ref dialogImage))
+            else if (NGUIText.encoding && NGUIText.ParseSymbol(text, ref texti, NGUIText.mTextModifiers))
             {
-                i--;
+                texti--;
             }
             else
             {
-                BMSymbol bmsymbol = (!NGUIText.useSymbols) ? null : NGUIText.GetSymbol(text, i, length);
+                BMSymbol bmsymbol = NGUIText.useSymbols ? NGUIText.GetSymbol(text, texti, textLength) : null;
                 if (bmsymbol == null)
                 {
-                    Single glyphWidth = NGUIText.GetGlyphWidth(num6, prev);
+                    Single glyphWidth = NGUIText.GetGlyphWidth(ch, prevCh);
                     if (glyphWidth != 0f)
                     {
-                        Single num7 = glyphWidth + NGUIText.finalSpacingX;
-                        if (Mathf.RoundToInt(num2 + num7) > NGUIText.regionWidth)
+                        Single advanceX = glyphWidth + NGUIText.finalSpacingX;
+                        if (Mathf.RoundToInt(currentX + advanceX) > NGUIText.regionWidth)
                         {
-                            if (num2 == 0f)
-                            {
+                            if (currentX == 0f)
                                 return;
-                            }
-                            if (NGUIText.alignment != NGUIText.Alignment.Left && size < verts.size)
+                            if (NGUIText.alignment != NGUIText.Alignment.Left && vIndex < verts.size)
                             {
-                                NGUIText.Align(verts, size, num2 - NGUIText.finalSpacingX, 2);
-                                size = verts.size;
+                                NGUIText.Align(verts, vIndex, currentX - NGUIText.finalSpacingX, 2);
+                                vIndex = verts.size;
                             }
-                            num2 = 0f;
-                            num3 += NGUIText.finalLineHeight;
-                            prev = 0;
-                            i--;
+                            currentX = 0f;
+                            textHeight += NGUIText.finalLineHeight;
+                            prevCh = 0;
+                            texti--;
                         }
                         else
                         {
-                            indices.Add(i);
-                            verts.Add(new Vector3(num2, -num3 - num));
-                            verts.Add(new Vector3(num2 + num7, -num3));
-                            prev = num6;
-                            num2 += num7;
+                            indices.Add(texti);
+                            verts.Add(new Vector3(currentX, -textHeight - lineHeight));
+                            verts.Add(new Vector3(currentX + advanceX, -textHeight));
+                            prevCh = ch;
+                            currentX += advanceX;
                         }
                     }
                 }
                 else
                 {
-                    Single num8 = (Single)bmsymbol.advance * NGUIText.fontScale + NGUIText.finalSpacingX;
-                    if (Mathf.RoundToInt(num2 + num8) > NGUIText.regionWidth)
+                    Single advanceX = bmsymbol.advance * NGUIText.fontScale + NGUIText.finalSpacingX;
+                    if (Mathf.RoundToInt(currentX + advanceX) > NGUIText.regionWidth)
                     {
-                        if (num2 == 0f)
-                        {
+                        if (currentX == 0f)
                             return;
-                        }
-                        if (NGUIText.alignment != NGUIText.Alignment.Left && size < verts.size)
+                        if (NGUIText.alignment != NGUIText.Alignment.Left && vIndex < verts.size)
                         {
-                            NGUIText.Align(verts, size, num2 - NGUIText.finalSpacingX, 2);
-                            size = verts.size;
+                            NGUIText.Align(verts, vIndex, currentX - NGUIText.finalSpacingX, 2);
+                            vIndex = verts.size;
                         }
-                        num2 = 0f;
-                        num3 += NGUIText.finalLineHeight;
-                        prev = 0;
-                        i--;
+                        currentX = 0f;
+                        textHeight += NGUIText.finalLineHeight;
+                        prevCh = 0;
+                        texti--;
                     }
                     else
                     {
-                        indices.Add(i);
-                        verts.Add(new Vector3(num2, -num3 - num));
-                        verts.Add(new Vector3(num2 + num8, -num3));
-                        i += bmsymbol.sequence.Length - 1;
-                        num2 += num8;
-                        prev = 0;
+                        indices.Add(texti);
+                        verts.Add(new Vector3(currentX, -textHeight - lineHeight));
+                        verts.Add(new Vector3(currentX + advanceX, -textHeight));
+                        texti += bmsymbol.sequence.Length - 1;
+                        currentX += advanceX;
+                        prevCh = 0;
                     }
                 }
             }
         }
-        if (NGUIText.alignment != NGUIText.Alignment.Left && size < verts.size)
-        {
-            NGUIText.Align(verts, size, num2 - NGUIText.finalSpacingX, 2);
-        }
+        if (NGUIText.alignment != NGUIText.Alignment.Left && vIndex < verts.size)
+            NGUIText.Align(verts, vIndex, currentX - NGUIText.finalSpacingX, 2);
     }
 
     public static void PrintCaretAndSelection(String text, Int32 start, Int32 end, BetterList<Vector3> caret, BetterList<Vector3> highlight)
     {
         if (String.IsNullOrEmpty(text))
-        {
             text = " ";
-        }
         NGUIText.Prepare(text);
-        Int32 num = end;
+        Int32 caretPos = end;
         if (start > end)
         {
             end = start;
-            start = num;
+            start = caretPos;
         }
-        Single num2 = 0f;
-        Single num3 = 0f;
-        Single num4 = 0f;
-        Single num5 = (Single)NGUIText.fontSize * NGUIText.fontScale;
-        Int32 indexOffset = (Int32)((caret == null) ? 0 : caret.size);
-        Int32 num6 = (Int32)((highlight == null) ? 0 : highlight.size);
-        Int32 length = text.Length;
-        Int32 i = 0;
-        Int32 prev = 0;
-        Boolean flag = false;
-        Boolean flag2 = false;
-        Int32 num7 = 0;
-        Dialog.DialogImage dialogImage = (Dialog.DialogImage)null;
-        Vector2 zero = Vector2.zero;
-        Vector2 zero2 = Vector2.zero;
-        while (i < length)
+        Single currentX = 0f;
+        Single textHeight = 0f;
+        Single maxLineWidth = 0f;
+        Single lineHeight = NGUIText.fontSize * NGUIText.fontScale;
+        Int32 caretStartIndex = caret == null ? 0 : caret.size;
+        Int32 highlightIndex = highlight == null ? 0 : highlight.size;
+        Int32 textLength = text.Length;
+        Int32 prevCh = 0;
+        Boolean highlightStarted = false;
+        Boolean caretInitialized = false;
+        Vector2 charEndPos1 = Vector2.zero;
+        Vector2 charEndPos2 = Vector2.zero;
+        Int32 texti;
+        NGUIText.mTextModifiers.Reset();
+        for (texti = 0; texti < textLength; texti++)
         {
-            if (caret != null && !flag2 && num <= i)
+            if (caret != null && !caretInitialized && caretPos <= texti)
             {
-                flag2 = true;
-                caret.Add(new Vector3(num2 - 1f, -num3 - num5 - 6f));
-                caret.Add(new Vector3(num2 - 1f, -num3 + 6f));
-                caret.Add(new Vector3(num2 + 1f, -num3 + 6f));
-                caret.Add(new Vector3(num2 + 1f, -num3 - num5 - 6f));
+                caretInitialized = true;
+                caret.Add(new Vector3(currentX - 1f, -textHeight - lineHeight - 6f));
+                caret.Add(new Vector3(currentX - 1f, -textHeight + 6f));
+                caret.Add(new Vector3(currentX + 1f, -textHeight + 6f));
+                caret.Add(new Vector3(currentX + 1f, -textHeight - lineHeight - 6f));
             }
-            Int32 num8 = (Int32)text[i];
-            if (num8 == 10)
+            Int32 ch = text[texti];
+            if (ch == '\n')
             {
-                if (num2 > num4)
-                {
-                    num4 = num2;
-                }
-                if (caret != null && flag2)
+                if (currentX > maxLineWidth)
+                    maxLineWidth = currentX;
+                if (caret != null && caretInitialized)
                 {
                     if (NGUIText.alignment != NGUIText.Alignment.Left)
-                    {
-                        NGUIText.Align(caret, indexOffset, num2 - NGUIText.finalSpacingX, 4);
-                    }
+                        NGUIText.Align(caret, caretStartIndex, currentX - NGUIText.finalSpacingX, 4);
                     caret = null;
                 }
                 if (highlight != null)
                 {
-                    if (flag)
+                    if (highlightStarted)
                     {
-                        flag = false;
-                        highlight.Add(zero2);
-                        highlight.Add(zero);
+                        highlightStarted = false;
+                        highlight.Add(charEndPos2);
+                        highlight.Add(charEndPos1);
                     }
-                    else if (start <= i && end > i)
+                    else if (start <= texti && end > texti)
                     {
-                        highlight.Add(new Vector3(num2, -num3 - num5));
-                        highlight.Add(new Vector3(num2, -num3));
-                        highlight.Add(new Vector3(num2 + 2f, -num3));
-                        highlight.Add(new Vector3(num2 + 2f, -num3 - num5));
+                        highlight.Add(new Vector3(currentX, -textHeight - lineHeight));
+                        highlight.Add(new Vector3(currentX, -textHeight));
+                        highlight.Add(new Vector3(currentX + 2f, -textHeight));
+                        highlight.Add(new Vector3(currentX + 2f, -textHeight - lineHeight));
                     }
-                    if (NGUIText.alignment != NGUIText.Alignment.Left && num6 < highlight.size)
+                    if (NGUIText.alignment != NGUIText.Alignment.Left && highlightIndex < highlight.size)
                     {
-                        NGUIText.Align(highlight, num6, num2 - NGUIText.finalSpacingX, 4);
-                        num6 = highlight.size;
+                        NGUIText.Align(highlight, highlightIndex, currentX - NGUIText.finalSpacingX, 4);
+                        highlightIndex = highlight.size;
                     }
                 }
-                num2 = 0f;
-                num3 += NGUIText.finalLineHeight;
-                prev = 0;
+                currentX = 0f;
+                textHeight += NGUIText.finalLineHeight;
+                prevCh = 0;
             }
-            else if (num8 < 32)
+            else if (ch < 32)
             {
-                prev = 0;
+                prevCh = 0;
             }
-            else if (NGUIText.encoding && NGUIText.ParseSymbol(text, ref i, ref num7, ref dialogImage))
+            else if (NGUIText.encoding && NGUIText.ParseSymbol(text, ref texti, NGUIText.mTextModifiers))
             {
-                i--;
+                texti--;
             }
             else
             {
-                BMSymbol bmsymbol = (!NGUIText.useSymbols) ? null : NGUIText.GetSymbol(text, i, length);
-                Single num9 = (bmsymbol == null) ? NGUIText.GetGlyphWidth(num8, prev) : ((Single)bmsymbol.advance * NGUIText.fontScale);
-                if (num9 != 0f)
+                BMSymbol bmsymbol = NGUIText.useSymbols ? NGUIText.GetSymbol(text, texti, textLength) : null;
+                Single glyphWidth = bmsymbol == null ? NGUIText.GetGlyphWidth(ch, prevCh) : bmsymbol.advance * NGUIText.fontScale;
+                if (glyphWidth != 0f)
                 {
-                    Single num10 = num2;
-                    Single num11 = num2 + num9;
-                    Single num12 = -num3 - num5 - 6f;
-                    Single num13 = -num3 + 6f;
-                    if (Mathf.RoundToInt(num11 + NGUIText.finalSpacingX) > NGUIText.regionWidth)
+                    Single charStartX = currentX;
+                    Single charEndX = currentX + glyphWidth;
+                    Single charStartY = -textHeight - lineHeight - 6f;
+                    Single charEndY = -textHeight + 6f;
+                    if (Mathf.RoundToInt(charEndX + NGUIText.finalSpacingX) > NGUIText.regionWidth)
                     {
-                        if (num2 == 0f)
-                        {
+                        if (currentX == 0f)
                             return;
-                        }
-                        if (num2 > num4)
-                        {
-                            num4 = num2;
-                        }
-                        if (caret != null && flag2)
+                        if (currentX > maxLineWidth)
+                            maxLineWidth = currentX;
+                        if (caret != null && caretInitialized)
                         {
                             if (NGUIText.alignment != NGUIText.Alignment.Left)
-                            {
-                                NGUIText.Align(caret, indexOffset, num2 - NGUIText.finalSpacingX, 4);
-                            }
+                                NGUIText.Align(caret, caretStartIndex, currentX - NGUIText.finalSpacingX, 4);
                             caret = null;
                         }
                         if (highlight != null)
                         {
-                            if (flag)
+                            if (highlightStarted)
                             {
-                                flag = false;
-                                highlight.Add(zero2);
-                                highlight.Add(zero);
+                                highlightStarted = false;
+                                highlight.Add(charEndPos2);
+                                highlight.Add(charEndPos1);
                             }
-                            else if (start <= i && end > i)
+                            else if (start <= texti && end > texti)
                             {
-                                highlight.Add(new Vector3(num2, -num3 - num5));
-                                highlight.Add(new Vector3(num2, -num3));
-                                highlight.Add(new Vector3(num2 + 2f, -num3));
-                                highlight.Add(new Vector3(num2 + 2f, -num3 - num5));
+                                highlight.Add(new Vector3(currentX, -textHeight - lineHeight));
+                                highlight.Add(new Vector3(currentX, -textHeight));
+                                highlight.Add(new Vector3(currentX + 2f, -textHeight));
+                                highlight.Add(new Vector3(currentX + 2f, -textHeight - lineHeight));
                             }
-                            if (NGUIText.alignment != NGUIText.Alignment.Left && num6 < highlight.size)
+                            if (NGUIText.alignment != NGUIText.Alignment.Left && highlightIndex < highlight.size)
                             {
-                                NGUIText.Align(highlight, num6, num2 - NGUIText.finalSpacingX, 4);
-                                num6 = highlight.size;
+                                NGUIText.Align(highlight, highlightIndex, currentX - NGUIText.finalSpacingX, 4);
+                                highlightIndex = highlight.size;
                             }
                         }
-                        num10 -= num2;
-                        num11 -= num2;
-                        num12 -= NGUIText.finalLineHeight;
-                        num13 -= NGUIText.finalLineHeight;
-                        num2 = 0f;
-                        num3 += NGUIText.finalLineHeight;
+                        charStartX -= currentX;
+                        charEndX -= currentX;
+                        charStartY -= NGUIText.finalLineHeight;
+                        charEndY -= NGUIText.finalLineHeight;
+                        currentX = 0f;
+                        textHeight += NGUIText.finalLineHeight;
                     }
-                    num2 += num9 + NGUIText.finalSpacingX;
+                    currentX += glyphWidth + NGUIText.finalSpacingX;
                     if (highlight != null)
                     {
-                        if (start > i || end <= i)
+                        if (start > texti || end <= texti)
                         {
-                            if (flag)
+                            if (highlightStarted)
                             {
-                                flag = false;
-                                highlight.Add(zero2);
-                                highlight.Add(zero);
+                                highlightStarted = false;
+                                highlight.Add(charEndPos2);
+                                highlight.Add(charEndPos1);
                             }
                         }
-                        else if (!flag)
+                        else if (!highlightStarted)
                         {
-                            flag = true;
-                            highlight.Add(new Vector3(num10, num12));
-                            highlight.Add(new Vector3(num10, num13));
+                            highlightStarted = true;
+                            highlight.Add(new Vector3(charStartX, charStartY));
+                            highlight.Add(new Vector3(charStartX, charEndY));
                         }
                     }
-                    zero = new Vector2(num11, num12);
-                    zero2 = new Vector2(num11, num13);
-                    prev = num8;
+                    charEndPos1 = new Vector2(charEndX, charStartY);
+                    charEndPos2 = new Vector2(charEndX, charEndY);
+                    prevCh = ch;
                 }
             }
-            i++;
         }
         if (caret != null)
         {
-            if (!flag2)
+            if (!caretInitialized)
             {
-                caret.Add(new Vector3(num2 - 1f, -num3 - num5 - 6f));
-                caret.Add(new Vector3(num2 - 1f, -num3 + 6f));
-                caret.Add(new Vector3(num2 + 1f, -num3 + 6f));
-                caret.Add(new Vector3(num2 + 1f, -num3 - num5 - 6f));
+                caret.Add(new Vector3(currentX - 1f, -textHeight - lineHeight - 6f));
+                caret.Add(new Vector3(currentX - 1f, -textHeight + 6f));
+                caret.Add(new Vector3(currentX + 1f, -textHeight + 6f));
+                caret.Add(new Vector3(currentX + 1f, -textHeight - lineHeight - 6f));
             }
             if (NGUIText.alignment != NGUIText.Alignment.Left)
-            {
-                NGUIText.Align(caret, indexOffset, num2 - NGUIText.finalSpacingX, 4);
-            }
+                NGUIText.Align(caret, caretStartIndex, currentX - NGUIText.finalSpacingX, 4);
         }
         if (highlight != null)
         {
-            if (flag)
+            if (highlightStarted)
             {
-                highlight.Add(zero2);
-                highlight.Add(zero);
+                highlight.Add(charEndPos2);
+                highlight.Add(charEndPos1);
             }
-            else if (start < i && end == i)
+            else if (start < texti && end == texti)
             {
-                highlight.Add(new Vector3(num2, -num3 - num5));
-                highlight.Add(new Vector3(num2, -num3));
-                highlight.Add(new Vector3(num2 + 2f, -num3));
-                highlight.Add(new Vector3(num2 + 2f, -num3 - num5));
+                highlight.Add(new Vector3(currentX, -textHeight - lineHeight));
+                highlight.Add(new Vector3(currentX, -textHeight));
+                highlight.Add(new Vector3(currentX + 2f, -textHeight));
+                highlight.Add(new Vector3(currentX + 2f, -textHeight - lineHeight));
             }
-            if (NGUIText.alignment != NGUIText.Alignment.Left && num6 < highlight.size)
-            {
-                NGUIText.Align(highlight, num6, num2 - NGUIText.finalSpacingX, 4);
-            }
+            if (NGUIText.alignment != NGUIText.Alignment.Left && highlightIndex < highlight.size)
+                NGUIText.Align(highlight, highlightIndex, currentX - NGUIText.finalSpacingX, 4);
         }
+    }
+
+    private static Boolean ShouldUseBIDI(String text)
+    {
+        // Currently, BIDI is used only if the base language is not left-to-right for speed performance
+        return NGUIText.readingDirection != UnicodeBIDI.LanguageReadingDirection.LeftToRight;
     }
 
     [Conditional("NGUI_TEXT_DEBUG")]
@@ -2524,27 +2342,17 @@ public static class NGUIText
     }
 
     public const Int32 FF9TIM_ID_APNUM_0 = 34;
-
     public const Int32 FF9TIM_ID_APNUM_1 = 35;
-
     public const Int32 FF9TIM_ID_APNUM_5 = 39;
-
     public const Int32 FF9TIM_ID_APNUM_SLUSH = 45;
 
     public const Int32 FF9TIM_ID_DMG_MISS = 159;
-
     public const Int32 FF9TIM_ID_DMG_DEATH = 160;
-
     public const Int32 FF9TIM_ID_DMG_GUARD = 161;
-
     public const Int32 FF9TIM_ID_DMG_CRITICAL = 162;
-
     public const Int32 FF9TIM_ID_DMG_MP = 163;
-
     public const Int32 FF9TIM_ID_DMG_9 = 173;
-
     public const Int32 FF9TIM_ID_DMG_SLASH = 174;
-
     public const Int32 FF9TIM_ID_DMG_CRITICAL_YELLOW = 179;
 
     public const String StartSentense = "STRT";
@@ -2601,71 +2409,54 @@ public static class NGUIText
     public const String KeyboardButtonIcon = "KCBT";
     public const String JoyStickButtonIcon = "JCBT";
     public const String NoTurboDialog = "NTUR";
+    public const String IconSprite = "SPRT";
 
-    public static readonly String[] RenderOpcodeSymbols;
+    public static readonly HashSet<String> RenderOpcodeSymbols;
+    public static readonly HashSet<String> TextOffsetOpcodeSymbols;
 
-    public static readonly String[] TextOffsetOpcodeSymbols;
+    public static readonly HashSet<Int32> IconIdException;
+    public static readonly HashSet<Char> CharException;
 
-    public static readonly List<Int32> IconIdException;
-
-    public static readonly List<Char> CharException;
-
-    public static readonly List<String> nameKeywordList;
-
+    public static readonly HashSet<String> nameKeywordList;
     public static readonly Dictionary<String, CharacterId> nameCustomKeywords;
 
     public static readonly String FF9WhiteColor;
-
     public static readonly String FF9YellowColor;
-
     public static readonly String FF9PinkColor;
-
     public static readonly String FF9BlueColor;
 
     public static readonly Int32 MobileTouchToConfirmJP;
-
     public static readonly Int32 MobileTouchToConfirmUS;
-
     private static Boolean forceShowButton;
 
     public static UIFont bitmapFont;
-
     public static Font dynamicFont;
 
     public static NGUIText.GlyphInfo glyph = new NGUIText.GlyphInfo();
 
     public static Int32 fontSize = 16;
-
     public static Single fontScale = 1f;
-
     public static Single pixelDensity = 1f;
 
     public static FontStyle fontStyle = FontStyle.Normal;
-
     public static NGUIText.Alignment alignment = NGUIText.Alignment.Left;
-
     public static Color tint = Color.white;
+    public static UnicodeBIDI.LanguageReadingDirection readingDirection = UnicodeBIDI.LanguageReadingDirection.LeftToRight;
 
-    public static Int32 rectWidth = 1000000;
-
-    public static Int32 rectHeight = 1000000;
-
-    public static Int32 regionWidth = 1000000;
-
-    public static Int32 regionHeight = 1000000;
+    public static Int32 rectWidth = 1000000;    // Text area width (for alignment)
+    public static Int32 rectHeight = 1000000;   // Not useful
+    public static Int32 regionWidth = 1000000;  // Available text width
+    public static Int32 regionHeight = 1000000; // Available text height
 
     public static Int32 maxLines = 0;
 
     public static Boolean gradient = false;
-
     public static Color gradientBottom = Color.white;
-
     public static Color gradientTop = Color.white;
 
     public static Boolean encoding = false;
 
     public static Single spacingX = 0f;
-
     public static Single spacingY = 0f;
 
     public static Boolean premultiply = false;
@@ -2673,18 +2464,14 @@ public static class NGUIText
     public static NGUIText.SymbolStyle symbolStyle;
 
     public static Int32 finalSize = 0;
-
     public static Single finalSpacingX = 0f;
-
     public static Single finalLineHeight = 0f;
-
     public static Single baseline = 0f;
-
     public static Boolean useSymbols = false;
 
     internal static Color mInvisible = new Color(0f, 0f, 0f, 0f);
 
-    private static BetterList<Color> mColors = new BetterList<Color>();
+    private static FFIXTextModifier mTextModifiers = new FFIXTextModifier();
 
     internal static Single mAlpha = 1f;
 
@@ -2693,7 +2480,6 @@ public static class NGUIText
     private static BetterList<Single> mSizes = new BetterList<Single>();
 
     private static Color32 s_c0;
-
     private static Color32 s_c1;
 
     private static Single[] mBoldOffset = new Single[]
@@ -2734,19 +2520,14 @@ public static class NGUIText
     public class GlyphInfo
     {
         public Vector2 v0;
-
         public Vector2 v1;
 
         public Vector2 u0;
-
         public Vector2 u1;
-
         public Vector2 u2;
-
         public Vector2 u3;
 
         public Single advance;
-
         public Int32 channel;
     }
 }

--- a/Assembly-CSharp/Global/SPS/CommonSPSSystem.cs
+++ b/Assembly-CSharp/Global/SPS/CommonSPSSystem.cs
@@ -410,10 +410,11 @@ public class CommonSPSSystem
             Directory.CreateDirectory($"{exportFolder}/Status/{prototype.Comment}");
             for (Int32 i = 0; i < prototype.TextureCount; i++)
             {
-                Texture2D shpTexture = AssetManager.Load<Texture2D>($"{prototype.TextureBasePath}_{i + 1}");
+                String path = prototype.TextureBasePath.Replace("%", (i + 1).ToString());
+                Texture2D shpTexture = AssetManager.Load<Texture2D>(path);
                 if (shpTexture == null)
                     continue;
-                File.WriteAllBytes($"{exportFolder}/Status/{prototype.Comment}/{Path.GetFileName(prototype.TextureBasePath)}_{i + 1}", TextureHelper.CopyAsReadable(shpTexture).EncodeToPNG());
+                File.WriteAllBytes($"{exportFolder}/Status/{prototype.Comment}/{Path.GetFileName(path)}", TextureHelper.CopyAsReadable(shpTexture).EncodeToPNG());
             }
         }
         foreach (SPSPrototype prototype in CommonSPSSystem.SPSPrototypes.Values)

--- a/Assembly-CSharp/Global/SlideshowUI.cs
+++ b/Assembly-CSharp/Global/SlideshowUI.cs
@@ -1,16 +1,15 @@
 ﻿using System;
 using UnityEngine;
+using Memoria.Assets;
 
 public class SlideshowUI : MonoBehaviour
 {
     public void SetupEndingText()
     {
-        String currentLanguage = FF9StateSystem.Settings.CurrentLanguage;
-        GameObject endingText;
-        if (currentLanguage == "English(UK)" || currentLanguage == "English(US)" || currentLanguage == "Japanese" || currentLanguage == "German")
-            endingText = AssetManager.Load<GameObject>("EmbeddedAsset/UI/Atlas/Ending_Text_US_JP_GR_Atlas", false);
-        else
-            endingText = AssetManager.Load<GameObject>("EmbeddedAsset/UI/Atlas/Ending_Text_FR_IT_ES_Atlas", false);
+        String languageSymbol = Localization.GetSymbol().ToLower();
+        if (languageSymbol == "uk")
+            languageSymbol = "us";
+        GameObject endingText = AssetManager.LoadInArchive<GameObject>(languageSymbol == "us" || languageSymbol == "jp" || languageSymbol == "gr" ? ATLAS_PATH_US_JP_GR : ATLAS_PATH_FR_IT_ES, false);
         UIAtlas endingTextAtlas = endingText.GetComponent<UIAtlas>();
         this.text1Sprite.atlas = endingTextAtlas;
         this.text2Sprite.atlas = endingTextAtlas;
@@ -20,14 +19,14 @@ public class SlideshowUI : MonoBehaviour
         this.text6Sprite.atlas = endingTextAtlas;
         this.text7Sprite.atlas = endingTextAtlas;
         this.text8Sprite.atlas = endingTextAtlas;
-        this.text1Sprite.spriteName = "ending_text_01" + this.GetLocalizeNameSubfix(currentLanguage);
-        this.text2Sprite.spriteName = "ending_text_02" + this.GetLocalizeNameSubfix(currentLanguage);
-        this.text3Sprite.spriteName = "ending_text_03" + this.GetLocalizeNameSubfix(currentLanguage);
-        this.text4Sprite.spriteName = "ending_text_04" + this.GetLocalizeNameSubfix(currentLanguage);
-        this.text5Sprite.spriteName = "ending_text_05" + this.GetLocalizeNameSubfix(currentLanguage);
-        this.text6Sprite.spriteName = "ending_text_06" + this.GetLocalizeNameSubfix(currentLanguage);
-        this.text7Sprite.spriteName = "ending_text_07" + this.GetLocalizeNameSubfix(currentLanguage);
-        this.text8Sprite.spriteName = "ending_text_07_bg" + this.GetLocalizeNameSubfix(currentLanguage);
+        this.text1Sprite.spriteName = "ending_text_01_" + languageSymbol;
+        this.text2Sprite.spriteName = "ending_text_02_" + languageSymbol;
+        this.text3Sprite.spriteName = "ending_text_03_" + languageSymbol;
+        this.text4Sprite.spriteName = "ending_text_04_" + languageSymbol;
+        this.text5Sprite.spriteName = "ending_text_05_" + languageSymbol;
+        this.text6Sprite.spriteName = "ending_text_06_" + languageSymbol;
+        this.text7Sprite.spriteName = "ending_text_07_" + languageSymbol;
+        this.text8Sprite.spriteName = "ending_text_07_bg_" + languageSymbol;
         this.text1Sprite.alpha = 0f;
         this.text2Sprite.alpha = 0f;
         this.text3Sprite.alpha = 0f;
@@ -46,38 +45,16 @@ public class SlideshowUI : MonoBehaviour
         this.text8Sprite.GetComponent<HonoFading>().widescreenRescale = false;
     }
 
-    private String GetLocalizeNameSubfix(String language)
-    {
-        String empty = String.Empty;
-        switch (language)
-        {
-            case "English(UK)":
-            case "English(US)":
-                return "_us";
-            case "German":
-                return "_gr";
-            case "Spanish":
-                return "_es";
-            case "French":
-                return "_fr";
-            case "Italian":
-                return "_it";
-            case "Japanese":
-                return "_jp";
-        }
-        return "_us";
-    }
-
     public void PlayEndingText(UIScene.SceneVoidDelegate action = null)
     {
-        this.text1Sprite.GetComponent<HonoFading>().FadePingPong((UIScene.SceneVoidDelegate)null, (UIScene.SceneVoidDelegate)null);
-        this.text2Sprite.GetComponent<HonoFading>().FadePingPong((UIScene.SceneVoidDelegate)null, (UIScene.SceneVoidDelegate)null);
-        this.text3Sprite.GetComponent<HonoFading>().FadePingPong((UIScene.SceneVoidDelegate)null, (UIScene.SceneVoidDelegate)null);
-        this.text4Sprite.GetComponent<HonoFading>().FadePingPong((UIScene.SceneVoidDelegate)null, (UIScene.SceneVoidDelegate)null);
-        this.text5Sprite.GetComponent<HonoFading>().FadePingPong((UIScene.SceneVoidDelegate)null, action);
-        this.text6Sprite.GetComponent<HonoFading>().FadePingPong((UIScene.SceneVoidDelegate)null, (UIScene.SceneVoidDelegate)null);
-        this.text7Sprite.GetComponent<HonoFading>().FadePingPong((UIScene.SceneVoidDelegate)null, (UIScene.SceneVoidDelegate)null);
-        this.text8Sprite.GetComponent<HonoFading>().FadePingPong((UIScene.SceneVoidDelegate)null, (UIScene.SceneVoidDelegate)null);
+        this.text1Sprite.GetComponent<HonoFading>().FadePingPong(null, null);
+        this.text2Sprite.GetComponent<HonoFading>().FadePingPong(null, null);
+        this.text3Sprite.GetComponent<HonoFading>().FadePingPong(null, null);
+        this.text4Sprite.GetComponent<HonoFading>().FadePingPong(null, null);
+        this.text5Sprite.GetComponent<HonoFading>().FadePingPong(null, action);
+        this.text6Sprite.GetComponent<HonoFading>().FadePingPong(null, null);
+        this.text7Sprite.GetComponent<HonoFading>().FadePingPong(null, null);
+        this.text8Sprite.GetComponent<HonoFading>().FadePingPong(null, null);
     }
 
     public void SetupLastEndingText()
@@ -90,25 +67,16 @@ public class SlideshowUI : MonoBehaviour
         this.lastEndingTextContainer.GetComponent<HonoFading>().FadeIn(callback);
     }
 
-    private const String endingTextAtlasName_us_jp_gr = "Ending_Text_US_JP_GR_Atlas";
+    private const String ATLAS_PATH_US_JP_GR = "EmbeddedAsset/UI/Atlas/Ending_Text_US_JP_GR_Atlas";
+    private const String ATLAS_PATH_FR_IT_ES = "EmbeddedAsset/UI/Atlas/Ending_Text_FR_IT_ES_Atlas";
 
-    private const String endingTextAtlasName_fr_it_es = "Ending_Text_FR_IT_ES_Atlas";
-
-    public UISprite text1Sprite;
-
-    public UISprite text2Sprite;
-
-    public UISprite text3Sprite;
-
-    public UISprite text4Sprite;
-
-    public UISprite text5Sprite;
-
-    public UISprite text6Sprite;
-
-    public UISprite text7Sprite;
-
-    public UISprite text8Sprite;
-
+    public UISprite text1Sprite; // "How did you survive...?"
+    public UISprite text2Sprite; // "I didn't have a choice."
+    public UISprite text3Sprite; // "I had to live."
+    public UISprite text4Sprite; // "I wanted to come home to you."
+    public UISprite text5Sprite; // "So..."
+    public UISprite text6Sprite; // "I sang your song."
+    public UISprite text7Sprite; // "Our song"
+    public UISprite text8Sprite; // "Our song" (fading to cinematic's)
     public UIWidget lastEndingTextContainer;
 }

--- a/Assembly-CSharp/Global/TutorialUI.cs
+++ b/Assembly-CSharp/Global/TutorialUI.cs
@@ -317,6 +317,7 @@ public class TutorialUI : UIScene
         this.battleBottomLabel.text = this.libraMessages[0];
         this.battleBottomLabel.fontSize = 42;
         this.battleBottomLabel.overflowMethod = UILabel.Overflow.ResizeFreely;
+        this.battleBottomLabel.PrintIconAfterProcessedText = true;
         this.libraPage = 0;
         base.Loading = true;
         this.AnimatePanel(new Vector3(1f, 1f, 1f));

--- a/Assembly-CSharp/Global/UI/UILabel.cs
+++ b/Assembly-CSharp/Global/UI/UILabel.cs
@@ -1,7 +1,8 @@
-﻿using Memoria.Assets;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Memoria.Assets;
+using Memoria.Prime;
 
 [AddComponentMenu("NGUI/UI/NGUI Label")]
 [ExecuteInEditMode]
@@ -713,112 +714,119 @@ public class UILabel : UIWidget
 
     private void ProcessText(Boolean legacyMode, Boolean full)
     {
-        if (!this.isValid)
-            return;
-        this.mChanged = true;
-        this.shouldBeProcessed = false;
-        Single drawWidth = this.mDrawRegion.z - this.mDrawRegion.x;
-        Single drawHeight = this.mDrawRegion.w - this.mDrawRegion.y;
-        NGUIText.rectWidth = legacyMode ? (this.mMaxLineWidth == 0 ? 1000000 : this.mMaxLineWidth) : base.width;
-        NGUIText.rectHeight = legacyMode ? (this.mMaxLineHeight == 0 ? 1000000 : this.mMaxLineHeight) : base.height;
-        NGUIText.regionWidth = drawWidth == 1f ? NGUIText.rectWidth : Mathf.RoundToInt(NGUIText.rectWidth * drawWidth);
-        NGUIText.regionHeight = drawHeight == 1f ? NGUIText.rectHeight : Mathf.RoundToInt(NGUIText.rectHeight * drawHeight);
-        this.mFinalFontSize = Mathf.Abs(legacyMode ? Mathf.RoundToInt(base.cachedTransform.localScale.x) : this.defaultFontSize);
-        this.mScale = 1f;
-        if (NGUIText.regionWidth < 1 || NGUIText.regionHeight < 0)
+        try
         {
-            this.mProcessedText = String.Empty;
-            return;
-        }
-        Boolean hasTrueTypeFont = this.trueTypeFont != null;
-        if (hasTrueTypeFont && this.keepCrisp)
-        {
-            UIRoot root = base.root;
-            if (root != null)
-                this.mDensity = root == null ? 1f : root.pixelSizeAdjustment;
-        }
-        else
-        {
-            this.mDensity = 1f;
-        }
-        if (full)
-            this.UpdateNGUIText();
-        if (this.mOverflow == UILabel.Overflow.ResizeFreely)
-        {
-            NGUIText.rectWidth = 1000000;
-            NGUIText.regionWidth = 1000000;
-        }
-        if (this.mOverflow == UILabel.Overflow.ResizeFreely || this.mOverflow == UILabel.Overflow.ResizeHeight)
-        {
-            NGUIText.rectHeight = 1000000;
-            NGUIText.regionHeight = 1000000;
-        }
-        if (this.mFinalFontSize > 0)
-        {
-            Boolean keepCrisp = this.keepCrisp;
-            for (Int32 shrinkedFontSize = this.mFinalFontSize; shrinkedFontSize > 2; shrinkedFontSize -= 2)
+            if (!this.isValid)
+                return;
+            this.mChanged = true;
+            this.shouldBeProcessed = false;
+            Single drawWidth = this.mDrawRegion.z - this.mDrawRegion.x;
+            Single drawHeight = this.mDrawRegion.w - this.mDrawRegion.y;
+            NGUIText.rectWidth = legacyMode ? (this.mMaxLineWidth == 0 ? 1000000 : this.mMaxLineWidth) : base.width;
+            NGUIText.rectHeight = legacyMode ? (this.mMaxLineHeight == 0 ? 1000000 : this.mMaxLineHeight) : base.height;
+            NGUIText.regionWidth = drawWidth == 1f ? NGUIText.rectWidth : Mathf.RoundToInt(NGUIText.rectWidth * drawWidth);
+            NGUIText.regionHeight = drawHeight == 1f ? NGUIText.rectHeight : Mathf.RoundToInt(NGUIText.rectHeight * drawHeight);
+            this.mFinalFontSize = Mathf.Abs(legacyMode ? Mathf.RoundToInt(base.cachedTransform.localScale.x) : this.defaultFontSize);
+            this.mScale = 1f;
+            if (NGUIText.regionWidth < 1 || NGUIText.regionHeight < 0)
             {
-                if (keepCrisp)
+                this.mProcessedText = String.Empty;
+                return;
+            }
+            Boolean hasTrueTypeFont = this.trueTypeFont != null;
+            if (hasTrueTypeFont && this.keepCrisp)
+            {
+                UIRoot root = base.root;
+                if (root != null)
+                    this.mDensity = root == null ? 1f : root.pixelSizeAdjustment;
+            }
+            else
+            {
+                this.mDensity = 1f;
+            }
+            if (full)
+                this.UpdateNGUIText();
+            if (this.mOverflow == UILabel.Overflow.ResizeFreely)
+            {
+                NGUIText.rectWidth = 1000000;
+                NGUIText.regionWidth = 1000000;
+            }
+            if (this.mOverflow == UILabel.Overflow.ResizeFreely || this.mOverflow == UILabel.Overflow.ResizeHeight)
+            {
+                NGUIText.rectHeight = 1000000;
+                NGUIText.regionHeight = 1000000;
+            }
+            if (this.mFinalFontSize > 0)
+            {
+                Boolean keepCrisp = this.keepCrisp;
+                for (Int32 shrinkedFontSize = this.mFinalFontSize; shrinkedFontSize > 2; shrinkedFontSize -= 2)
                 {
-                    this.mFinalFontSize = shrinkedFontSize;
-                    NGUIText.fontSize = this.mFinalFontSize;
-                }
-                else
-                {
-                    this.mScale = (Single)shrinkedFontSize / this.mFinalFontSize;
-                    NGUIText.fontScale = hasTrueTypeFont ? this.mScale : this.mScale * this.mFontSize / this.mFont.defaultSize;
-                }
-                NGUIText.Update(false);
-                Boolean properWrapping = NGUIText.WrapText(this.mText, out this.mProcessedText, true, false);
-                if (this.mOverflow != UILabel.Overflow.ShrinkContent || properWrapping)
-                {
-                    if (this.mOverflow == UILabel.Overflow.ResizeFreely)
+                    if (keepCrisp)
                     {
-                        this.mCalculatedSize = NGUIText.CalculatePrintedSize(this.mProcessedText);
-                        this.mWidth = Mathf.Max(this.minWidth, Mathf.RoundToInt(this.mCalculatedSize.x));
-                        if (drawWidth != 1f)
-                            this.mWidth = Mathf.RoundToInt(this.mWidth / drawWidth);
-                        this.mHeight = Mathf.Max(this.minHeight, Mathf.RoundToInt(this.mCalculatedSize.y));
-                        if (drawHeight != 1f)
-                            this.mHeight = Mathf.RoundToInt(this.mHeight / drawHeight);
-                        if ((this.mWidth & 1) == 1)
-                            this.mWidth++;
-                        if ((this.mHeight & 1) == 1)
-                            this.mHeight++;
-                    }
-                    else if (this.mOverflow == UILabel.Overflow.ResizeHeight)
-                    {
-                        this.mCalculatedSize = NGUIText.CalculatePrintedSize(this.mProcessedText);
-                        this.mHeight = Mathf.Max(this.minHeight, Mathf.RoundToInt(this.mCalculatedSize.y));
-                        if (drawHeight != 1f)
-                            this.mHeight = Mathf.RoundToInt(this.mHeight / drawHeight);
-                        if ((this.mHeight & 1) == 1)
-                            this.mHeight++;
+                        this.mFinalFontSize = shrinkedFontSize;
+                        NGUIText.fontSize = this.mFinalFontSize;
                     }
                     else
                     {
-                        this.mCalculatedSize = NGUIText.CalculatePrintedSize(this.mProcessedText);
+                        this.mScale = (Single)shrinkedFontSize / this.mFinalFontSize;
+                        NGUIText.fontScale = hasTrueTypeFont ? this.mScale : this.mScale * this.mFontSize / this.mFont.defaultSize;
                     }
-                    if (legacyMode)
+                    NGUIText.Update(false);
+                    Boolean properWrapping = NGUIText.WrapText(this.mText, out this.mProcessedText, true, false);
+                    if (this.mOverflow != UILabel.Overflow.ShrinkContent || properWrapping)
                     {
-                        base.width = Mathf.RoundToInt(this.mCalculatedSize.x);
-                        base.height = Mathf.RoundToInt(this.mCalculatedSize.y);
-                        base.cachedTransform.localScale = Vector3.one;
+                        if (this.mOverflow == UILabel.Overflow.ResizeFreely)
+                        {
+                            this.mCalculatedSize = NGUIText.CalculatePrintedSize(this.mProcessedText);
+                            this.mWidth = Mathf.Max(this.minWidth, Mathf.RoundToInt(this.mCalculatedSize.x));
+                            if (drawWidth != 1f)
+                                this.mWidth = Mathf.RoundToInt(this.mWidth / drawWidth);
+                            this.mHeight = Mathf.Max(this.minHeight, Mathf.RoundToInt(this.mCalculatedSize.y));
+                            if (drawHeight != 1f)
+                                this.mHeight = Mathf.RoundToInt(this.mHeight / drawHeight);
+                            if ((this.mWidth & 1) == 1)
+                                this.mWidth++;
+                            if ((this.mHeight & 1) == 1)
+                                this.mHeight++;
+                        }
+                        else if (this.mOverflow == UILabel.Overflow.ResizeHeight)
+                        {
+                            this.mCalculatedSize = NGUIText.CalculatePrintedSize(this.mProcessedText);
+                            this.mHeight = Mathf.Max(this.minHeight, Mathf.RoundToInt(this.mCalculatedSize.y));
+                            if (drawHeight != 1f)
+                                this.mHeight = Mathf.RoundToInt(this.mHeight / drawHeight);
+                            if ((this.mHeight & 1) == 1)
+                                this.mHeight++;
+                        }
+                        else
+                        {
+                            this.mCalculatedSize = NGUIText.CalculatePrintedSize(this.mProcessedText);
+                        }
+                        if (legacyMode)
+                        {
+                            base.width = Mathf.RoundToInt(this.mCalculatedSize.x);
+                            base.height = Mathf.RoundToInt(this.mCalculatedSize.y);
+                            base.cachedTransform.localScale = Vector3.one;
+                        }
+                        break;
                     }
-                    break;
                 }
             }
+            else
+            {
+                base.cachedTransform.localScale = Vector3.one;
+                this.mProcessedText = String.Empty;
+                this.mScale = 1f;
+            }
+            if (full)
+            {
+                NGUIText.bitmapFont = null;
+                NGUIText.dynamicFont = null;
+            }
         }
-        else
+        catch (Exception err)
         {
-            base.cachedTransform.localScale = Vector3.one;
-            this.mProcessedText = String.Empty;
-            this.mScale = 1f;
-        }
-        if (full)
-        {
-            NGUIText.bitmapFont = null;
-            NGUIText.dynamicFont = null;
+            Log.Error(err);
         }
     }
 
@@ -1148,7 +1156,10 @@ public class UILabel : UIWidget
             if (this.printIconAfterProcessedText)
                 this.PrintIcon(this.imageList);
         }
-        catch (Exception err) { Memoria.Prime.Log.Error(err); }
+        catch (Exception err)
+        {
+            Log.Error(err);
+        }
     }
 
     public Vector2 ApplyOffset(BetterList<Vector3> verts, Int32 start)

--- a/Assembly-CSharp/Global/UI/UILabel.cs
+++ b/Assembly-CSharp/Global/UI/UILabel.cs
@@ -1,9 +1,7 @@
-﻿using Assets.Sources.Scripts.UI.Common;
-using Memoria.Assets;
+﻿using Memoria.Assets;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
-using Object = System.Object;
 
 [AddComponentMenu("NGUI/UI/NGUI Label")]
 [ExecuteInEditMode]
@@ -15,42 +13,22 @@ public class UILabel : UIWidget
         this.vertsLineOffsets = new BetterList<Int32>();
     }
 
-    public BetterList<Dialog.DialogImage> ImageList
-    {
-        get
-        {
-            return this.imageList;
-        }
-    }
+    public BetterList<Dialog.DialogImage> ImageList => this.imageList;
 
     public Boolean PrintIconAfterProcessedText
     {
-        get
-        {
-            return this.printIconAfterProcessedText;
-        }
-        set
-        {
-            this.printIconAfterProcessedText = value;
-        }
+        get => this.printIconAfterProcessedText;
+        set => this.printIconAfterProcessedText = value;
     }
 
-    public BetterList<Int32> VertsLineOffsets
-    {
-        get
-        {
-            return this.vertsLineOffsets;
-        }
-    }
+    public BetterList<Int32> VertsLineOffsets => this.vertsLineOffsets;
 
     public void ApplyHighShadow(BetterList<Vector3> verts, BetterList<Int32> shadowVertIndexes, Single x, Single y)
     {
-        foreach (Int32 num in shadowVertIndexes)
+        foreach (Int32 index in shadowVertIndexes)
         {
-            Vector3 vector = verts.buffer[num];
-            vector.x += x;
-            vector.y += y;
-            verts.buffer[num] = vector;
+            verts.buffer[index].x += x;
+            verts.buffer[index].y += y;
         }
     }
 
@@ -71,9 +49,7 @@ public class UILabel : UIWidget
     {
         Int32 childCount = base.transform.childCount;
         for (Int32 i = 0; i < childCount; i++)
-        {
             Singleton<BitmapIconManager>.Instance.RemoveBitmapIcon(base.transform.GetChild(0).gameObject);
-        }
     }
 
     public String PhrasePreOpcodeSymbol(String text, ref Single additionalWidth)
@@ -85,31 +61,16 @@ public class UILabel : UIWidget
     {
         foreach (Dialog.DialogImage dialogImage in imageList)
         {
-            Dialog.DialogImage dialogImage2 = dialogImage;
-            dialogImage2.LocalPosition.x = dialogImage2.LocalPosition.x + offset.x;
-            Dialog.DialogImage dialogImage3 = dialogImage;
-            dialogImage3.LocalPosition.y = dialogImage3.LocalPosition.y + offset.y;
+            dialogImage.LocalPosition.x += offset.x;
+            dialogImage.LocalPosition.y += offset.y;
         }
     }
 
-    public Int32 finalFontSize
-    {
-        get
-        {
-            if (this.trueTypeFont)
-            {
-                return Mathf.RoundToInt(this.mScale * (Single)this.mFinalFontSize);
-            }
-            return Mathf.RoundToInt((Single)this.mFinalFontSize * this.mScale);
-        }
-    }
+    public Int32 finalFontSize => Mathf.RoundToInt(this.mScale * this.mFinalFontSize);
 
     private Boolean shouldBeProcessed
     {
-        get
-        {
-            return this.mShouldBeProcessed;
-        }
+        get => this.mShouldBeProcessed;
         set
         {
             if (value)
@@ -124,39 +85,20 @@ public class UILabel : UIWidget
         }
     }
 
-    public override Boolean isAnchoredHorizontally
-    {
-        get
-        {
-            return base.isAnchoredHorizontally || this.mOverflow == UILabel.Overflow.ResizeFreely;
-        }
-    }
-
-    public override Boolean isAnchoredVertically
-    {
-        get
-        {
-            return base.isAnchoredVertically || this.mOverflow == UILabel.Overflow.ResizeFreely || this.mOverflow == UILabel.Overflow.ResizeHeight;
-        }
-    }
+    public override Boolean isAnchoredHorizontally => base.isAnchoredHorizontally || this.mOverflow == UILabel.Overflow.ResizeFreely;
+    public override Boolean isAnchoredVertically => base.isAnchoredVertically || this.mOverflow == UILabel.Overflow.ResizeFreely || this.mOverflow == UILabel.Overflow.ResizeHeight;
 
     public override Material material
     {
         get
         {
-            if (this.mMaterial != (UnityEngine.Object)null)
-            {
+            if (this.mMaterial != null)
                 return this.mMaterial;
-            }
-            if (this.mFont != (UnityEngine.Object)null)
-            {
+            if (this.mFont != null)
                 return this.mFont.material;
-            }
-            if (this.mTrueTypeFont != (UnityEngine.Object)null)
-            {
+            if (this.mTrueTypeFont != null)
                 return this.mTrueTypeFont.material;
-            }
-            return (Material)null;
+            return null;
         }
         set
         {
@@ -172,29 +114,20 @@ public class UILabel : UIWidget
     [Obsolete("Use UILabel.bitmapFont instead")]
     public UIFont font
     {
-        get
-        {
-            return this.bitmapFont;
-        }
-        set
-        {
-            this.bitmapFont = value;
-        }
+        get => this.bitmapFont;
+        set => this.bitmapFont = value;
     }
 
     public UIFont bitmapFont
     {
-        get
-        {
-            return this.mFont;
-        }
+        get => this.mFont;
         set
         {
             if (this.mFont != value)
             {
                 base.RemoveFromPanel();
                 this.mFont = value;
-                this.mTrueTypeFont = (Font)null;
+                this.mTrueTypeFont = null;
                 this.MarkAsChanged();
             }
         }
@@ -204,67 +137,49 @@ public class UILabel : UIWidget
     {
         get
         {
-            if (this.mTrueTypeFont != (UnityEngine.Object)null)
-            {
+            if (this.mTrueTypeFont != null)
                 return this.mTrueTypeFont;
-            }
-            if (this.mFont != (UnityEngine.Object)null)
-            {
+            if (this.mFont != null)
                 return this.mFont.dynamicFont;
-            }
             return EncryptFontManager.SetDefaultFont();
         }
         set
         {
             if (this.mTrueTypeFont != value)
             {
-                this.SetActiveFont((Font)null);
+                this.SetActiveFont(null);
                 base.RemoveFromPanel();
                 this.mTrueTypeFont = value;
                 this.shouldBeProcessed = true;
-                this.mFont = (UIFont)null;
+                this.mFont = null;
                 this.SetActiveFont(value);
                 this.ProcessAndRequest();
-                if (this.mActiveTTF != (UnityEngine.Object)null)
-                {
+                if (this.mActiveTTF != null)
                     base.MarkAsChanged();
-                }
             }
         }
     }
 
     public UnityEngine.Object ambigiousFont
     {
-        get
-        {
-            return (UnityEngine.Object)this.mFont ?? (UnityEngine.Object)this.mTrueTypeFont;
-        }
+        get => (UnityEngine.Object)this.mFont ?? this.mTrueTypeFont;
         set
         {
             UIFont uifont = value as UIFont;
-            if (uifont != (UnityEngine.Object)null)
-            {
+            if (uifont != null)
                 this.bitmapFont = uifont;
-            }
             else
-            {
-                this.trueTypeFont = (value as Font);
-            }
+                this.trueTypeFont = value as Font;
         }
     }
 
     public String text
     {
-        get
-        {
-            return this.mText;
-        }
+        get => this.mText;
         set
         {
             if (this.mText == value)
-            {
                 return;
-            }
             if (String.IsNullOrEmpty(value))
             {
                 if (!String.IsNullOrEmpty(this.mText))
@@ -281,26 +196,15 @@ public class UILabel : UIWidget
                 this.ProcessAndRequest();
             }
             if (this.autoResizeBoxCollider)
-            {
                 base.ResizeCollider();
-            }
         }
     }
 
-    public Int32 defaultFontSize
-    {
-        get
-        {
-            return (Int32)((!(this.trueTypeFont != (UnityEngine.Object)null)) ? ((Int32)((!(this.mFont != (UnityEngine.Object)null)) ? 16 : this.mFont.defaultSize)) : this.mFontSize);
-        }
-    }
+    public Int32 defaultFontSize => this.trueTypeFont == null ? (this.mFont == null ? 16 : this.mFont.defaultSize) : this.mFontSize;
 
     public Int32 fontSize
     {
-        get
-        {
-            return this.mFontSize;
-        }
+        get => this.mFontSize;
         set
         {
             value = Mathf.Clamp(value, 0, 256);
@@ -315,10 +219,7 @@ public class UILabel : UIWidget
 
     public FontStyle fontStyle
     {
-        get
-        {
-            return this.mFontStyle;
-        }
+        get => this.mFontStyle;
         set
         {
             if (this.mFontStyle != value)
@@ -332,10 +233,7 @@ public class UILabel : UIWidget
 
     public NGUIText.Alignment alignment
     {
-        get
-        {
-            return this.mAlignment;
-        }
+        get => this.mAlignment;
         set
         {
             if (this.mAlignment != value)
@@ -349,10 +247,7 @@ public class UILabel : UIWidget
 
     public Boolean applyGradient
     {
-        get
-        {
-            return this.mApplyGradient;
-        }
+        get => this.mApplyGradient;
         set
         {
             if (this.mApplyGradient != value)
@@ -365,48 +260,35 @@ public class UILabel : UIWidget
 
     public Color gradientTop
     {
-        get
-        {
-            return this.mGradientTop;
-        }
+        get => this.mGradientTop;
         set
         {
             if (this.mGradientTop != value)
             {
                 this.mGradientTop = value;
                 if (this.mApplyGradient)
-                {
                     this.MarkAsChanged();
-                }
             }
         }
     }
 
     public Color gradientBottom
     {
-        get
-        {
-            return this.mGradientBottom;
-        }
+        get => this.mGradientBottom;
         set
         {
             if (this.mGradientBottom != value)
             {
                 this.mGradientBottom = value;
                 if (this.mApplyGradient)
-                {
                     this.MarkAsChanged();
-                }
             }
         }
     }
 
     public Int32 spacingX
     {
-        get
-        {
-            return this.mSpacingX;
-        }
+        get => this.mSpacingX;
         set
         {
             if (this.mSpacingX != value)
@@ -419,10 +301,7 @@ public class UILabel : UIWidget
 
     public Int32 spacingY
     {
-        get
-        {
-            return this.mSpacingY;
-        }
+        get => this.mSpacingY;
         set
         {
             if (this.mSpacingY != value)
@@ -435,10 +314,7 @@ public class UILabel : UIWidget
 
     public Boolean useFloatSpacing
     {
-        get
-        {
-            return this.mUseFloatSpacing;
-        }
+        get => this.mUseFloatSpacing;
         set
         {
             if (this.mUseFloatSpacing != value)
@@ -451,10 +327,7 @@ public class UILabel : UIWidget
 
     public Single floatSpacingX
     {
-        get
-        {
-            return this.mFloatSpacingX;
-        }
+        get => this.mFloatSpacingX;
         set
         {
             if (!Mathf.Approximately(this.mFloatSpacingX, value))
@@ -467,10 +340,7 @@ public class UILabel : UIWidget
 
     public Single floatSpacingY
     {
-        get
-        {
-            return this.mFloatSpacingY;
-        }
+        get => this.mFloatSpacingY;
         set
         {
             if (!Mathf.Approximately(this.mFloatSpacingY, value))
@@ -481,36 +351,14 @@ public class UILabel : UIWidget
         }
     }
 
-    public Single effectiveSpacingY
-    {
-        get
-        {
-            return (!this.mUseFloatSpacing) ? ((Single)this.mSpacingY) : this.mFloatSpacingY;
-        }
-    }
+    public Single effectiveSpacingY => this.mUseFloatSpacing ? this.mFloatSpacingY : this.mSpacingY;
+    public Single effectiveSpacingX => this.mUseFloatSpacing ? this.mFloatSpacingX : this.mSpacingX;
 
-    public Single effectiveSpacingX
-    {
-        get
-        {
-            return (!this.mUseFloatSpacing) ? ((Single)this.mSpacingX) : this.mFloatSpacingX;
-        }
-    }
-
-    private Boolean keepCrisp
-    {
-        get
-        {
-            return this.trueTypeFont != (UnityEngine.Object)null && this.keepCrispWhenShrunk != UILabel.Crispness.Never;
-        }
-    }
+    private Boolean keepCrisp => this.trueTypeFont != null && this.keepCrispWhenShrunk != UILabel.Crispness.Never;
 
     public Boolean supportEncoding
     {
-        get
-        {
-            return this.mEncoding;
-        }
+        get => this.mEncoding;
         set
         {
             if (this.mEncoding != value)
@@ -523,10 +371,7 @@ public class UILabel : UIWidget
 
     public NGUIText.SymbolStyle symbolStyle
     {
-        get
-        {
-            return this.mSymbols;
-        }
+        get => this.mSymbols;
         set
         {
             if (this.mSymbols != value)
@@ -539,10 +384,7 @@ public class UILabel : UIWidget
 
     public UILabel.Overflow overflowMethod
     {
-        get
-        {
-            return this.mOverflow;
-        }
+        get => this.mOverflow;
         set
         {
             if (this.mOverflow != value)
@@ -556,40 +398,25 @@ public class UILabel : UIWidget
     [Obsolete("Use 'width' instead")]
     public Int32 lineWidth
     {
-        get
-        {
-            return base.width;
-        }
-        set
-        {
-            base.width = value;
-        }
+        get => base.width;
+        set => base.width = value;
     }
 
     [Obsolete("Use 'height' instead")]
     public Int32 lineHeight
     {
-        get
-        {
-            return base.height;
-        }
-        set
-        {
-            base.height = value;
-        }
+        get => base.height;
+        set => base.height = value;
     }
 
     public Boolean multiLine
     {
-        get
-        {
-            return this.mMaxLineCount != 1;
-        }
+        get => this.mMaxLineCount != 1;
         set
         {
             if (this.mMaxLineCount != 1 != value)
             {
-                this.mMaxLineCount = (Int32)((!value) ? 1 : 0);
+                this.mMaxLineCount = value ? 0 : 1;
                 this.shouldBeProcessed = true;
             }
         }
@@ -600,9 +427,7 @@ public class UILabel : UIWidget
         get
         {
             if (this.shouldBeProcessed)
-            {
                 this.ProcessText();
-            }
             return base.localCorners;
         }
     }
@@ -612,9 +437,7 @@ public class UILabel : UIWidget
         get
         {
             if (this.shouldBeProcessed)
-            {
                 this.ProcessText();
-            }
             return base.worldCorners;
         }
     }
@@ -624,19 +447,14 @@ public class UILabel : UIWidget
         get
         {
             if (this.shouldBeProcessed)
-            {
                 this.ProcessText();
-            }
             return base.drawingDimensions;
         }
     }
 
     public Int32 maxLineCount
     {
-        get
-        {
-            return this.mMaxLineCount;
-        }
+        get => this.mMaxLineCount;
         set
         {
             if (this.mMaxLineCount != value)
@@ -644,19 +462,14 @@ public class UILabel : UIWidget
                 this.mMaxLineCount = Mathf.Max(value, 0);
                 this.shouldBeProcessed = true;
                 if (this.overflowMethod == UILabel.Overflow.ShrinkContent)
-                {
                     this.MakePixelPerfect();
-                }
             }
         }
     }
 
     public UILabel.Effect effectStyle
     {
-        get
-        {
-            return this.mEffectStyle;
-        }
+        get => this.mEffectStyle;
         set
         {
             if (this.mEffectStyle != value)
@@ -669,29 +482,21 @@ public class UILabel : UIWidget
 
     public Color effectColor
     {
-        get
-        {
-            return this.mEffectColor;
-        }
+        get => this.mEffectColor;
         set
         {
             if (this.mEffectColor != value)
             {
                 this.mEffectColor = value;
                 if (this.mEffectStyle != UILabel.Effect.None)
-                {
                     this.shouldBeProcessed = true;
-                }
             }
         }
     }
 
     public Vector2 effectDistance
     {
-        get
-        {
-            return this.mEffectDistance;
-        }
+        get => this.mEffectDistance;
         set
         {
             if (this.mEffectDistance != value)
@@ -705,16 +510,11 @@ public class UILabel : UIWidget
     [Obsolete("Use 'overflowMethod == UILabel.Overflow.ShrinkContent' instead")]
     public Boolean shrinkToFit
     {
-        get
-        {
-            return this.mOverflow == UILabel.Overflow.ShrinkContent;
-        }
+        get => this.mOverflow == UILabel.Overflow.ShrinkContent;
         set
         {
             if (value)
-            {
                 this.overflowMethod = UILabel.Overflow.ShrinkContent;
-            }
         }
     }
 
@@ -729,9 +529,7 @@ public class UILabel : UIWidget
                 this.mShouldBeProcessed = true;
             }
             if (this.shouldBeProcessed)
-            {
                 this.ProcessText();
-            }
             return this.mProcessedText;
         }
     }
@@ -741,9 +539,7 @@ public class UILabel : UIWidget
         get
         {
             if (this.shouldBeProcessed)
-            {
                 this.ProcessText();
-            }
             return this.mCalculatedSize;
         }
     }
@@ -753,20 +549,12 @@ public class UILabel : UIWidget
         get
         {
             if (this.shouldBeProcessed)
-            {
                 this.ProcessText();
-            }
             return base.localSize;
         }
     }
 
-    private Boolean isValid
-    {
-        get
-        {
-            return this.mFont != (UnityEngine.Object)null || this.mTrueTypeFont != (UnityEngine.Object)null;
-        }
-    }
+    private Boolean isValid => this.mFont != null || this.mTrueTypeFont != null;
 
     protected override void OnInit()
     {
@@ -777,7 +565,7 @@ public class UILabel : UIWidget
 
     protected override void OnDisable()
     {
-        this.SetActiveFont((Font)null);
+        this.SetActiveFont(null);
         UILabel.mList.Remove(this);
         base.OnDisable();
     }
@@ -786,52 +574,40 @@ public class UILabel : UIWidget
     {
         if (this.mActiveTTF != fnt)
         {
-            Int32 num;
-            if (this.mActiveTTF != (UnityEngine.Object)null && UILabel.mFontUsage.TryGetValue(this.mActiveTTF, out num))
+            if (this.mActiveTTF != null && UILabel.mFontUsage.TryGetValue(this.mActiveTTF, out Int32 fontUsageCount))
             {
-                num = Mathf.Max(0, --num);
-                if (num == 0)
-                {
+                fontUsageCount = Mathf.Max(0, fontUsageCount - 1);
+                if (fontUsageCount == 0)
                     UILabel.mFontUsage.Remove(this.mActiveTTF);
-                }
                 else
-                {
-                    UILabel.mFontUsage[this.mActiveTTF] = num;
-                }
+                    UILabel.mFontUsage[this.mActiveTTF] = fontUsageCount;
             }
             this.mActiveTTF = fnt;
-            if (this.mActiveTTF != (UnityEngine.Object)null)
-            {
-                Int32 num2 = 0;
-                UILabel.mFontUsage[this.mActiveTTF] = num2 + 1;
-            }
+            if (this.mActiveTTF != null)
+                UILabel.mFontUsage[this.mActiveTTF] = 1;
         }
     }
 
     private static void OnFontChanged(Font font)
     {
-        for (Int32 i = 0; i < UILabel.mList.size; i++)
+        foreach (UILabel uilabel in UILabel.mList)
         {
-            UILabel uilabel = UILabel.mList[i];
-            if (uilabel != (UnityEngine.Object)null)
+            if (uilabel != null)
+            {
+                Font trueTypeFont = uilabel.trueTypeFont;
+                if (trueTypeFont == font)
+                    trueTypeFont.RequestCharactersInTexture(uilabel.mText, uilabel.mFinalFontSize, uilabel.mFontStyle);
+            }
+        }
+        foreach (UILabel uilabel in UILabel.mList)
+        {
+            if (uilabel != null)
             {
                 Font trueTypeFont = uilabel.trueTypeFont;
                 if (trueTypeFont == font)
                 {
-                    trueTypeFont.RequestCharactersInTexture(uilabel.mText, uilabel.mFinalFontSize, uilabel.mFontStyle);
-                }
-            }
-        }
-        for (Int32 j = 0; j < UILabel.mList.size; j++)
-        {
-            UILabel uilabel2 = UILabel.mList[j];
-            if (uilabel2 != (UnityEngine.Object)null)
-            {
-                Font trueTypeFont2 = uilabel2.trueTypeFont;
-                if (trueTypeFont2 == font)
-                {
-                    uilabel2.RemoveFromPanel();
-                    uilabel2.CreatePanel();
+                    uilabel.RemoveFromPanel();
+                    uilabel.CreatePanel();
                 }
             }
         }
@@ -840,9 +616,7 @@ public class UILabel : UIWidget
     public override Vector3[] GetSides(Transform relativeTo)
     {
         if (this.shouldBeProcessed)
-        {
             this.ProcessText();
-        }
         return base.GetSides(relativeTo);
     }
 
@@ -857,23 +631,19 @@ public class UILabel : UIWidget
         if (this.mMaxLineWidth != 0)
         {
             base.width = this.mMaxLineWidth;
-            this.overflowMethod = (UILabel.Overflow)((this.mMaxLineCount <= 0) ? UILabel.Overflow.ShrinkContent : UILabel.Overflow.ResizeHeight);
+            this.overflowMethod = this.mMaxLineCount <= 0 ? UILabel.Overflow.ShrinkContent : UILabel.Overflow.ResizeHeight;
         }
         else
         {
             this.overflowMethod = UILabel.Overflow.ResizeFreely;
         }
         if (this.mMaxLineHeight != 0)
-        {
             base.height = this.mMaxLineHeight;
-        }
-        if (this.mFont != (UnityEngine.Object)null)
+        if (this.mFont != null)
         {
             Int32 defaultSize = this.mFont.defaultSize;
             if (base.height < defaultSize)
-            {
                 base.height = defaultSize;
-            }
             this.fontSize = defaultSize;
         }
         this.mMaxLineWidth = 0;
@@ -887,11 +657,9 @@ public class UILabel : UIWidget
         if (this.mOverflow == UILabel.Overflow.ResizeFreely)
         {
             if (base.isFullyAnchored)
-            {
                 this.mOverflow = UILabel.Overflow.ShrinkContent;
-            }
         }
-        else if (this.mOverflow == UILabel.Overflow.ResizeHeight && this.topAnchor.target != (UnityEngine.Object)null && this.bottomAnchor.target != (UnityEngine.Object)null)
+        else if (this.mOverflow == UILabel.Overflow.ResizeHeight && this.topAnchor.target != null && this.bottomAnchor.target != null)
         {
             this.mOverflow = UILabel.Overflow.ShrinkContent;
         }
@@ -900,10 +668,8 @@ public class UILabel : UIWidget
 
     private void ProcessAndRequest()
     {
-        if (this.ambigiousFont != (UnityEngine.Object)null)
-        {
+        if (this.ambigiousFont != null)
             this.ProcessText();
-        }
     }
 
     protected override void OnEnable()
@@ -930,7 +696,7 @@ public class UILabel : UIWidget
             this.mMaxLineCount = 1;
             this.mMultiline = true;
         }
-        this.mPremultiply = (this.material != (UnityEngine.Object)null && this.material.shader != (UnityEngine.Object)null && this.material.shader.name.Contains("Premultiplied"));
+        this.mPremultiply = this.material != null && this.material.shader != null && this.material.shader.name.Contains("Premultiplied");
         this.ProcessAndRequest();
     }
 
@@ -948,41 +714,35 @@ public class UILabel : UIWidget
     private void ProcessText(Boolean legacyMode, Boolean full)
     {
         if (!this.isValid)
-        {
             return;
-        }
         this.mChanged = true;
         this.shouldBeProcessed = false;
-        Single num = this.mDrawRegion.z - this.mDrawRegion.x;
-        Single num2 = this.mDrawRegion.w - this.mDrawRegion.y;
-        NGUIText.rectWidth = (Int32)((!legacyMode) ? base.width : ((Int32)((this.mMaxLineWidth == 0) ? 1000000 : this.mMaxLineWidth)));
-        NGUIText.rectHeight = (Int32)((!legacyMode) ? base.height : ((Int32)((this.mMaxLineHeight == 0) ? 1000000 : this.mMaxLineHeight)));
-        NGUIText.regionWidth = (Int32)((num == 1f) ? NGUIText.rectWidth : Mathf.RoundToInt((Single)NGUIText.rectWidth * num));
-        NGUIText.regionHeight = (Int32)((num2 == 1f) ? NGUIText.rectHeight : Mathf.RoundToInt((Single)NGUIText.rectHeight * num2));
-        this.mFinalFontSize = Mathf.Abs((Int32)((!legacyMode) ? this.defaultFontSize : Mathf.RoundToInt(base.cachedTransform.localScale.x)));
+        Single drawWidth = this.mDrawRegion.z - this.mDrawRegion.x;
+        Single drawHeight = this.mDrawRegion.w - this.mDrawRegion.y;
+        NGUIText.rectWidth = legacyMode ? (this.mMaxLineWidth == 0 ? 1000000 : this.mMaxLineWidth) : base.width;
+        NGUIText.rectHeight = legacyMode ? (this.mMaxLineHeight == 0 ? 1000000 : this.mMaxLineHeight) : base.height;
+        NGUIText.regionWidth = drawWidth == 1f ? NGUIText.rectWidth : Mathf.RoundToInt(NGUIText.rectWidth * drawWidth);
+        NGUIText.regionHeight = drawHeight == 1f ? NGUIText.rectHeight : Mathf.RoundToInt(NGUIText.rectHeight * drawHeight);
+        this.mFinalFontSize = Mathf.Abs(legacyMode ? Mathf.RoundToInt(base.cachedTransform.localScale.x) : this.defaultFontSize);
         this.mScale = 1f;
         if (NGUIText.regionWidth < 1 || NGUIText.regionHeight < 0)
         {
             this.mProcessedText = String.Empty;
             return;
         }
-        Boolean flag = this.trueTypeFont != (UnityEngine.Object)null;
-        if (flag && this.keepCrisp)
+        Boolean hasTrueTypeFont = this.trueTypeFont != null;
+        if (hasTrueTypeFont && this.keepCrisp)
         {
             UIRoot root = base.root;
-            if (root != (UnityEngine.Object)null)
-            {
-                this.mDensity = ((!(root != (UnityEngine.Object)null)) ? 1f : root.pixelSizeAdjustment);
-            }
+            if (root != null)
+                this.mDensity = root == null ? 1f : root.pixelSizeAdjustment;
         }
         else
         {
             this.mDensity = 1f;
         }
         if (full)
-        {
             this.UpdateNGUIText();
-        }
         if (this.mOverflow == UILabel.Overflow.ResizeFreely)
         {
             NGUIText.rectWidth = 1000000;
@@ -996,56 +756,44 @@ public class UILabel : UIWidget
         if (this.mFinalFontSize > 0)
         {
             Boolean keepCrisp = this.keepCrisp;
-            for (Int32 i = this.mFinalFontSize; i > 0; i--)
+            for (Int32 shrinkedFontSize = this.mFinalFontSize; shrinkedFontSize > 2; shrinkedFontSize -= 2)
             {
                 if (keepCrisp)
                 {
-                    this.mFinalFontSize = i;
+                    this.mFinalFontSize = shrinkedFontSize;
                     NGUIText.fontSize = this.mFinalFontSize;
                 }
                 else
                 {
-                    this.mScale = (Single)i / (Single)this.mFinalFontSize;
-                    NGUIText.fontScale = ((!flag) ? ((Single)this.mFontSize / (Single)this.mFont.defaultSize * this.mScale) : this.mScale);
+                    this.mScale = (Single)shrinkedFontSize / this.mFinalFontSize;
+                    NGUIText.fontScale = hasTrueTypeFont ? this.mScale : this.mScale * this.mFontSize / this.mFont.defaultSize;
                 }
                 NGUIText.Update(false);
-                Boolean flag2 = NGUIText.WrapText(this.mText, out this.mProcessedText, true, false);
-                if (this.mOverflow != UILabel.Overflow.ShrinkContent || flag2)
+                Boolean properWrapping = NGUIText.WrapText(this.mText, out this.mProcessedText, true, false);
+                if (this.mOverflow != UILabel.Overflow.ShrinkContent || properWrapping)
                 {
                     if (this.mOverflow == UILabel.Overflow.ResizeFreely)
                     {
                         this.mCalculatedSize = NGUIText.CalculatePrintedSize(this.mProcessedText);
                         this.mWidth = Mathf.Max(this.minWidth, Mathf.RoundToInt(this.mCalculatedSize.x));
-                        if (num != 1f)
-                        {
-                            this.mWidth = Mathf.RoundToInt((Single)this.mWidth / num);
-                        }
+                        if (drawWidth != 1f)
+                            this.mWidth = Mathf.RoundToInt(this.mWidth / drawWidth);
                         this.mHeight = Mathf.Max(this.minHeight, Mathf.RoundToInt(this.mCalculatedSize.y));
-                        if (num2 != 1f)
-                        {
-                            this.mHeight = Mathf.RoundToInt((Single)this.mHeight / num2);
-                        }
+                        if (drawHeight != 1f)
+                            this.mHeight = Mathf.RoundToInt(this.mHeight / drawHeight);
                         if ((this.mWidth & 1) == 1)
-                        {
                             this.mWidth++;
-                        }
                         if ((this.mHeight & 1) == 1)
-                        {
                             this.mHeight++;
-                        }
                     }
                     else if (this.mOverflow == UILabel.Overflow.ResizeHeight)
                     {
                         this.mCalculatedSize = NGUIText.CalculatePrintedSize(this.mProcessedText);
                         this.mHeight = Mathf.Max(this.minHeight, Mathf.RoundToInt(this.mCalculatedSize.y));
-                        if (num2 != 1f)
-                        {
-                            this.mHeight = Mathf.RoundToInt((Single)this.mHeight / num2);
-                        }
+                        if (drawHeight != 1f)
+                            this.mHeight = Mathf.RoundToInt(this.mHeight / drawHeight);
                         if ((this.mHeight & 1) == 1)
-                        {
                             this.mHeight++;
-                        }
                     }
                     else
                     {
@@ -1059,10 +807,6 @@ public class UILabel : UIWidget
                     }
                     break;
                 }
-                if (--i <= 1)
-                {
-                    break;
-                }
             }
         }
         else
@@ -1073,19 +817,19 @@ public class UILabel : UIWidget
         }
         if (full)
         {
-            NGUIText.bitmapFont = (UIFont)null;
-            NGUIText.dynamicFont = (Font)null;
+            NGUIText.bitmapFont = null;
+            NGUIText.dynamicFont = null;
         }
     }
 
     public override void MakePixelPerfect()
     {
-        if (this.ambigiousFont != (UnityEngine.Object)null)
+        if (this.ambigiousFont != null)
         {
             Vector3 localPosition = base.cachedTransform.localPosition;
-            localPosition.x = (Single)Mathf.RoundToInt(localPosition.x);
-            localPosition.y = (Single)Mathf.RoundToInt(localPosition.y);
-            localPosition.z = (Single)Mathf.RoundToInt(localPosition.z);
+            localPosition.x = Mathf.RoundToInt(localPosition.x);
+            localPosition.y = Mathf.RoundToInt(localPosition.y);
+            localPosition.z = Mathf.RoundToInt(localPosition.z);
             base.cachedTransform.localPosition = localPosition;
             base.cachedTransform.localScale = Vector3.one;
             if (this.mOverflow == UILabel.Overflow.ResizeFreely)
@@ -1098,27 +842,21 @@ public class UILabel : UIWidget
                 Int32 height = base.height;
                 UILabel.Overflow overflow = this.mOverflow;
                 if (overflow != UILabel.Overflow.ResizeHeight)
-                {
                     this.mWidth = 100000;
-                }
                 this.mHeight = 100000;
                 this.mOverflow = UILabel.Overflow.ShrinkContent;
                 this.ProcessText(false, true);
                 this.mOverflow = overflow;
-                Int32 num = Mathf.RoundToInt(this.mCalculatedSize.x);
-                Int32 num2 = Mathf.RoundToInt(this.mCalculatedSize.y);
-                num = Mathf.Max(num, base.minWidth);
-                num2 = Mathf.Max(num2, base.minHeight);
-                if ((num & 1) == 1)
-                {
-                    num++;
-                }
-                if ((num2 & 1) == 1)
-                {
-                    num2++;
-                }
-                this.mWidth = Mathf.Max(width, num);
-                this.mHeight = Mathf.Max(height, num2);
+                this.mWidth = Mathf.Max(Mathf.RoundToInt(this.mCalculatedSize.x), base.minWidth);
+                this.mHeight = Mathf.Max(Mathf.RoundToInt(this.mCalculatedSize.y), base.minHeight);
+                if ((this.mWidth & 1) == 1)
+                    this.mWidth++;
+                if ((this.mHeight & 1) == 1)
+                    this.mHeight++;
+                if (this.mWidth < width)
+                    this.mWidth = width;
+                if (this.mHeight < height)
+                    this.mHeight = height;
                 this.MarkAsChanged();
             }
         }
@@ -1130,7 +868,7 @@ public class UILabel : UIWidget
 
     public void AssumeNaturalSize()
     {
-        if (this.ambigiousFont != (UnityEngine.Object)null)
+        if (this.ambigiousFont != null)
         {
             this.mWidth = 100000;
             this.mHeight = 100000;
@@ -1138,13 +876,9 @@ public class UILabel : UIWidget
             this.mWidth = Mathf.RoundToInt(this.mCalculatedSize.x);
             this.mHeight = Mathf.RoundToInt(this.mCalculatedSize.y);
             if ((this.mWidth & 1) == 1)
-            {
                 this.mWidth++;
-            }
             if ((this.mHeight & 1) == 1)
-            {
                 this.mHeight++;
-            }
             this.MarkAsChanged();
         }
     }
@@ -1173,30 +907,24 @@ public class UILabel : UIWidget
         {
             String processedText = this.processedText;
             if (String.IsNullOrEmpty(processedText))
-            {
                 return 0;
-            }
             this.UpdateNGUIText();
             if (precise)
-            {
                 NGUIText.PrintExactCharacterPositions(processedText, UILabel.mTempVerts, UILabel.mTempIndices);
-            }
             else
-            {
                 NGUIText.PrintApproximateCharacterPositions(processedText, UILabel.mTempVerts, UILabel.mTempIndices);
-            }
             if (UILabel.mTempVerts.size > 0)
             {
                 this.ApplyOffset(UILabel.mTempVerts, 0);
-                Int32 result = (Int32)((!precise) ? NGUIText.GetApproximateCharacterIndex(UILabel.mTempVerts, UILabel.mTempIndices, localPos) : NGUIText.GetExactCharacterIndex(UILabel.mTempVerts, UILabel.mTempIndices, localPos));
+                Int32 result = precise ? NGUIText.GetExactCharacterIndex(UILabel.mTempVerts, UILabel.mTempIndices, localPos) : NGUIText.GetApproximateCharacterIndex(UILabel.mTempVerts, UILabel.mTempIndices, localPos);
                 UILabel.mTempVerts.Clear();
                 UILabel.mTempIndices.Clear();
-                NGUIText.bitmapFont = (UIFont)null;
-                NGUIText.dynamicFont = (Font)null;
+                NGUIText.bitmapFont = null;
+                NGUIText.dynamicFont = null;
                 return result;
             }
-            NGUIText.bitmapFont = (UIFont)null;
-            NGUIText.dynamicFont = (Font)null;
+            NGUIText.bitmapFont = null;
+            NGUIText.dynamicFont = null;
         }
         return 0;
     }
@@ -1213,37 +941,20 @@ public class UILabel : UIWidget
         return this.GetWordAtCharacterIndex(characterIndexAtPosition);
     }
 
+    static readonly Char[] WordStartCheck = [' ', '\n'];
+    static readonly Char[] WordEndCheck = [' ', '\n', ',', '.'];
     public String GetWordAtCharacterIndex(Int32 characterIndex)
     {
         if (characterIndex != -1 && characterIndex < this.mText.Length)
         {
-            Int32 num = this.mText.LastIndexOfAny(new Char[]
-            {
-                ' ',
-                '\n'
-            }, characterIndex) + 1;
-            Int32 num2 = this.mText.IndexOfAny(new Char[]
-            {
-                ' ',
-                '\n',
-                ',',
-                '.'
-            }, characterIndex);
-            if (num2 == -1)
-            {
-                num2 = this.mText.Length;
-            }
-            if (num != num2)
-            {
-                Int32 num3 = num2 - num;
-                if (num3 > 0)
-                {
-                    String text = this.mText.Substring(num, num3);
-                    return NGUIText.StripSymbols(text);
-                }
-            }
+            Int32 wordStart = this.mText.LastIndexOfAny(UILabel.WordStartCheck, characterIndex) + 1;
+            Int32 wordEnd = this.mText.IndexOfAny(UILabel.WordEndCheck, characterIndex);
+            if (wordEnd == -1)
+                wordEnd = this.mText.Length;
+            if (wordStart < wordEnd)
+                return NGUIText.StripSymbols(this.mText.Substring(wordStart, wordEnd - wordStart));
         }
-        return (String)null;
+        return null;
     }
 
     public String GetUrlAtPosition(Vector3 worldPos)
@@ -1260,32 +971,22 @@ public class UILabel : UIWidget
     {
         if (characterIndex != -1 && characterIndex < this.mText.Length - 6)
         {
-            Int32 num;
+            Int32 urlStart;
             if (this.mText[characterIndex] == '[' && this.mText[characterIndex + 1] == 'u' && this.mText[characterIndex + 2] == 'r' && this.mText[characterIndex + 3] == 'l' && this.mText[characterIndex + 4] == '=')
-            {
-                num = characterIndex;
-            }
+                urlStart = characterIndex;
             else
-            {
-                num = this.mText.LastIndexOf("[url=", characterIndex);
-            }
-            if (num == -1)
-            {
-                return (String)null;
-            }
-            num += 5;
-            Int32 num2 = this.mText.IndexOf("]", num);
-            if (num2 == -1)
-            {
-                return (String)null;
-            }
-            Int32 num3 = this.mText.IndexOf("[/url]", num2);
-            if (num3 == -1 || characterIndex <= num3)
-            {
-                return this.mText.Substring(num, num2 - num);
-            }
+                urlStart = this.mText.LastIndexOf("[url=", characterIndex);
+            if (urlStart == -1)
+                return null;
+            urlStart += 5;
+            Int32 urlEnd = this.mText.IndexOf("]", urlStart);
+            if (urlEnd == -1)
+                return null;
+            Int32 urlTagEnd = this.mText.IndexOf("[/url]", urlEnd);
+            if (urlTagEnd == -1 || characterIndex <= urlTagEnd)
+                return this.mText.Substring(urlStart, urlEnd - urlStart);
         }
-        return (String)null;
+        return null;
     }
 
     public Int32 GetCharacterIndex(Int32 currentIndex, KeyCode key)
@@ -1294,64 +995,43 @@ public class UILabel : UIWidget
         {
             String processedText = this.processedText;
             if (String.IsNullOrEmpty(processedText))
-            {
                 return 0;
-            }
             Int32 defaultFontSize = this.defaultFontSize;
             this.UpdateNGUIText();
             NGUIText.PrintApproximateCharacterPositions(processedText, UILabel.mTempVerts, UILabel.mTempIndices);
             if (UILabel.mTempVerts.size > 0)
             {
                 this.ApplyOffset(UILabel.mTempVerts, 0);
-                Int32 i = 0;
-                while (i < UILabel.mTempIndices.size)
+                for (Int32 i = 0; i < UILabel.mTempIndices.size; i++)
                 {
                     if (UILabel.mTempIndices[i] == currentIndex)
                     {
-                        Vector2 pos = UILabel.mTempVerts[i];
+                        Vector2 charPos = UILabel.mTempVerts[i];
                         if (key == KeyCode.UpArrow)
-                        {
-                            pos.y += (Single)defaultFontSize + this.effectiveSpacingY;
-                        }
+                            charPos.y += defaultFontSize + this.effectiveSpacingY;
                         else if (key == KeyCode.DownArrow)
-                        {
-                            pos.y -= (Single)defaultFontSize + this.effectiveSpacingY;
-                        }
+                            charPos.y -= defaultFontSize + this.effectiveSpacingY;
                         else if (key == KeyCode.Home)
-                        {
-                            pos.x -= 1000f;
-                        }
+                            charPos.x -= 1000f;
                         else if (key == KeyCode.End)
-                        {
-                            pos.x += 1000f;
-                        }
-                        Int32 approximateCharacterIndex = NGUIText.GetApproximateCharacterIndex(UILabel.mTempVerts, UILabel.mTempIndices, pos);
+                            charPos.x += 1000f;
+                        Int32 approximateCharacterIndex = NGUIText.GetApproximateCharacterIndex(UILabel.mTempVerts, UILabel.mTempIndices, charPos);
                         if (approximateCharacterIndex == currentIndex)
-                        {
                             break;
-                        }
                         UILabel.mTempVerts.Clear();
                         UILabel.mTempIndices.Clear();
                         return approximateCharacterIndex;
-                    }
-                    else
-                    {
-                        i++;
                     }
                 }
                 UILabel.mTempVerts.Clear();
                 UILabel.mTempIndices.Clear();
             }
-            NGUIText.bitmapFont = (UIFont)null;
-            NGUIText.dynamicFont = (Font)null;
+            NGUIText.bitmapFont = null;
+            NGUIText.dynamicFont = null;
             if (key == KeyCode.UpArrow || key == KeyCode.Home)
-            {
                 return 0;
-            }
             if (key == KeyCode.DownArrow || key == KeyCode.End)
-            {
                 return processedText.Length;
-            }
         }
         return currentIndex;
     }
@@ -1359,34 +1039,28 @@ public class UILabel : UIWidget
     public void PrintOverlay(Int32 start, Int32 end, UIGeometry caret, UIGeometry highlight, Color caretColor, Color highlightColor)
     {
         if (caret != null)
-        {
             caret.Clear();
-        }
         if (highlight != null)
-        {
             highlight.Clear();
-        }
         if (!this.isValid)
-        {
             return;
-        }
         String processedText = this.processedText;
         this.UpdateNGUIText();
-        Int32 size = caret.verts.size;
-        Vector2 item = new Vector2(0.5f, 0.5f);
-        Single finalAlpha = this.finalAlpha;
+        Int32 vBeforeOverlay = caret.verts.size;
+        Vector2 constantUV = new Vector2(0.5f, 0.5f);
+        highlightColor = new Color(highlightColor.r, highlightColor.g, highlightColor.b, highlightColor.a * this.finalAlpha);
+        caretColor = new Color(caretColor.r, caretColor.g, caretColor.b, caretColor.a * this.finalAlpha);
         if (highlight != null && start != end)
         {
-            Int32 size2 = highlight.verts.size;
+            Int32 vStartHighlight = highlight.verts.size;
             NGUIText.PrintCaretAndSelection(processedText, start, end, caret.verts, highlight.verts);
-            if (highlight.verts.size > size2)
+            if (highlight.verts.size > vStartHighlight)
             {
-                this.ApplyOffset(highlight.verts, size2);
-                Color32 item2 = new Color(highlightColor.r, highlightColor.g, highlightColor.b, highlightColor.a * finalAlpha);
-                for (Int32 i = size2; i < highlight.verts.size; i++)
+                this.ApplyOffset(highlight.verts, vStartHighlight);
+                for (Int32 i = vStartHighlight; i < highlight.verts.size; i++)
                 {
-                    highlight.uvs.Add(item);
-                    highlight.cols.Add(item2);
+                    highlight.uvs.Add(constantUV);
+                    highlight.cols.Add(highlightColor);
                 }
             }
         }
@@ -1394,142 +1068,127 @@ public class UILabel : UIWidget
         {
             NGUIText.PrintCaretAndSelection(processedText, start, end, caret.verts, null);
         }
-        this.ApplyOffset(caret.verts, size);
-        Color32 item3 = new Color(caretColor.r, caretColor.g, caretColor.b, caretColor.a * finalAlpha);
-        for (Int32 j = size; j < caret.verts.size; j++)
+        this.ApplyOffset(caret.verts, vBeforeOverlay);
+        for (Int32 i = vBeforeOverlay; i < caret.verts.size; i++)
         {
-            caret.uvs.Add(item);
-            caret.cols.Add(item3);
+            caret.uvs.Add(constantUV);
+            caret.cols.Add(caretColor);
         }
-        NGUIText.bitmapFont = (UIFont)null;
-        NGUIText.dynamicFont = (Font)null;
+        NGUIText.bitmapFont = null;
+        NGUIText.dynamicFont = null;
     }
 
     public override void OnFill(BetterList<Vector3> verts, BetterList<Vector2> uvs, BetterList<Color32> cols)
     {
-        if (!this.isValid)
+        try
         {
-            return;
-        }
-        Int32 num = verts.size;
-        Color color = base.color;
-        color.a = this.finalAlpha;
-        if (this.mFont != (UnityEngine.Object)null && this.mFont.premultipliedAlphaShader)
-        {
-            color = NGUITools.ApplyPMA(color);
-        }
-        if (QualitySettings.activeColorSpace == ColorSpace.Linear)
-        {
-            color.r = Mathf.GammaToLinearSpace(color.r);
-            color.g = Mathf.GammaToLinearSpace(color.g);
-            color.b = Mathf.GammaToLinearSpace(color.b);
-        }
-        String processedText = this.processedText;
-        Int32 size = verts.size;
-        this.UpdateNGUIText();
-        if (this.printIconAfterProcessedText)
-        {
-            this.ReleaseIcon();
-        }
-        NGUIText.tint = color;
-        BetterList<Int32> shadowVertIndexes;
-        NGUIText.Print(processedText, verts, uvs, cols, out shadowVertIndexes, out this.imageList, out this.vertsLineOffsets);
-        NGUIText.bitmapFont = (UIFont)null;
-        NGUIText.dynamicFont = (Font)null;
-        Vector2 offset = this.ApplyOffset(verts, size);
-        this.ApplyIconOffset(this.imageList, offset);
-        if (this.mFont != (UnityEngine.Object)null && this.mFont.packedFontShader)
-        {
-            return;
-        }
-        if (this.effectStyle != UILabel.Effect.None)
-        {
-            Int32 size2 = verts.size;
-            offset.x = this.mEffectDistance.x;
-            offset.y = this.mEffectDistance.y;
-            this.ApplyShadow(verts, uvs, cols, num, size2, offset.x, -offset.y);
-            this.ApplyHighShadow(verts, shadowVertIndexes, offset.x / 3f, -offset.y / 3f);
-            if (this.effectStyle == UILabel.Effect.Outline || this.effectStyle == UILabel.Effect.Outline8)
+            if (!this.isValid)
+                return;
+            Int32 vStart = verts.size;
+            Color textColor = base.color;
+            textColor.a = this.finalAlpha;
+            if (this.mFont != null && this.mFont.premultipliedAlphaShader)
+                textColor = NGUITools.ApplyPMA(textColor);
+            if (QualitySettings.activeColorSpace == ColorSpace.Linear)
             {
-                num = size2;
-                size2 = verts.size;
-                this.ApplyShadow(verts, uvs, cols, num, size2, -offset.x, offset.y);
-                num = size2;
-                size2 = verts.size;
-                this.ApplyShadow(verts, uvs, cols, num, size2, offset.x, offset.y);
-                num = size2;
-                size2 = verts.size;
-                this.ApplyShadow(verts, uvs, cols, num, size2, -offset.x, -offset.y);
-                if (this.effectStyle == UILabel.Effect.Outline8)
+                textColor.r = Mathf.GammaToLinearSpace(textColor.r);
+                textColor.g = Mathf.GammaToLinearSpace(textColor.g);
+                textColor.b = Mathf.GammaToLinearSpace(textColor.b);
+            }
+            String processedText = this.processedText;
+            this.UpdateNGUIText();
+            if (this.printIconAfterProcessedText)
+                this.ReleaseIcon();
+            NGUIText.tint = textColor;
+            BetterList<Int32> shadowVertIndexes;
+            NGUIText.Print(processedText, verts, uvs, cols, out shadowVertIndexes, out this.imageList, out this.vertsLineOffsets);
+            NGUIText.bitmapFont = null;
+            NGUIText.dynamicFont = null;
+            Vector2 pivotOffset = this.ApplyOffset(verts, vStart);
+            this.ApplyIconOffset(this.imageList, pivotOffset);
+            if (this.mFont != null && this.mFont.packedFontShader)
+                return;
+            if (this.effectStyle != UILabel.Effect.None)
+            {
+                Int32 vEnd = verts.size;
+                pivotOffset.x = this.mEffectDistance.x;
+                pivotOffset.y = this.mEffectDistance.y;
+                this.ApplyShadow(verts, uvs, cols, vStart, vEnd, pivotOffset.x, -pivotOffset.y);
+                this.ApplyHighShadow(verts, shadowVertIndexes, pivotOffset.x / 3f, -pivotOffset.y / 3f);
+                if (this.effectStyle == UILabel.Effect.Outline || this.effectStyle == UILabel.Effect.Outline8)
                 {
-                    num = size2;
-                    size2 = verts.size;
-                    this.ApplyShadow(verts, uvs, cols, num, size2, -offset.x, 0f);
-                    num = size2;
-                    size2 = verts.size;
-                    this.ApplyShadow(verts, uvs, cols, num, size2, offset.x, 0f);
-                    num = size2;
-                    size2 = verts.size;
-                    this.ApplyShadow(verts, uvs, cols, num, size2, 0f, offset.y);
-                    num = size2;
-                    size2 = verts.size;
-                    this.ApplyShadow(verts, uvs, cols, num, size2, 0f, -offset.y);
+                    vStart = vEnd;
+                    vEnd = verts.size;
+                    this.ApplyShadow(verts, uvs, cols, vStart, vEnd, -pivotOffset.x, pivotOffset.y);
+                    vStart = vEnd;
+                    vEnd = verts.size;
+                    this.ApplyShadow(verts, uvs, cols, vStart, vEnd, pivotOffset.x, pivotOffset.y);
+                    vStart = vEnd;
+                    vEnd = verts.size;
+                    this.ApplyShadow(verts, uvs, cols, vStart, vEnd, -pivotOffset.x, -pivotOffset.y);
+                    if (this.effectStyle == UILabel.Effect.Outline8)
+                    {
+                        vStart = vEnd;
+                        vEnd = verts.size;
+                        this.ApplyShadow(verts, uvs, cols, vStart, vEnd, -pivotOffset.x, 0f);
+                        vStart = vEnd;
+                        vEnd = verts.size;
+                        this.ApplyShadow(verts, uvs, cols, vStart, vEnd, pivotOffset.x, 0f);
+                        vStart = vEnd;
+                        vEnd = verts.size;
+                        this.ApplyShadow(verts, uvs, cols, vStart, vEnd, 0f, pivotOffset.y);
+                        vStart = vEnd;
+                        vEnd = verts.size;
+                        this.ApplyShadow(verts, uvs, cols, vStart, vEnd, 0f, -pivotOffset.y);
+                    }
                 }
             }
+            if (this.onPostFill != null)
+                this.onPostFill(this, vStart, verts, uvs, cols);
+            if (this.printIconAfterProcessedText)
+                this.PrintIcon(this.imageList);
         }
-        if (this.onPostFill != null)
-        {
-            this.onPostFill(this, num, verts, uvs, cols);
-        }
-        if (this.printIconAfterProcessedText)
-        {
-            this.PrintIcon(this.imageList);
-        }
+        catch (Exception err) { Memoria.Prime.Log.Error(err); }
     }
 
     public Vector2 ApplyOffset(BetterList<Vector3> verts, Int32 start)
     {
         Vector2 pivotOffset = base.pivotOffset;
-        Single num = Mathf.Lerp(0f, (Single)(-(Single)this.mWidth), pivotOffset.x);
-        Single num2 = Mathf.Lerp((Single)this.mHeight, 0f, pivotOffset.y) + Mathf.Lerp(this.mCalculatedSize.y - (Single)this.mHeight, 0f, pivotOffset.y);
-        num = Mathf.Round(num);
-        num2 = Mathf.Round(num2);
+        Single offsetX = Mathf.Round(Mathf.Lerp(0f, -this.mWidth, pivotOffset.x));
+        Single offsetY = Mathf.Round(Mathf.Lerp(this.mHeight, 0f, pivotOffset.y) + Mathf.Lerp(this.mCalculatedSize.y - this.mHeight, 0f, pivotOffset.y));
         for (Int32 i = start; i < verts.size; i++)
         {
-            Vector3[] buffer = verts.buffer;
-            Int32 num3 = i;
-            buffer[num3].x = buffer[num3].x + num;
-            Vector3[] buffer2 = verts.buffer;
-            Int32 num4 = i;
-            buffer2[num4].y = buffer2[num4].y + num2;
+            verts.buffer[i].x += offsetX;
+            verts.buffer[i].y += offsetY;
         }
-        return new Vector2(num, num2);
+        return new Vector2(offsetX, offsetY);
     }
 
-    public void ApplyShadow(BetterList<Vector3> verts, BetterList<Vector2> uvs, BetterList<Color32> cols, Int32 start, Int32 end, Single x, Single y)
+    public void ApplyShadow(BetterList<Vector3> verts, BetterList<Vector2> uvs, BetterList<Color32> cols, Int32 start, Int32 end, Single dx, Single dy)
     {
-        Color color = this.mEffectColor;
-        color.a *= this.finalAlpha;
-        Color32 color2 = (!(this.bitmapFont != (UnityEngine.Object)null) || !this.bitmapFont.premultipliedAlphaShader) ? color : NGUITools.ApplyPMA(color);
+        Color shadowColor = this.mEffectColor;
+        shadowColor.a *= this.finalAlpha;
+        if (this.bitmapFont != null && this.bitmapFont.premultipliedAlphaShader)
+            shadowColor = NGUITools.ApplyPMA(shadowColor);
         for (Int32 i = start; i < end; i++)
         {
             verts.Add(verts.buffer[i]);
             uvs.Add(uvs.buffer[i]);
             cols.Add(cols.buffer[i]);
-            Vector3 vector = verts.buffer[i];
-            vector.x += x;
-            vector.y += y;
-            verts.buffer[i] = vector;
-            Color32 color3 = cols.buffer[i];
-            if (color3.a == 255)
+            verts.buffer[i].x += dx;
+            verts.buffer[i].y += dy;
+            Byte bufferColorAlpha = cols.buffer[i].a;
+            if (bufferColorAlpha == Byte.MaxValue)
             {
-                cols.buffer[i] = color2;
+                cols.buffer[i] = shadowColor;
             }
             else
             {
-                Color color4 = color;
-                color4.a = (Single)color3.a / 255f * color.a;
-                cols.buffer[i] = ((!(this.bitmapFont != (UnityEngine.Object)null) || !this.bitmapFont.premultipliedAlphaShader) ? color4 : NGUITools.ApplyPMA(color4));
+                Color vertColor = shadowColor;
+                vertColor.a = bufferColorAlpha / 255f * shadowColor.a;
+                if (this.bitmapFont != null && this.bitmapFont.premultipliedAlphaShader)
+                    vertColor = NGUITools.ApplyPMA(vertColor);
+                cols.buffer[i] = vertColor;
             }
         }
     }
@@ -1540,33 +1199,27 @@ public class UILabel : UIWidget
         NGUIText.encoding = false;
         NGUIText.symbolStyle = NGUIText.SymbolStyle.None;
         Int32 result = NGUIText.CalculateOffsetToFit(text);
-        NGUIText.bitmapFont = (UIFont)null;
-        NGUIText.dynamicFont = (Font)null;
+        NGUIText.bitmapFont = null;
+        NGUIText.dynamicFont = null;
         return result;
     }
 
     public void SetCurrentProgress()
     {
-        if (UIProgressBar.current != (UnityEngine.Object)null)
-        {
+        if (UIProgressBar.current != null)
             this.text = UIProgressBar.current.value.ToString("F");
-        }
     }
 
     public void SetCurrentPercent()
     {
-        if (UIProgressBar.current != (UnityEngine.Object)null)
-        {
+        if (UIProgressBar.current != null)
             this.text = Mathf.RoundToInt(UIProgressBar.current.value * 100f) + "%";
-        }
     }
 
     public void SetCurrentSelection()
     {
-        if (UIPopupList.current != (UnityEngine.Object)null)
-        {
-            this.text = ((!UIPopupList.current.isLocalized) ? UIPopupList.current.value : Localization.Get(UIPopupList.current.value));
-        }
+        if (UIPopupList.current != null)
+            this.text = UIPopupList.current.isLocalized ? Localization.Get(UIPopupList.current.value) : UIPopupList.current.value;
     }
 
     public Boolean Wrap(String text, out String final)
@@ -1580,22 +1233,22 @@ public class UILabel : UIWidget
         NGUIText.rectHeight = height;
         NGUIText.regionHeight = height;
         Boolean result = NGUIText.WrapText(text, out final, false);
-        NGUIText.bitmapFont = (UIFont)null;
-        NGUIText.dynamicFont = (Font)null;
+        NGUIText.bitmapFont = null;
+        NGUIText.dynamicFont = null;
         return result;
     }
 
     public void UpdateNGUIText()
     {
         Font trueTypeFont = this.trueTypeFont;
-        Boolean flag = trueTypeFont != (UnityEngine.Object)null;
+        Boolean hasTrueTypeFont = trueTypeFont != null;
         NGUIText.fontSize = this.mFinalFontSize;
         NGUIText.fontStyle = this.mFontStyle;
         NGUIText.rectWidth = this.mWidth;
         NGUIText.rectHeight = this.mHeight;
-        NGUIText.regionWidth = Mathf.RoundToInt((Single)this.mWidth * (this.mDrawRegion.z - this.mDrawRegion.x));
-        NGUIText.regionHeight = Mathf.RoundToInt((Single)this.mHeight * (this.mDrawRegion.w - this.mDrawRegion.y));
-        NGUIText.gradient = (this.mApplyGradient && (this.mFont == (UnityEngine.Object)null || !this.mFont.packedFontShader));
+        NGUIText.regionWidth = Mathf.RoundToInt(this.mWidth * (this.mDrawRegion.z - this.mDrawRegion.x));
+        NGUIText.regionHeight = Mathf.RoundToInt(this.mHeight * (this.mDrawRegion.w - this.mDrawRegion.y));
+        NGUIText.gradient = this.mApplyGradient && (this.mFont == null || !this.mFont.packedFontShader);
         NGUIText.gradientTop = this.mGradientTop;
         NGUIText.gradientBottom = this.mGradientBottom;
         NGUIText.encoding = this.mEncoding;
@@ -1604,41 +1257,33 @@ public class UILabel : UIWidget
         NGUIText.maxLines = this.mMaxLineCount;
         NGUIText.spacingX = this.effectiveSpacingX;
         NGUIText.spacingY = this.effectiveSpacingY;
-        NGUIText.fontScale = ((!flag) ? ((Single)this.mFontSize / (Single)this.mFont.defaultSize * this.mScale) : this.mScale);
-        if (this.mFont != (UnityEngine.Object)null)
+        NGUIText.fontScale = hasTrueTypeFont ? this.mScale : (this.mScale * this.mFontSize / this.mFont.defaultSize);
+        if (this.mFont != null)
         {
             NGUIText.bitmapFont = this.mFont;
-            for (; ; )
-            {
-                UIFont replacement = NGUIText.bitmapFont.replacement;
-                if (replacement == (UnityEngine.Object)null)
-                {
-                    break;
-                }
+            UIFont replacement;
+            while ((replacement = NGUIText.bitmapFont.replacement) != null)
                 NGUIText.bitmapFont = replacement;
-            }
             if (NGUIText.bitmapFont.isDynamic)
             {
                 NGUIText.dynamicFont = NGUIText.bitmapFont.dynamicFont;
-                NGUIText.bitmapFont = (UIFont)null;
+                NGUIText.bitmapFont = null;
             }
             else
             {
-                NGUIText.dynamicFont = (Font)null;
+                NGUIText.dynamicFont = null;
             }
         }
         else
         {
             NGUIText.dynamicFont = trueTypeFont;
-            NGUIText.bitmapFont = (UIFont)null;
+            NGUIText.bitmapFont = null;
         }
-        if (flag && this.keepCrisp)
+        if (hasTrueTypeFont && this.keepCrisp)
         {
             UIRoot root = base.root;
-            if (root != (UnityEngine.Object)null)
-            {
-                NGUIText.pixelDensity = ((!(root != (UnityEngine.Object)null)) ? 1f : root.pixelSizeAdjustment);
-            }
+            if (root != null)
+                NGUIText.pixelDensity = root == null ? 1f : root.pixelSizeAdjustment;
         }
         else
         {
@@ -1649,24 +1294,18 @@ public class UILabel : UIWidget
             this.ProcessText(false, false);
             NGUIText.rectWidth = this.mWidth;
             NGUIText.rectHeight = this.mHeight;
-            NGUIText.regionWidth = Mathf.RoundToInt((Single)this.mWidth * (this.mDrawRegion.z - this.mDrawRegion.x));
-            NGUIText.regionHeight = Mathf.RoundToInt((Single)this.mHeight * (this.mDrawRegion.w - this.mDrawRegion.y));
+            NGUIText.regionWidth = Mathf.RoundToInt(this.mWidth * (this.mDrawRegion.z - this.mDrawRegion.x));
+            NGUIText.regionHeight = Mathf.RoundToInt(this.mHeight * (this.mDrawRegion.w - this.mDrawRegion.y));
         }
         if (this.alignment == NGUIText.Alignment.Automatic)
         {
             UIWidget.Pivot pivot = base.pivot;
             if (pivot == UIWidget.Pivot.Left || pivot == UIWidget.Pivot.TopLeft || pivot == UIWidget.Pivot.BottomLeft)
-            {
                 NGUIText.alignment = NGUIText.Alignment.Left;
-            }
             else if (pivot == UIWidget.Pivot.Right || pivot == UIWidget.Pivot.TopRight || pivot == UIWidget.Pivot.BottomRight)
-            {
                 NGUIText.alignment = NGUIText.Alignment.Right;
-            }
             else
-            {
                 NGUIText.alignment = NGUIText.Alignment.Center;
-            }
         }
         else
         {
@@ -1677,10 +1316,8 @@ public class UILabel : UIWidget
 
     private void OnApplicationPause(Boolean paused)
     {
-        if (!paused && this.mTrueTypeFont != (UnityEngine.Object)null)
-        {
+        if (!paused && this.mTrueTypeFont != null)
             this.Invalidate(false);
-        }
     }
 
     private BetterList<Dialog.DialogImage> imageList;
@@ -1831,13 +1468,11 @@ public class UILabel : UIWidget
     private Int32 mLastHeight;
 
     private static BetterList<UILabel> mList = new BetterList<UILabel>();
-
     private static Dictionary<Font, Int32> mFontUsage = new Dictionary<Font, Int32>();
 
     private static Boolean mTexRebuildAdded = false;
 
     private static BetterList<Vector3> mTempVerts = new BetterList<Vector3>();
-
     private static BetterList<Int32> mTempIndices = new BetterList<Int32>();
 
     public enum Effect

--- a/Assembly-CSharp/Global/World/WorldHUD.cs
+++ b/Assembly-CSharp/Global/World/WorldHUD.cs
@@ -77,18 +77,15 @@ public class WorldHUD : UIScene
                 this.DisplayChocographLocation(true);
             }
             if (PersistenSingleton<UIManager>.Instance.PreviousState == UIManager.UIState.Pause && this.currentState != WorldHUD.State.FullMap && PersistenSingleton<EventEngine>.Instance.GetUserControl())
-            {
                 base.StartCoroutine(this.DisableEventInputForAWhile());
-            }
         };
         if (afterFinished != null)
-        {
-            sceneVoidDelegate = (UIScene.SceneVoidDelegate)Delegate.Combine(sceneVoidDelegate, afterFinished);
-        }
+            sceneVoidDelegate += afterFinished;
         base.Show(sceneVoidDelegate);
         PersistenSingleton<UIManager>.Instance.SetEventEnable(true);
         PersistenSingleton<UIManager>.Instance.SetMenuControlEnable(ff9.GetUserControl());
-        PersistenSingleton<UIManager>.Instance.SetPlayerControlEnable(ff9.GetUserControl(), (Action)null);
+        PersistenSingleton<UIManager>.Instance.SetPlayerControlEnable(ff9.GetUserControl(), null);
+        this.EnableContinentTitle(false);
         this.InitialHUD();
         this.DisplayButtonHud();
         VirtualAnalog.Init(base.gameObject);
@@ -106,17 +103,13 @@ public class WorldHUD : UIScene
         UIScene.SceneVoidDelegate sceneVoidDelegate = delegate
         {
             if (!base.NextSceneIsModal)
-            {
                 PersistenSingleton<UIManager>.Instance.SetGameCameraEnable(false);
-            }
         };
         if (afterFinished != null)
-        {
-            sceneVoidDelegate = (UIScene.SceneVoidDelegate)Delegate.Combine(sceneVoidDelegate, afterFinished);
-        }
+            sceneVoidDelegate += afterFinished;
         base.Hide(sceneVoidDelegate);
         this.PauseButtonGameObject.SetActive(false);
-        PersistenSingleton<UIManager>.Instance.SetPlayerControlEnable(false, (Action)null);
+        PersistenSingleton<UIManager>.Instance.SetPlayerControlEnable(false, null);
         PersistenSingleton<UIManager>.Instance.SetEventEnable(false);
     }
 
@@ -974,21 +967,15 @@ public class WorldHUD : UIScene
     private void DisplayCameraOptionHud()
     {
         if (this.RotationLockButtonGameObject.activeInHierarchy)
-        {
             this.SetRotationLockToggle(FF9StateSystem.Settings.IsAutoRotation);
-        }
         if (this.PerspectiveButtonGameObject.activeInHierarchy)
-        {
             this.SetPerspectiveToggle(FF9StateSystem.Settings.IsPerspectCamera);
-        }
     }
 
     public void ClearFullMapLocations()
     {
-        if (this.mapLocationPointerPanel != (UnityEngine.Object)null)
-        {
+        if (this.mapLocationPointerPanel != null)
             this.mapLocationPointerPanel.transform.DestroyChildren();
-        }
         this.locationPointerList.Clear();
     }
 
@@ -998,6 +985,14 @@ public class WorldHUD : UIScene
         this.continentTitleShadow.sprite2D = FF9UIDataTool.LoadWorldTitle(titleId, true);
         this.continentTitleText.MakePixelPerfect();
         this.continentTitleShadow.MakePixelPerfect();
+        Rect spriteRect = WorldConfiguration.GetTitleSpriteRect(titleId);
+        this.continentTitleText.transform.localPosition = spriteRect.min;
+        this.continentTitleShadow.transform.localPosition = spriteRect.min;
+        if (spriteRect.x != this.continentTitleText.width || spriteRect.y != this.continentTitleText.height)
+        {
+            this.continentTitleText.SetDimensions((Int32)spriteRect.width, (Int32)spriteRect.height);
+            this.continentTitleShadow.SetDimensions((Int32)spriteRect.width, (Int32)spriteRect.height);
+        }
     }
 
     public void ShowContinentTitle(Int32 fadeInFrames)
@@ -1005,8 +1000,8 @@ public class WorldHUD : UIScene
         Single fadeInDuration = this.CalculateTitleFadeDuration(fadeInFrames);
         this.continentTitleTextFader.fadeInDuration = fadeInDuration;
         this.continentTitleShadowFader.fadeInDuration = fadeInDuration;
-        this.continentTitleTextFader.FadeIn((UIScene.SceneVoidDelegate)null);
-        this.continentTitleShadowFader.FadeIn((UIScene.SceneVoidDelegate)null);
+        this.continentTitleTextFader.FadeIn(null);
+        this.continentTitleShadowFader.FadeIn(null);
     }
 
     public void HideContinentTitle(Int32 fadeOutFrames)
@@ -1014,8 +1009,8 @@ public class WorldHUD : UIScene
         Single fadeOutDuration = this.CalculateTitleFadeDuration(fadeOutFrames);
         this.continentTitleTextFader.fadeOutDuration = fadeOutDuration;
         this.continentTitleShadowFader.fadeOutDuration = fadeOutDuration;
-        this.continentTitleTextFader.FadeOut((UIScene.SceneVoidDelegate)null);
-        this.continentTitleShadowFader.FadeOut((UIScene.SceneVoidDelegate)null);
+        this.continentTitleTextFader.FadeOut(null);
+        this.continentTitleShadowFader.FadeOut(null);
     }
 
     public void EnableContinentTitle(Boolean isActive)
@@ -1029,8 +1024,8 @@ public class WorldHUD : UIScene
 
     private Single CalculateTitleFadeDuration(Int32 frames)
     {
-        Single num = (Single)frames / 30f;
-        return (!HonoBehaviorSystem.Instance.IsFastForwardModeActive()) ? num : (num / (Single)FF9StateSystem.Settings.FastForwardFactor);
+        Single seconds = frames / 30f;
+        return HonoBehaviorSystem.Instance.IsFastForwardModeActive() ? seconds / FF9StateSystem.Settings.FastForwardFactor : seconds;
     }
 
     public void SetButtonVisible(Boolean isVisible)

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Nested.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.Nested.cs
@@ -74,11 +74,12 @@ public partial class BattleHUD : UIScene
         AttackList = 0x800,
         StatusAuto = 0x1000,
         StatusImmune = 0x2000,
+        StatusResist = 0x4000,
 
         NameLevel = Name | Level,
         HPMP = HP | MP,
         ElementalAffinities = ElementWeak | ElementResist | ElementImmune | ElementAbsorb,
-        StatusAffinities = StatusImmune | StatusAuto,
+        StatusAffinities = StatusAuto | StatusImmune | StatusResist,
 
         Default = NameLevel | HPMP | Category | ElementWeak,
         All = NameLevel | HPMP | ElementalAffinities | StatusAffinities | Category | ItemSteal | BlueLearn | AttackList
@@ -93,6 +94,7 @@ public partial class BattleHUD : UIScene
         LibraInformation.ElementAbsorb,
         LibraInformation.StatusAuto,
         LibraInformation.StatusImmune,
+        LibraInformation.StatusResist,
         LibraInformation.ItemSteal,
         LibraInformation.BlueLearn,
         LibraInformation.AttackList

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
@@ -189,16 +189,24 @@ public partial class BattleHUD : UIScene
             case LibraInformation.StatusAuto:
             case LibraInformation.StatusImmune:
             {
-                // TODO Make it so status sprites are displayed
-                //BattleStatus status = info == LibraInformation.StatusAuto ? unit.PermanentStatus : unit.ResistStatus;
-                //Dictionary<BattleStatusId, String> icons = info == LibraInformation.StatusAuto ? BattleHUD.BuffIconNames : BattleHUD.DebuffIconNames;
-                //foreach (BattleStatusId statusId in status.ToStatusList())
-                //    if (icons.TryGetValue(statusId, out String spriteName))
-                //        messages.Add(spriteName);
-                //if (messages.Count == 0)
-                //    return [];
-                //return [Localization.GetWithDefault(info.ToString()).Replace("%", String.Join(" ", messages.ToArray()))];
-                return [];
+                BattleStatus status = info == LibraInformation.StatusAuto ? unit.PermanentStatus : unit.ResistStatus;
+                Dictionary<BattleStatusId, String> icons = info == LibraInformation.StatusAuto ? BattleHUD.BuffIconNames : BattleHUD.DebuffIconNames;
+                foreach (BattleStatusId statusId in status.ToStatusList())
+                    if (icons.TryGetValue(statusId, out String spriteName))
+                        messages.Add($"[SPRT={spriteName},48,48]");
+                if (messages.Count == 0)
+                    return [];
+                return [Localization.GetWithDefault(info.ToString()).Replace("%", String.Join("  ", messages.ToArray())) + " "];
+            }
+            case LibraInformation.StatusResist:
+            {
+                String spriteName;
+                foreach (KeyValuePair<BattleStatusId, Single> resist in unit.PartialResistStatus)
+                    if (resist.Value > 0f && (BattleHUD.BuffIconNames.TryGetValue(resist.Key, out spriteName) || BattleHUD.DebuffIconNames.TryGetValue(resist.Key, out spriteName)))
+                        messages.Add($"[SPRT={spriteName},48,48]  ({(Int32)Math.Min(100, resist.Value * 100)}%)");
+                if (messages.Count == 0)
+                    return [];
+                return [Localization.GetWithDefault(info.ToString()).Replace("%", String.Join(", ", messages.ToArray())) + " "];
             }
             case LibraInformation.ItemSteal:
                 if (!unit.IsPlayer)

--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
@@ -196,7 +196,7 @@ public partial class BattleHUD : UIScene
                         messages.Add($"[SPRT={spriteName},48,48]");
                 if (messages.Count == 0)
                     return [];
-                return [Localization.GetWithDefault(info.ToString()).Replace("%", String.Join("  ", messages.ToArray())) + " "];
+                return [Localization.GetWithDefault(info.ToString()).Replace("%", String.Join("  ", messages.ToArray()))];
             }
             case LibraInformation.StatusResist:
             {

--- a/Assembly-CSharp/Global/ff9/ff9.cs
+++ b/Assembly-CSharp/Global/ff9/ff9.cs
@@ -7002,8 +7002,11 @@ public static class ff9
 
     public static void w_naviTitleElement()
     {
-        UInt32 fadeoutTime = ff9.w_naviFadeInTime + 120u;
-        UInt32 closeTime = ff9.w_naviFadeInTime + 180u;
+        UInt32[] durations = WorldConfiguration.GetTitleSpriteDurations(ff9.w_naviTitle);
+        UInt32 fadeInDuration = Math.Max(2, durations[0]);
+        UInt32 fadeOutDuration = Math.Max(1, durations[2]);
+        UInt32 fadeoutTime = ff9.w_naviFadeInTime + fadeInDuration + durations[1];
+        UInt32 closeTime = fadeoutTime + fadeOutDuration + 1u;
         ff9.w_naviLocationDraw = 0;
         if (ff9.w_frameCounterReady > ff9.w_naviFadeInTime)
             ff9.w_naviLocationDraw = ff9.WorldTitleFadeInMode;
@@ -7032,10 +7035,9 @@ public static class ff9
                 ff9.w_naviTitleColor += 4;
             if (ff9.w_naviLocationDraw != ff9.lastTitleDrawState)
             {
-                Int32 fadeInFrames = Convert.ToInt32(fadeoutTime) - ff9.w_frameCounterReady;
                 PersistenSingleton<UIManager>.Instance.WorldHUDScene.SetContinentTitleSprite(ff9.w_naviTitle);
                 PersistenSingleton<UIManager>.Instance.WorldHUDScene.EnableContinentTitle(true);
-                PersistenSingleton<UIManager>.Instance.WorldHUDScene.ShowContinentTitle(fadeInFrames);
+                PersistenSingleton<UIManager>.Instance.WorldHUDScene.ShowContinentTitle((Int32)fadeInDuration);
                 PersistenSingleton<UIManager>.Instance.WorldHUDScene.SetButtonVisible(false);
             }
         }
@@ -7044,10 +7046,7 @@ public static class ff9
             if (ff9.w_naviTitleColor != 0)
                 ff9.w_naviTitleColor -= 4;
             if (ff9.w_naviLocationDraw != ff9.lastTitleDrawState)
-            {
-                Int32 fadeOutFrames = Convert.ToInt32(closeTime) - ff9.w_frameCounterReady;
-                PersistenSingleton<UIManager>.Instance.WorldHUDScene.HideContinentTitle(fadeOutFrames);
-            }
+                PersistenSingleton<UIManager>.Instance.WorldHUDScene.HideContinentTitle((Int32)fadeOutDuration);
         }
         else if (ff9.w_naviLocationDraw == ff9.WorldTitleCloseMode)
         {

--- a/Assembly-CSharp/Memoria/Assets/Export/Grahpics/Export/GraphicResourceExporter.cs
+++ b/Assembly-CSharp/Memoria/Assets/Export/Grahpics/Export/GraphicResourceExporter.cs
@@ -25,7 +25,7 @@ namespace Memoria.Assets
                     if (atlas != null)
                     {
                         path = GraphicResources.Export.GetAtlasPath(name);
-                        ExportAtlasSafe(path, atlas);
+                        ExportAtlasSafe(path, atlas, true);
                     }
                     else
                     {
@@ -36,7 +36,7 @@ namespace Memoria.Assets
                             continue;
                         }
                         path = GraphicResources.Export.GetAtlasPath(name);
-                        ExportSpriteListSafe(path, spriteList);
+                        ExportSpriteListSafe(path, spriteList, true);
                     }
                 }
 
@@ -48,16 +48,10 @@ namespace Memoria.Assets
             }
         }
 
-        public static void ExportAtlasSafe(String outputDirectory, UIAtlas atlas)
+        public static void ExportAtlasSafe(String outputDirectory, UIAtlas atlas, Boolean exportFragments)
         {
             try
             {
-                if (Directory.Exists(outputDirectory))
-                {
-                    Log.Warning("[GraphicResourceExporter] Export was skipped because a directory already exists: [{0}].", outputDirectory);
-                    return;
-                }
-
                 String outputPath = outputDirectory + ".png";
                 if (File.Exists(outputPath))
                 {
@@ -65,14 +59,20 @@ namespace Memoria.Assets
                     return;
                 }
 
-                Directory.CreateDirectory(outputDirectory);
+                if (exportFragments)
+                    Directory.CreateDirectory(outputDirectory);
+                else
+                    Directory.CreateDirectory(Path.GetDirectoryName(outputDirectory));
 
                 Texture2D texture = TextureHelper.CopyAsReadable(atlas.texture);
                 TextureHelper.WriteTextureToFile(texture, outputPath);
-                foreach (UISpriteData sprite in atlas.spriteList)
+                if (exportFragments)
                 {
-                    Texture2D fragment = TextureHelper.GetFragment(texture, sprite.x, texture.height - sprite.y - sprite.height, sprite.width, sprite.height);
-                    TextureHelper.WriteTextureToFile(fragment, Path.Combine(outputDirectory, sprite.name + ".png"));
+                    foreach (UISpriteData sprite in atlas.spriteList)
+                    {
+                        Texture2D fragment = TextureHelper.GetFragment(texture, sprite.x, texture.height - sprite.y - sprite.height, sprite.width, sprite.height);
+                        TextureHelper.WriteTextureToFile(fragment, Path.Combine(outputDirectory, sprite.name + ".png"));
+                    }
                 }
 
                 String outputPathTPSheet = outputDirectory + ".tpsheet";
@@ -96,16 +96,10 @@ namespace Memoria.Assets
             }
         }
 
-        public static void ExportSpriteListSafe(String outputDirectory, Sprite[] spriteList)
+        public static void ExportSpriteListSafe(String outputDirectory, Sprite[] spriteList, Boolean exportFragments)
         {
             try
             {
-                if (Directory.Exists(outputDirectory))
-                {
-                    Log.Warning("[GraphicResourceExporter] Export was skipped because a directory already exists: [{0}].", outputDirectory);
-                    return;
-                }
-
                 String outputPath = outputDirectory + ".png";
                 if (File.Exists(outputPath))
                 {
@@ -113,14 +107,20 @@ namespace Memoria.Assets
                     return;
                 }
 
-                Directory.CreateDirectory(outputDirectory);
+                if (exportFragments)
+                    Directory.CreateDirectory(outputDirectory);
+                else
+                    Directory.CreateDirectory(Path.GetDirectoryName(outputDirectory));
 
                 Texture2D sharedTexture = TextureHelper.CopyAsReadable(spriteList[0].texture);
                 TextureHelper.WriteTextureToFile(sharedTexture, outputDirectory + ".png");
-                foreach (Sprite sprite in spriteList)
+                if (exportFragments)
                 {
-                    Texture2D texture = TextureHelper.GetFragment(sharedTexture, (Int32)sprite.rect.x, (Int32)sprite.rect.y, (Int32)sprite.rect.width, (Int32)sprite.rect.height);
-                    TextureHelper.WriteTextureToFile(texture, Path.ChangeExtension(Path.Combine(outputDirectory, sprite.name), ".png"));
+                    foreach (Sprite sprite in spriteList)
+                    {
+                        Texture2D texture = TextureHelper.GetFragment(sharedTexture, (Int32)sprite.rect.x, (Int32)sprite.rect.y, (Int32)sprite.rect.width, (Int32)sprite.rect.height);
+                        TextureHelper.WriteTextureToFile(texture, Path.ChangeExtension(Path.Combine(outputDirectory, sprite.name), ".png"));
+                    }
                 }
 
                 String outputPathTPSheet = outputDirectory + ".tpsheet";

--- a/Assembly-CSharp/Memoria/Assets/Export/Grahpics/Export/GraphicResourceExporter.cs
+++ b/Assembly-CSharp/Memoria/Assets/Export/Grahpics/Export/GraphicResourceExporter.cs
@@ -80,6 +80,8 @@ namespace Memoria.Assets
                 //  + ":texture=" + texture.name + "\n"
                 //  + ":normalmap=\n";
                     + ":size=" + texture.width + "x" + texture.height + "\n";
+                if (!exportFragments)
+                    tpsheetText += ":append=true\n";
                 foreach (UISpriteData sprite in atlas.spriteList)
                 {
                     tpsheetText += sprite.name + ";" + sprite.x + ";" + sprite.y + ";" + sprite.width + ";" + sprite.height;
@@ -128,6 +130,8 @@ namespace Memoria.Assets
                 //  + ":texture=" + texture.name + "\n"
                 //  + ":normalmap=\n";
                     + ":size=" + sharedTexture.width + "x" + sharedTexture.height + "\n";
+                if (!exportFragments)
+                    tpsheetText += ":append=true\n";
                 foreach (Sprite sprite in spriteList)
                 {
                     tpsheetText += sprite.name + ";" + (Int32)sprite.rect.x + ";" + (Int32)sprite.rect.y + ";" + (Int32)sprite.rect.width + ";" + (Int32)sprite.rect.height;

--- a/Assembly-CSharp/Memoria/Assets/Export/TranslationExporter.cs
+++ b/Assembly-CSharp/Memoria/Assets/Export/TranslationExporter.cs
@@ -1,0 +1,569 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Collections.Generic;
+using UnityEngine;
+using Assets.Sources.Scripts.UI.Common;
+using Memoria.Data;
+using Memoria.Prime;
+
+namespace Memoria.Assets
+{
+    public static class TranslationExporter
+    {
+        public static void ExportSafe()
+        {
+            try
+            {
+                if (!Configuration.Export.Translation)
+                {
+                    Log.Message("[TranslationExporter] Pass through {Configuration.Export.Translation = 0}.");
+                    return;
+                }
+
+                String exportSymbol = Localization.GetSymbol();
+                String modFolder = $"ExportedTranslation{exportSymbol}/";
+                if (Directory.Exists(modFolder))
+                {
+                    Log.Message($"[TranslationExporter] Translation export was skipped because a directory already exists [{modFolder}].");
+                    return;
+                }
+
+                DataPatchers.Initialize();
+                InitialiseStaticBatches();
+
+                ExportFieldTexts(exportSymbol, modFolder);
+                ExportBattleTexts(exportSymbol, modFolder);
+                ExportCommandTexts(exportSymbol, modFolder);
+                ExportAbilityTexts(exportSymbol, modFolder);
+                ExportSupportTexts(exportSymbol, modFolder);
+                ExportItemTexts(exportSymbol, modFolder);
+                ExportKeyItemTexts(exportSymbol, modFolder);
+                ExportLocationNames(exportSymbol, modFolder);
+                ExportCharacterNames(exportSymbol, modFolder);
+                ExportEtcTexts(exportSymbol, modFolder);
+                ExportLocalizationTexts(exportSymbol, modFolder);
+
+                ExportPlaceTitles(exportSymbol, modFolder);
+                ExportContinentTitles(exportSymbol, modFolder);
+                ExportMessageAtlases(exportSymbol, modFolder);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to export translation materials.");
+            }
+        }
+
+        private static void ExportFieldTexts(String symbol, String modFolder)
+        {
+            Log.Message("[TranslationExporter] Exporting field texts...");
+            HashSet<Int32> zones = new HashSet<Int32>(EventEngineUtils.eventIDToMESID.Values);
+            String exportDirectoryMes = $"{modFolder}FF9_Data/EmbeddedAsset/Text/{symbol}/Field/";
+            String exportDirectoryHW = $"{modFolder}HadesWorkshop/Field/";
+            Directory.CreateDirectory(exportDirectoryMes);
+            Directory.CreateDirectory(exportDirectoryHW);
+            foreach (Int32 zoneId in zones)
+            {
+                if (!PersistenSingleton<FF9TextTool>.Instance.UpdateFieldTextNow(zoneId))
+                    continue;
+                String textAsMes = "";
+                String textAsHW = $"#HW filetype TEXT\n#HW language {symbol.ToLower()}\n#HW fileid {zoneId}\n\n";
+                for (Int32 i = 0; i < FF9TextTool.fieldText.Length; i++)
+                {
+                    String sentence = FF9TextTool.FieldText(i);
+                    textAsMes += ProcessStringForStrtMes(sentence);
+                    if (sentence.EndsWith("[ENDN]"))
+                        sentence = sentence.Substring(0, sentence.Length - 6);
+                    textAsHW += $"#HW newtext {i + 1}\n{sentence}\n\n"; // TODO: have HW handle non-shifted text ID
+                }
+                File.WriteAllText($"{exportDirectoryMes}{zoneId}.mes", textAsMes);
+                File.WriteAllText($"{exportDirectoryHW}{FF9DBAll.MesDB[zoneId]}.txt", textAsHW);
+            }
+            Log.Message("[TranslationExporter] Done.");
+        }
+
+        private static void ExportBattleTexts(String symbol, String modFolder)
+        {
+            Log.Message("[TranslationExporter] Exporting battle texts...");
+            String exportDirectoryMes = $"{modFolder}FF9_Data/EmbeddedAsset/Text/{symbol}/Battle/";
+            String exportDirectoryHW = $"{modFolder}HadesWorkshop/Battle/";
+            Directory.CreateDirectory(exportDirectoryMes);
+            Directory.CreateDirectory(exportDirectoryHW);
+            foreach (KeyValuePair<String, Int32> pair in FF9BattleDB.SceneData)
+            {
+                Int32 battleId = pair.Value;
+                if (!PersistenSingleton<FF9TextTool>.Instance.UpdateBattleTextNow(battleId))
+                    continue;
+                BTL_SCENE scene = new BTL_SCENE();
+                scene.ReadBattleScene(pair.Key.Substring(4));
+                Int32 typCount = scene.header.TypCount;
+                Int32 typAtkCount = typCount + scene.header.AtkCount;
+                if (typAtkCount == 0)
+                    continue;
+                String textAsMes = "";
+                String textAsHW = $"#HW filetype TEXT_BATTLE\n#HW language {symbol.ToLower()}\n#HW fileid {battleId}\n\n";
+                for (Int32 i = 0; i < FF9TextTool.battleText.Length; i++)
+                {
+                    String sentence = FF9TextTool.BattleText(i);
+                    textAsMes += ProcessStringForStrtMes(sentence);
+                    if (sentence.EndsWith("[ENDN]"))
+                        sentence = sentence.Substring(0, sentence.Length - 6);
+                    if (i < typCount)
+                        textAsHW += $"#HW enemyname {i}\n{sentence}\n\n";
+                    else if (i < typAtkCount)
+                        textAsHW += $"#HW attackname {i - typCount}\n{sentence}\n\n";
+                    else
+                        textAsHW += $"#HW text {i - typAtkCount}\n{sentence}\n\n";
+                }
+                File.WriteAllText($"{exportDirectoryMes}{battleId}.mes", textAsMes);
+                File.WriteAllText($"{exportDirectoryHW}{battleId}.txt", textAsHW);
+            }
+            Log.Message("[TranslationExporter] Done.");
+        }
+
+        private static void ExportCommandTexts(String symbol, String modFolder)
+        {
+            Log.Message("[TranslationExporter] Exporting command texts...");
+            String nameAsMes = "";
+            String helpAsMes = "";
+            String textAsHW = $"#HW filetype TEXT_COMMAND\n#HW language {symbol.ToLower()}\n\n";
+            Int32 idCounter = -1;
+            foreach (KeyValuePair<BattleCommandId, String> pair in FF9TextTool.commandName)
+            {
+                nameAsMes += ProcessStringForDatabaseMes(ref idCounter, pair.Value, (Int32)pair.Key);
+                textAsHW += $"#HW name {(Int32)pair.Key}\n{pair.Value}\n\n";
+                if (FF9TextTool.commandHelpDesc.TryGetValue(pair.Key, out String help))
+                    textAsHW += $"#HW help {(Int32)pair.Key}\n{help}\n\n";
+            }
+            foreach (KeyValuePair<BattleCommandId, String> pair in FF9TextTool.commandHelpDesc)
+                helpAsMes += ProcessStringForDatabaseMes(ref idCounter, pair.Value, (Int32)pair.Key);
+            String exportDirectoryMes = $"{modFolder}FF9_Data/EmbeddedAsset/Text/{symbol}/Command/";
+            String exportDirectoryHW = $"{modFolder}HadesWorkshop/Databases/";
+            Directory.CreateDirectory(exportDirectoryMes);
+            Directory.CreateDirectory(exportDirectoryHW);
+            File.WriteAllText($"{exportDirectoryMes}Com_Name.mes", nameAsMes);
+            File.WriteAllText($"{exportDirectoryMes}Com_Help.mes", helpAsMes);
+            File.WriteAllText($"{exportDirectoryHW}Commands.txt", textAsHW);
+            Log.Message("[TranslationExporter] Done.");
+        }
+
+        private static void ExportAbilityTexts(String symbol, String modFolder)
+        {
+            Log.Message("[TranslationExporter] Exporting active ability texts...");
+            String nameAsMes = "";
+            String helpAsMes = "";
+            String textAsHW = $"#HW filetype TEXT_ABILITY\n#HW language {symbol.ToLower()}\n\n";
+            Int32 idCounter = -1;
+            foreach (KeyValuePair<BattleAbilityId, String> pair in FF9TextTool.actionAbilityName)
+            {
+                nameAsMes += ProcessStringForDatabaseMes(ref idCounter, pair.Value, (Int32)pair.Key);
+                textAsHW += $"#HW name {(Int32)pair.Key}\n{pair.Value}\n\n";
+                if (FF9TextTool.actionAbilityHelpDesc.TryGetValue(pair.Key, out String help))
+                    textAsHW += $"#HW help {(Int32)pair.Key}\n{help}\n\n";
+            }
+            idCounter = -1;
+            foreach (KeyValuePair<BattleAbilityId, String> pair in FF9TextTool.actionAbilityHelpDesc)
+                helpAsMes += ProcessStringForDatabaseMes(ref idCounter, pair.Value, (Int32)pair.Key);
+            String exportDirectoryMes = $"{modFolder}FF9_Data/EmbeddedAsset/Text/{symbol}/Ability/";
+            String exportDirectoryHW = $"{modFolder}HadesWorkshop/Databases/";
+            Directory.CreateDirectory(exportDirectoryMes);
+            Directory.CreateDirectory(exportDirectoryHW);
+            File.WriteAllText($"{exportDirectoryMes}AA_Name.mes", nameAsMes);
+            File.WriteAllText($"{exportDirectoryMes}AA_Help.mes", helpAsMes);
+            File.WriteAllText($"{exportDirectoryHW}ActiveAbilities.txt", textAsHW);
+            Log.Message("[TranslationExporter] Done.");
+        }
+
+        private static void ExportSupportTexts(String symbol, String modFolder)
+        {
+            Log.Message("[TranslationExporter] Exporting supporting ability texts...");
+            String nameAsMes = "";
+            String helpAsMes = "";
+            String textAsHW = $"#HW filetype TEXT_SUPPORT\n#HW language {symbol.ToLower()}\n\n";
+            Int32 idCounter = -1;
+            foreach (KeyValuePair<SupportAbility, String> pair in FF9TextTool.supportAbilityName)
+            {
+                nameAsMes += ProcessStringForDatabaseMes(ref idCounter, pair.Value, (Int32)pair.Key);
+                textAsHW += $"#HW name {(Int32)pair.Key}\n{pair.Value}\n\n";
+                if (FF9TextTool.supportAbilityHelpDesc.TryGetValue(pair.Key, out String help))
+                    textAsHW += $"#HW help {(Int32)pair.Key}\n{help}\n\n";
+            }
+            idCounter = -1;
+            foreach (KeyValuePair<SupportAbility, String> pair in FF9TextTool.supportAbilityHelpDesc)
+                helpAsMes += ProcessStringForDatabaseMes(ref idCounter, pair.Value, (Int32)pair.Key);
+            String exportDirectoryMes = $"{modFolder}FF9_Data/EmbeddedAsset/Text/{symbol}/Ability/";
+            String exportDirectoryHW = $"{modFolder}HadesWorkshop/Databases/";
+            Directory.CreateDirectory(exportDirectoryMes);
+            Directory.CreateDirectory(exportDirectoryHW);
+            File.WriteAllText($"{exportDirectoryMes}SA_Name.mes", nameAsMes);
+            File.WriteAllText($"{exportDirectoryMes}SA_Help.mes", helpAsMes);
+            File.WriteAllText($"{exportDirectoryHW}SupportAbilities.txt", textAsHW);
+            Log.Message("[TranslationExporter] Done.");
+        }
+
+        private static void ExportItemTexts(String symbol, String modFolder)
+        {
+            Log.Message("[TranslationExporter] Exporting item texts...");
+            String nameAsMes = "";
+            String helpAsMes = "";
+            String btlHelpAsMes = "";
+            String textAsHW = $"#HW filetype TEXT_ITEM\n#HW language {symbol.ToLower()}\n\n";
+            Int32 idCounter = -1;
+            foreach (KeyValuePair<RegularItem, String> pair in FF9TextTool.itemName)
+            {
+                nameAsMes += ProcessStringForDatabaseMes(ref idCounter, pair.Value, (Int32)pair.Key);
+                textAsHW += $"#HW name {(Int32)pair.Key}\n{pair.Value}\n\n";
+                if (FF9TextTool.itemHelpDesc.TryGetValue(pair.Key, out String help))
+                    textAsHW += $"#HW help {(Int32)pair.Key}\n{help}\n\n";
+                if (FF9TextTool.itemBattleDesc.TryGetValue(pair.Key, out help))
+                    textAsHW += $"#HW battlehelp {(Int32)pair.Key}\n{help}\n\n";
+            }
+            idCounter = -1;
+            foreach (KeyValuePair<RegularItem, String> pair in FF9TextTool.itemHelpDesc)
+                helpAsMes += ProcessStringForDatabaseMes(ref idCounter, pair.Value, (Int32)pair.Key);
+            idCounter = -1;
+            foreach (KeyValuePair<RegularItem, String> pair in FF9TextTool.itemBattleDesc)
+                btlHelpAsMes += ProcessStringForDatabaseMes(ref idCounter, pair.Value, (Int32)pair.Key);
+            String exportDirectoryMes = $"{modFolder}FF9_Data/EmbeddedAsset/Text/{symbol}/Item/";
+            String exportDirectoryHW = $"{modFolder}HadesWorkshop/Databases/";
+            Directory.CreateDirectory(exportDirectoryMes);
+            Directory.CreateDirectory(exportDirectoryHW);
+            File.WriteAllText($"{exportDirectoryMes}Itm_Name.mes", nameAsMes);
+            File.WriteAllText($"{exportDirectoryMes}Itm_Help.mes", helpAsMes);
+            File.WriteAllText($"{exportDirectoryMes}Itm_Btl.mes", btlHelpAsMes);
+            File.WriteAllText($"{exportDirectoryHW}Items.txt", textAsHW);
+            Log.Message("[TranslationExporter] Done.");
+        }
+
+        private static void ExportKeyItemTexts(String symbol, String modFolder)
+        {
+            Log.Message("[TranslationExporter] Exporting key item texts...");
+            String nameAsMes = "";
+            String helpAsMes = "";
+            String descAsMes = "";
+            String textAsHW = $"#HW filetype TEXT_KEY_ITEM\n#HW language {symbol.ToLower()}\n\n";
+            Int32 idCounter = -1;
+            foreach (KeyValuePair<Int32, String> pair in FF9TextTool.importantItemName)
+            {
+                nameAsMes += ProcessStringForDatabaseMes(ref idCounter, pair.Value, pair.Key);
+                textAsHW += $"#HW name {pair.Key}\n{pair.Value}\n\n";
+                if (FF9TextTool.importantItemHelpDesc.TryGetValue(pair.Key, out String help))
+                    textAsHW += $"#HW help {pair.Key}\n{help}\n\n";
+                if (FF9TextTool.importantSkinDesc.TryGetValue(pair.Key, out help))
+                    textAsHW += $"#HW description {pair.Key}\n{help}\n\n";
+            }
+            idCounter = -1;
+            foreach (KeyValuePair<Int32, String> pair in FF9TextTool.importantItemHelpDesc)
+                helpAsMes += ProcessStringForDatabaseMes(ref idCounter, pair.Value, pair.Key);
+            idCounter = -1;
+            foreach (KeyValuePair<Int32, String> pair in FF9TextTool.importantSkinDesc)
+                descAsMes += ProcessStringForDatabaseMes(ref idCounter, pair.Value, pair.Key);
+            String exportDirectoryMes = $"{modFolder}FF9_Data/EmbeddedAsset/Text/{symbol}/KeyItem/";
+            String exportDirectoryHW = $"{modFolder}HadesWorkshop/Databases/";
+            Directory.CreateDirectory(exportDirectoryMes);
+            Directory.CreateDirectory(exportDirectoryHW);
+            File.WriteAllText($"{exportDirectoryMes}Imp_Name.mes", nameAsMes);
+            File.WriteAllText($"{exportDirectoryMes}Imp_Help.mes", helpAsMes);
+            File.WriteAllText($"{exportDirectoryMes}Imp_Skin.mes", descAsMes);
+            File.WriteAllText($"{exportDirectoryHW}KeyItems.txt", textAsHW);
+            Log.Message("[TranslationExporter] Done.");
+        }
+
+        private static void ExportLocationNames(String symbol, String modFolder)
+        {
+            Log.Message("[TranslationExporter] Exporting field location names...");
+            String textAsMes = "";
+            String textAsHW = $"#HW filetype TEXT_LOCATION\n#HW language {symbol.ToLower()}\n\n";
+            foreach (KeyValuePair<Int32, String> pair in FF9TextTool.LocationNames)
+            {
+                textAsMes += $"{pair.Key}:{pair.Value}\r\n";
+                textAsHW += $"#HW fieldname {pair.Key}\n{pair.Value}\n\n";
+            }
+            String exportDirectoryMes = $"{modFolder}FF9_Data/EmbeddedAsset/Text/{symbol}/Location/";
+            String exportDirectoryHW = $"{modFolder}HadesWorkshop/Databases/";
+            Directory.CreateDirectory(exportDirectoryMes);
+            Directory.CreateDirectory(exportDirectoryHW);
+            File.WriteAllText($"{exportDirectoryMes}Loc_Name.mes", textAsMes);
+            File.WriteAllText($"{exportDirectoryHW}Locations.txt", textAsHW);
+            Log.Message("[TranslationExporter] Done.");
+        }
+
+        private static void ExportCharacterNames(String symbol, String modFolder)
+        {
+            Log.Message("[TranslationExporter] Exporting character names...");
+            String textAsDP = "";
+            foreach (PLAYER player in FF9StateSystem.Common.FF9.PlayerList)
+                textAsDP += $"CharacterDefaultName {(Int32)player.Index} {symbol} {player.Name}\n";
+            File.WriteAllText($"{modFolder}DictionaryPatch.txt", textAsDP);
+            Log.Message("[TranslationExporter] Done.");
+        }
+
+        private static void ExportEtcTexts(String symbol, String modFolder)
+        {
+            Log.Message("[TranslationExporter] Exporting various UI texts...");
+            String exportDirectoryMes = $"{modFolder}FF9_Data/EmbeddedAsset/Text/{symbol}/Etc/";
+            String exportDirectoryHW = $"{modFolder}HadesWorkshop/Interface/";
+            Directory.CreateDirectory(exportDirectoryMes);
+            Directory.CreateDirectory(exportDirectoryHW);
+            foreach (EtcTextBatch block in _etcBatches)
+            {
+                String textAsMes = "";
+                String textAsHW = $"#HW filetype TEXT_INTERFACE\n#HW language {symbol.ToLower()}\n#HW fileid {block.hwId}\n\n";
+                for (Int32 i = 0; i < block.texts.Length; i++)
+                {
+                    textAsMes += $"{block.texts[i]}[ENDN]";
+                    textAsHW += $"#HW text {i}\n{block.texts[i]}\n\n";
+                }
+                File.WriteAllText($"{exportDirectoryMes}{block.fileName}.mes", textAsMes);
+                File.WriteAllText($"{exportDirectoryHW}{block.hwName}.txt", textAsHW);
+            }
+            {
+                String textAsMes = "";
+                String textAsHW = $"#HW filetype TEXT_INTERFACE\n#HW language {symbol.ToLower()}\n#HW fileid 6\n\n";
+                Int32 idCounter = -1;
+                foreach (KeyValuePair<TetraMasterCardId, String> pair in FF9TextTool.cardName)
+                {
+                    textAsMes += ProcessStringForDatabaseMes(ref idCounter, pair.Value, (Int32)pair.Key);
+                    textAsHW += $"#HW text {(Int32)pair.Key}\n{pair.Value}\n\n";
+                }
+                File.WriteAllText($"{exportDirectoryMes}Minista.mes", textAsMes);
+                File.WriteAllText($"{exportDirectoryHW}CardNames.txt", textAsHW);
+            }
+            Log.Message("[TranslationExporter] Done.");
+        }
+
+        private static void ExportLocalizationTexts(String symbol, String modFolder)
+        {
+            Log.Message("[TranslationExporter] Exporting localization texts...");
+            SortedList<String, String> allEntries = Localization.Provider.ProvideDictionary(symbol);
+            String exportDirectoryLoc = $"{modFolder}StreamingAssets/Data/Text/";
+            String exportDirectoryHW = $"{modFolder}HadesWorkshop/Interface/";
+            Directory.CreateDirectory(exportDirectoryLoc);
+            Directory.CreateDirectory(exportDirectoryHW);
+            String textAsLoc = "";
+            String textAsHW = $"#HW filetype TEXT_LOCALIZATION\n#HW language {symbol.ToLower()}\n\n";
+            foreach (String header in new String[] { "KEY", "Symbol" })
+            {
+                textAsLoc += $"{header},{Localization.ProcessEntryForCSVWriting(allEntries[header])}\n";
+                textAsHW += $"#HW entry {header}\n{allEntries[header]}\n\n";
+            }
+            foreach (KeyValuePair<String, String> pair in allEntries)
+            {
+                if (pair.Key == "KEY" || pair.Key == "Symbol")
+                    continue;
+                textAsLoc += $"{pair.Key},{Localization.ProcessEntryForCSVWriting(pair.Value)}\n";
+                textAsHW += $"#HW entry {pair.Key}\n{pair.Value}\n\n";
+            }
+            foreach (KeyValuePair<String, Dictionary<String, String>> dict in Localization.DefaultDictionary)
+            {
+                if (allEntries.ContainsKey(dict.Key))
+                    continue;
+                if (!dict.Value.TryGetValue(symbol, out String entry))
+                    continue;
+                textAsLoc += $"{dict.Key},{Localization.ProcessEntryForCSVWriting(entry)}\n";
+                textAsHW += $"#HW entry {dict.Key}\n{entry}\n\n";
+            }
+            File.WriteAllText($"{exportDirectoryLoc}LocalizationPatch.txt", textAsLoc);
+            File.WriteAllText($"{exportDirectoryHW}LocalizationEntries.txt", textAsHW);
+            Log.Message("[TranslationExporter] Done.");
+        }
+
+        private static void ExportPlaceTitles(String symbol, String modFolder)
+        {
+            Log.Message("[TranslationExporter] Exporting place titles...");
+            foreach (KeyValuePair<String, FieldMapLocalizeAreaTitleInfo> pair in FieldMapInfo.localizeAreaTitle.dict)
+            {
+                String scenePath = FieldMap.GetMapResourcePath(pair.Key);
+                String exportDirectory = $"{modFolder}StreamingAssets/Assets/Resources/{scenePath}";
+                Directory.CreateDirectory(exportDirectory);
+                BGSCENE_DEF scene = new BGSCENE_DEF(true);
+                scene.LoadResources(scenePath, pair.Key);
+                for (Int32 i = pair.Value.startOvrIdx; i <= pair.Value.endOvrIdx; i++)
+                {
+                    if (!scene.overlayList[i].isMemoria)
+                    {
+                        scene.atlas = TextureHelper.CopyAsReadable(scene.atlas, true);
+                        break;
+                    }
+                }
+                String bgxContent = $"USE_BASE_SCENE\nLANGUAGE: {symbol}\n\n";
+                for (Int32 i = pair.Value.startOvrIdx; i <= pair.Value.endOvrIdx; i++)
+                {
+                    bgxContent += $"OVERLAY\nOverlayId: {i}\n";
+                    bgxContent += scene.ExportMemoriaBGXOverlay(scene.overlayList[i], $"{exportDirectory}Title");
+                }
+                File.WriteAllText(exportDirectory + pair.Key + BGSCENE_DEF.MemoriaBGXExtension, bgxContent);
+                UnityEngine.Object.DestroyImmediate(scene.atlas);
+            }
+            Log.Message("[TranslationExporter] Done.");
+        }
+
+        private static void ExportContinentTitles(String symbol, String modFolder)
+        {
+            Log.Message("[TranslationExporter] Exporting continent titles...");
+            String textureDirectory = $"{modFolder}FF9_Data/EmbeddedAsset/UI/Sprites/{symbol}/";
+            String environmentCode = $"# Resize or reposition continent titles here\n# Rect has format (x, y, width, height)\n# where (x, y) is the central position of the title on the screen\n\n";
+            Directory.CreateDirectory(textureDirectory);
+            for (SByte titleId = 0; titleId < 4; titleId++)
+            {
+                foreach (Boolean isShadow in new Boolean[] { false, true })
+                {
+                    Sprite sprite = FF9UIDataTool.LoadWorldTitle(titleId, isShadow);
+                    Texture2D fullTexture = TextureHelper.CopyAsReadable(sprite.texture, true);
+                    Texture2D texture = TextureHelper.GetFragment(fullTexture, (Int32)sprite.rect.x, (Int32)sprite.rect.y, (Int32)sprite.rect.width, (Int32)sprite.rect.height);
+                    File.WriteAllBytes(textureDirectory + FF9UIDataTool.GetWorldTitleSpriteName(titleId, isShadow, symbol), texture.EncodeToPNG());
+                    UnityEngine.Object.DestroyImmediate(fullTexture);
+                    UnityEngine.Object.DestroyImmediate(texture);
+                }
+                Rect spriteRect = WorldConfiguration.GetTitleSpriteRect(titleId);
+                environmentCode += $"Title {WorldConfiguration.GetContinentName(titleId)} {symbol} [Rect=({(Int32)spriteRect.x}, {(Int32)spriteRect.y}, {(Int32)spriteRect.width}, {(Int32)spriteRect.height})]\n";
+            }
+            String exportEnvDirectory = $"{modFolder}StreamingAssets/Data/World/";
+            Directory.CreateDirectory(exportEnvDirectory);
+            File.WriteAllText($"{exportEnvDirectory}Environment.txt", environmentCode);
+            Log.Message("[TranslationExporter] Done.");
+        }
+
+        private static void ExportMessageAtlases(String symbol, String modFolder)
+        {
+            Log.Message("[TranslationExporter] Exporting message atlases...");
+            foreach (AtlasWithMessage messAtlas in _messageAtlases)
+            {
+                if (!messAtlas.languages.Contains(symbol))
+                    continue;
+                String exportPath = $"{modFolder}FF9_Data/{messAtlas.atlasPath}";
+                String exportDirectory = Path.GetDirectoryName(exportPath);
+                UIAtlas atlas = AssetManager.Load<UIAtlas>(messAtlas.atlasPath, true);
+                if (atlas != null)
+                {
+                    Directory.CreateDirectory(exportDirectory);
+                    GraphicResourceExporter.ExportAtlasSafe(exportPath, atlas, false);
+                }
+                else
+                {
+                    Sprite[] spriteList = Resources.LoadAll<Sprite>(messAtlas.atlasPath);
+                    if (spriteList == null || spriteList.Length == 0)
+                    {
+                        Log.Message($"[TranslationExporter] Failed to export '{exportPath}' as an atlas or a sprite list");
+                        continue;
+                    }
+                    Directory.CreateDirectory(exportDirectory);
+                    GraphicResourceExporter.ExportSpriteListSafe(exportPath, spriteList, false);
+                }
+            }
+            String titleImageDirectory = $"EmbeddedAsset/UI/Sprites/{symbol}/";
+            String exportDirectoryTitle = $"{modFolder}FF9_Data/{titleImageDirectory}";
+            Directory.CreateDirectory(exportDirectoryTitle);
+            for (Int32 i = 0; i < 8; i++)
+            {
+                for (Int32 j = 0; j < 2; j++)
+                {
+                    String texturePath = $"{titleImageDirectory}Title_Image_{i:D2}_Text{j}";
+                    Texture2D texture = AssetManager.Load<Texture2D>(texturePath, false);
+                    if (texture == null || texture.width <= 1 || texture.height <= 1)
+                        continue;
+                    texture = TextureHelper.CopyAsReadable(texture, true);
+                    TextureHelper.WriteTextureToFile(texture, $"{modFolder}FF9_Data/{texturePath}");
+                    UnityEngine.Object.DestroyImmediate(texture);
+                }
+            }
+            Log.Message("[TranslationExporter] Done.");
+        }
+
+        private static String ProcessStringForStrtMes(String str)
+        {
+            if (!str.StartsWith("[STRT=")) // Make sure the string starts with a [STRT] opcode...
+            {
+                Int32 width;
+                Int32 lineNo;
+                if (str.StartsWith("{W"))
+                {
+                    Int32 hPos = str.IndexOf('H');
+                    Int32 bePos = str.IndexOf('}');
+                    Int32.TryParse(str.Substring(2, hPos - 2), out width);
+                    Int32.TryParse(str.Substring(hPos + 1, bePos - hPos - 1), out lineNo);
+                    str = str.Substring(bePos + 1);
+                }
+                else
+                {
+                    width = 0;
+                    lineNo = 1;
+                    foreach (Char c in str)
+                        if (c == '\n')
+                            lineNo++;
+                }
+                str = $"[STRT={width},{lineNo}]" + str;
+            }
+            if (!str.EndsWith("]")) // ...and ends with either [ENDN] or [TIME=XXX]
+                str += "[ENDN]";
+            return str;
+        }
+
+        private static String ProcessStringForDatabaseMes(ref Int32 counter, String str, Int32 txtId)
+        {
+            Boolean addCounterCode = counter + 1 == txtId;
+            counter = txtId;
+            if (addCounterCode)
+                return $"[TXID={txtId}]{str}[ENDN]";
+            return str + "[ENDN]";
+        }
+
+        private class EtcTextBatch
+        {
+            public String fileName;
+            public String hwName;
+            public Int32 hwId;
+            public String[] texts;
+            public EtcTextBatch(String n, String hn, Int32 id, String[] t)
+            {
+                fileName = n;
+                hwName = hn;
+                hwId = id;
+                texts = t;
+            }
+        }
+
+        private class AtlasWithMessage
+        {
+            // TODO: Maybe register the specific sprites that are textual messages
+            public String atlasPath;
+            public HashSet<String> languages;
+            public AtlasWithMessage(String p, HashSet<String> l)
+            {
+                atlasPath = p;
+                languages = l;
+            }
+        }
+
+        private static EtcTextBatch[] _etcBatches;
+        private static AtlasWithMessage[] _messageAtlases;
+
+        private static void InitialiseStaticBatches()
+        {
+            _etcBatches =
+            [
+                new EtcTextBatch("WorldLoc", "WorldLocations", 0, FF9TextTool.worldLocationText),
+                new EtcTextBatch("Follow",   "BattleMessages", 1, FF9TextTool.followText),
+                new EtcTextBatch("Libra",    "ScanTexts",      2, FF9TextTool.libraText),
+                new EtcTextBatch("CmdTitle", "CommandTitles",  3, FF9TextTool.cmdTitleText),
+                new EtcTextBatch("FF9Choco", "Chocographs",    4, FF9TextTool.chocoUIText),
+                new EtcTextBatch("Card",     "CardRanks",      5, FF9TextTool.cardLvName),
+                //new EtcTextBatch("Minista","CardNames",      6, FF9TextTool.cardName),
+            ];
+            _messageAtlases =
+            [
+                new AtlasWithMessage("EmbeddedAsset/QuadMist/Atlas/QuadMist_Text_US",     new HashSet<String>{ "US" }),
+                new AtlasWithMessage("EmbeddedAsset/QuadMist/Atlas/QuadMist_Text_UK",     new HashSet<String>{ "UK" }),
+                new AtlasWithMessage("EmbeddedAsset/QuadMist/Atlas/QuadMist_Text_JP",     new HashSet<String>{ "JP" }),
+                new AtlasWithMessage("EmbeddedAsset/QuadMist/Atlas/QuadMist_Text_GR",     new HashSet<String>{ "GR" }),
+                new AtlasWithMessage("EmbeddedAsset/QuadMist/Atlas/QuadMist_Text_IT",     new HashSet<String>{ "IT" }),
+                new AtlasWithMessage("EmbeddedAsset/QuadMist/Atlas/QuadMist_Text_FR",     new HashSet<String>{ "FR" }),
+                new AtlasWithMessage("EmbeddedAsset/QuadMist/Atlas/QuadMist_Text_ES",     new HashSet<String>{ "ES" }),
+                new AtlasWithMessage("EmbeddedAsset/UI/Atlas/Ending_Text_FR_IT_ES_Atlas", new HashSet<String>{ "FR", "IT", "ES" }),
+                new AtlasWithMessage("EmbeddedAsset/UI/Atlas/Ending_Text_US_JP_GR_Atlas", new HashSet<String>{ "US", "UK", "JP", "GR" }),
+                new AtlasWithMessage("EmbeddedAsset/UI/Atlas/General Atlas",              new HashSet<String>{ "US", "UK", "JP", "GR", "FR", "IT", "ES" }),
+                new AtlasWithMessage("EmbeddedAsset/UI/Atlas/TutorialUI Atlas",           new HashSet<String>{ "US", "UK", "JP", "GR", "FR", "IT", "ES" }),
+            ];
+        }
+    }
+}

--- a/Assembly-CSharp/Memoria/Assets/Export/TranslationExporter.cs
+++ b/Assembly-CSharp/Memoria/Assets/Export/TranslationExporter.cs
@@ -501,7 +501,7 @@ namespace Memoria.Assets
 
         private static String ProcessStringForDatabaseMes(ref Int32 counter, String str, Int32 txtId)
         {
-            Boolean addCounterCode = counter + 1 == txtId;
+            Boolean addCounterCode = counter + 1 != txtId;
             counter = txtId;
             if (addCounterCode)
                 return $"[TXID={txtId}]{str}[ENDN]";
@@ -540,6 +540,8 @@ namespace Memoria.Assets
 
         private static void InitialiseStaticBatches()
         {
+            foreach (EtcImporter importer in EtcImporter.EnumerateImporters())
+                importer.LoadSync();
             _etcBatches =
             [
                 new EtcTextBatch("WorldLoc", "WorldLocations", 0, FF9TextTool.worldLocationText),

--- a/Assembly-CSharp/Memoria/Assets/FieldCreator/FieldCreatorScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/FieldCreator/FieldCreatorScene.cs
@@ -572,7 +572,7 @@ namespace Memoria.Assets
             {
                 scene.name = newName;
                 scene.ReadMemoriaBGS(filePath);
-                scene.CreateMemoriaScene(fieldMapGo.transform, freeCameraMode);
+                scene.CreatePureMemoriaScene(fieldMapGo.transform, freeCameraMode);
                 ChangeCameraSelection(cameraSelection, true);
                 ChangeOverlaySelection(overlaySelection);
             }
@@ -671,7 +671,7 @@ namespace Memoria.Assets
             freeCameraMode = free;
             shouldRefreshWalkmesh = true;
             DestroyMemoriaScene();
-            scene.CreateMemoriaScene(fieldMapGo.transform, freeCameraMode);
+            scene.CreatePureMemoriaScene(fieldMapGo.transform, freeCameraMode);
             SetupDummy();
             Camera camera = GetCamera();
             cameraPosition = free ? new Vector3(0f, 0f, -10000f) : Vector3.zero;

--- a/Assembly-CSharp/Memoria/Assets/Import/Text/BattleImporter.cs
+++ b/Assembly-CSharp/Memoria/Assets/Import/Text/BattleImporter.cs
@@ -79,8 +79,9 @@ namespace Memoria.Assets
             Int32 battleZoneId = FF9TextTool.BattleZoneId;
             String path = EmbadedTextResources.GetCurrentPath("/Battle/" + battleZoneId + ".mes");
             String[] text = EmbadedSentenseLoader.LoadSentense(path);
-            if (text != null)
-                FF9TextTool.SetBattleText(text);
+            if (text == null)
+                return false;
+            FF9TextTool.SetBattleText(text);
             return true;
         }
 

--- a/Assembly-CSharp/Memoria/Assets/Import/Text/TextImporter.cs
+++ b/Assembly-CSharp/Memoria/Assets/Import/Text/TextImporter.cs
@@ -27,6 +27,13 @@ namespace Memoria.Assets
                 throw new Exception("Failed to load embaded resources.");
         }
 
+        public Boolean LoadSync()
+        {
+            if (Configuration.Import.Text)
+                return LoadExternal();
+            return LoadInternal();
+        }
+
         protected abstract Boolean LoadExternal();
         protected abstract Boolean LoadInternal();
     }

--- a/Assembly-CSharp/Memoria/Assets/Text/Dialogs/DialogBoxRenderer.cs
+++ b/Assembly-CSharp/Memoria/Assets/Text/Dialogs/DialogBoxRenderer.cs
@@ -6,171 +6,171 @@ namespace Memoria.Assets
 {
     public class DialogBoxRenderer
     {
-        public static Boolean ProcessMemoriaTag(Char[] toCharArray, ref Int32 index, BetterList<Color> colors, ref Boolean highShadow, ref Boolean center, ref Boolean justified, ref Int32 ff9Signal, ref Vector3 extraOffset, ref Single tabX, ref Dialog.DialogImage insertImage)
+        public static Boolean ProcessMemoriaTag(Char[] toCharArray, ref Int32 index, FFIXTextModifier modifiers)
         {
-            Int32 num = index;
+            Int32 afterTag = index;
             Int32 left = toCharArray.Length - index;
-            FFIXTextTag tag = FFIXTextTag.TryRead(toCharArray, ref num, ref left);
+            FFIXTextTag tag = FFIXTextTag.TryRead(toCharArray, ref afterTag, ref left);
             if (tag == null)
                 return false;
 
             switch (tag.Code)
             {
                 case FFIXTextTagCode.Justified:
-                    justified = true;
+                    modifiers.justified = true;
                     break;
                 case FFIXTextTagCode.Center:
-                    center = true;
+                    modifiers.center = true;
                     break;
                 case FFIXTextTagCode.Signal:
-                    ff9Signal = 10 + tag.Param[0];
+                    modifiers.ff9Signal = 10 + tag.Param[0];
                     break;
                 case FFIXTextTagCode.IncreaseSignal:
-                    ff9Signal = 2;
+                    modifiers.ff9Signal = 2;
                     break;
                 case FFIXTextTagCode.IncreaseSignalEx:
-                    ff9Signal = 2;
+                    modifiers.ff9Signal = 2;
                     break;
                 case FFIXTextTagCode.DialogF:
-                    extraOffset.x += (tag.Param[0] >= FieldMap.HalfFieldWidth) ? 0f : (tag.Param[0] * UIManager.ResourceXMultipier);
+                    modifiers.extraOffset.x += (tag.Param[0] >= FieldMap.HalfFieldWidth) ? 0f : (tag.Param[0] * UIManager.ResourceXMultipier);
                     break;
                 case FFIXTextTagCode.DialogY:
-                    extraOffset.y -= tag.Param[0] * UIManager.ResourceYMultipier;
+                    modifiers.extraOffset.y -= tag.Param[0] * UIManager.ResourceYMultipier;
                     break;
                 case FFIXTextTagCode.DialogX:
                     if (tag.Param[0] == 224)
                         tag.Param[0] = 0;
-                    tabX = tag.Param[0] * UIManager.ResourceYMultipier;
+                    modifiers.tabX = tag.Param[0] * UIManager.ResourceYMultipier;
                     break;
                 case FFIXTextTagCode.Up:
-                    OnButton(out insertImage, index, false, "DBTN", "UP");
+                    OnButton(out modifiers.insertImage, index, false, "DBTN", "UP");
                     break;
                 case FFIXTextTagCode.Down:
-                    OnButton(out insertImage, index, false, "DBTN", "DOWN");
+                    OnButton(out modifiers.insertImage, index, false, "DBTN", "DOWN");
                     break;
                 case FFIXTextTagCode.Left:
-                    OnButton(out insertImage, index, false, "DBTN", "LEFT");
+                    OnButton(out modifiers.insertImage, index, false, "DBTN", "LEFT");
                     break;
                 case FFIXTextTagCode.Right:
-                    OnButton(out insertImage, index, false, "DBTN", "RIGHT");
+                    OnButton(out modifiers.insertImage, index, false, "DBTN", "RIGHT");
                     break;
                 case FFIXTextTagCode.Circle:
-                    OnButton(out insertImage, index, false, "DBTN", "CIRCLE");
+                    OnButton(out modifiers.insertImage, index, false, "DBTN", "CIRCLE");
                     break;
                 case FFIXTextTagCode.Cross:
-                    OnButton(out insertImage, index, false, "DBTN", "CROSS");
+                    OnButton(out modifiers.insertImage, index, false, "DBTN", "CROSS");
                     break;
                 case FFIXTextTagCode.Triangle:
-                    OnButton(out insertImage, index, false, "DBTN", "TRIANGLE");
+                    OnButton(out modifiers.insertImage, index, false, "DBTN", "TRIANGLE");
                     break;
                 case FFIXTextTagCode.Square:
-                    OnButton(out insertImage, index, false, "DBTN", "SQUARE");
+                    OnButton(out modifiers.insertImage, index, false, "DBTN", "SQUARE");
                     break;
                 case FFIXTextTagCode.R1:
-                    OnButton(out insertImage, index, false, "DBTN", "R1");
+                    OnButton(out modifiers.insertImage, index, false, "DBTN", "R1");
                     break;
                 case FFIXTextTagCode.R2:
-                    OnButton(out insertImage, index, false, "DBTN", "R2");
+                    OnButton(out modifiers.insertImage, index, false, "DBTN", "R2");
                     break;
                 case FFIXTextTagCode.L1:
-                    OnButton(out insertImage, index, false, "DBTN", "L1");
+                    OnButton(out modifiers.insertImage, index, false, "DBTN", "L1");
                     break;
                 case FFIXTextTagCode.L2:
-                    OnButton(out insertImage, index, false, "DBTN", "L2");
+                    OnButton(out modifiers.insertImage, index, false, "DBTN", "L2");
                     break;
                 case FFIXTextTagCode.Select:
-                    OnButton(out insertImage, index, false, "DBTN", "SELECT");
+                    OnButton(out modifiers.insertImage, index, false, "DBTN", "SELECT");
                     break;
                 case FFIXTextTagCode.Start:
-                    OnButton(out insertImage, index, false, "DBTN", "START");
+                    OnButton(out modifiers.insertImage, index, false, "DBTN", "START");
                     break;
                 case FFIXTextTagCode.Pad:
-                    OnButton(out insertImage, index, false, "DBTN", "PAD");
+                    OnButton(out modifiers.insertImage, index, false, "DBTN", "PAD");
                     break;
                 case FFIXTextTagCode.UpEx:
-                    OnButton(out insertImage, index, true, "CBTN", "UP");
+                    OnButton(out modifiers.insertImage, index, true, "CBTN", "UP");
                     break;
                 case FFIXTextTagCode.DownEx:
-                    OnButton(out insertImage, index, true, "CBTN", "DOWN");
+                    OnButton(out modifiers.insertImage, index, true, "CBTN", "DOWN");
                     break;
                 case FFIXTextTagCode.LeftEx:
-                    OnButton(out insertImage, index, true, "CBTN", "LEFT");
+                    OnButton(out modifiers.insertImage, index, true, "CBTN", "LEFT");
                     break;
                 case FFIXTextTagCode.RightEx:
-                    OnButton(out insertImage, index, true, "CBTN", "RIGHT");
+                    OnButton(out modifiers.insertImage, index, true, "CBTN", "RIGHT");
                     break;
                 case FFIXTextTagCode.CircleEx:
-                    OnButton(out insertImage, index, true, "CBTN", "CIRCLE");
+                    OnButton(out modifiers.insertImage, index, true, "CBTN", "CIRCLE");
                     break;
                 case FFIXTextTagCode.CrossEx:
-                    OnButton(out insertImage, index, true, "CBTN", "CROSS");
+                    OnButton(out modifiers.insertImage, index, true, "CBTN", "CROSS");
                     break;
                 case FFIXTextTagCode.TriangleEx:
-                    OnButton(out insertImage, index, true, "CBTN", "TRIANGLE");
+                    OnButton(out modifiers.insertImage, index, true, "CBTN", "TRIANGLE");
                     break;
                 case FFIXTextTagCode.SquareEx:
-                    OnButton(out insertImage, index, true, "CBTN", "SQUARE");
+                    OnButton(out modifiers.insertImage, index, true, "CBTN", "SQUARE");
                     break;
                 case FFIXTextTagCode.R1Ex:
-                    OnButton(out insertImage, index, true, "CBTN", "R1");
+                    OnButton(out modifiers.insertImage, index, true, "CBTN", "R1");
                     break;
                 case FFIXTextTagCode.R2Ex:
-                    OnButton(out insertImage, index, true, "CBTN", "R2");
+                    OnButton(out modifiers.insertImage, index, true, "CBTN", "R2");
                     break;
                 case FFIXTextTagCode.L1Ex:
-                    OnButton(out insertImage, index, true, "CBTN", "L1");
+                    OnButton(out modifiers.insertImage, index, true, "CBTN", "L1");
                     break;
                 case FFIXTextTagCode.L2Ex:
-                    OnButton(out insertImage, index, true, "CBTN", "L2");
+                    OnButton(out modifiers.insertImage, index, true, "CBTN", "L2");
                     break;
                 case FFIXTextTagCode.SelectEx:
-                    OnButton(out insertImage, index, true, "CBTN", "SELECT");
+                    OnButton(out modifiers.insertImage, index, true, "CBTN", "SELECT");
                     break;
                 case FFIXTextTagCode.StartEx:
-                    OnButton(out insertImage, index, true, "CBTN", "START");
+                    OnButton(out modifiers.insertImage, index, true, "CBTN", "START");
                     break;
                 case FFIXTextTagCode.PadEx:
-                    OnButton(out insertImage, index, true, "CBTN", "PAD");
+                    OnButton(out modifiers.insertImage, index, true, "CBTN", "PAD");
                     break;
                 case FFIXTextTagCode.Icon:
-                    OnIcon(index, out insertImage, tag.Param[0]);
+                    OnIcon(index, out modifiers.insertImage, tag.Param[0]);
                     break;
                 case FFIXTextTagCode.IconEx:
-                    OnIconEx(index, out insertImage);
+                    OnIconEx(index, out modifiers.insertImage);
                     break;
                 case FFIXTextTagCode.Mobile:
-                    OnMobileIcon(index, ref insertImage, tag.Param[0]);
+                    OnMobileIcon(index, ref modifiers.insertImage, tag.Param[0]);
                     break;
                 case FFIXTextTagCode.Tab:
-                    extraOffset.x += (18 - 4f) * UIManager.ResourceXMultipier;
+                    modifiers.extraOffset.x += (18 - 4f) * UIManager.ResourceXMultipier;
                     break;
                 case FFIXTextTagCode.White:
-                    OnColor(colors, "C8C8C8");
-                    highShadow = true;
+                    OnColor(modifiers.colors, "C8C8C8");
+                    modifiers.highShadow = true;
                     break;
                 case FFIXTextTagCode.Pink:
-                    OnColor(colors, "B880E0");
-                    highShadow = true;
+                    OnColor(modifiers.colors, "B880E0");
+                    modifiers.highShadow = true;
                     break;
                 case FFIXTextTagCode.Cyan:
-                    OnColor(colors, "68C0D8");
-                    highShadow = true;
+                    OnColor(modifiers.colors, "68C0D8");
+                    modifiers.highShadow = true;
                     break;
                 case FFIXTextTagCode.Brown:
-                    OnColor(colors, "D06050");
-                    highShadow = true;
+                    OnColor(modifiers.colors, "D06050");
+                    modifiers.highShadow = true;
                     break;
                 case FFIXTextTagCode.Yellow:
-                    OnColor(colors, "C8B040");
-                    highShadow = true;
+                    OnColor(modifiers.colors, "C8B040");
+                    modifiers.highShadow = true;
                     break;
                 case FFIXTextTagCode.Green:
-                    OnColor(colors, "78C840");
-                    highShadow = true;
+                    OnColor(modifiers.colors, "78C840");
+                    modifiers.highShadow = true;
                     break;
                 case FFIXTextTagCode.Grey:
-                    OnColor(colors, "909090");
-                    highShadow = true;
+                    OnColor(modifiers.colors, "909090");
+                    modifiers.highShadow = true;
                     break;
                 case FFIXTextTagCode.DialogSize:
                 case FFIXTextTagCode.Choice:
@@ -213,14 +213,14 @@ namespace Memoria.Assets
                 case FFIXTextTagCode.Table:
                 case FFIXTextTagCode.Widths:
                 case FFIXTextTagCode.NewPage:
-                    index = num;
+                    index = afterTag;
                     return true;
 
                 default:
                     return false;
             }
 
-            index = num;
+            index = afterTag;
             return true;
         }
 
@@ -231,91 +231,94 @@ namespace Memoria.Assets
             {
                 color.a = colors[colors.size - 1].a;
                 if (NGUIText.premultiply && color.a != 1f)
-                {
                     color = Color.Lerp(NGUIText.mInvisible, color, color.a);
-                }
                 colors.Add(color);
             }
         }
 
-        private static void PhraseRenderOpcodeSymbol(Char[] text, Int32 index, ref Int32 closingBracket, String tag, ref Boolean highShadow, ref Boolean center, ref Int32 ff9Signal, ref Vector3 extraOffset, ref Single tabX, ref Dialog.DialogImage insertImage)
+        private static void PhraseRenderOpcodeSymbol(Char[] text, Int32 index, ref Int32 closingBracket, String tag, FFIXTextModifier modifiers)
         {
             if (tag == NGUIText.Center)
             {
                 closingBracket = Array.IndexOf(text, ']', index + 4);
-                center = true;
+                modifiers.center = true;
             }
             else if (tag == NGUIText.Shadow)
             {
                 closingBracket = Array.IndexOf(text, ']', index + 4);
-                highShadow = !highShadow; // The tag seems to be used as a toggle (see issue #397)
+                modifiers.highShadow = !modifiers.highShadow; // The tag seems to be used as a toggle (see issue #397)
             }
             else if (tag == NGUIText.NoShadow)
             {
                 closingBracket = Array.IndexOf(text, ']', index + 4);
-                highShadow = false;
+                modifiers.highShadow = false;
             }
             else if (tag == NGUIText.Signal)
             {
-                Int32 oneParameterFromTag = NGUIText.GetOneParameterFromTag(text, index, ref closingBracket);
-                ff9Signal = 10 + oneParameterFromTag;
+                Int32 absoluteSignal = NGUIText.GetOneParameterFromTag(text, index, ref closingBracket);
+                modifiers.ff9Signal = 10 + absoluteSignal;
             }
             else if (tag == NGUIText.IncreaseSignal)
             {
                 closingBracket = Array.IndexOf(text, ']', index + 4);
-                ff9Signal = 2;
+                modifiers.ff9Signal = 2;
             }
             else if (tag == NGUIText.MessageFeed)
             {
-                Single[] allParameters = NGUIText.GetAllParameters(text, index, ref closingBracket);
-                extraOffset.x += ((allParameters[0] >= FieldMap.HalfFieldWidth) ? 0f : (allParameters[0] * UIManager.ResourceXMultipier));
+                Single[] offX = NGUIText.GetAllParameters(text, index, ref closingBracket);
+                modifiers.extraOffset.x += offX[0] >= FieldMap.HalfFieldWidth ? 0f : offX[0] * UIManager.ResourceXMultipier;
             }
             else if (tag == NGUIText.YSubOffset)
             {
-                Single[] allParameters2 = NGUIText.GetAllParameters(text, index, ref closingBracket);
-                extraOffset.y += allParameters2[0] * UIManager.ResourceYMultipier;
+                Single[] offY = NGUIText.GetAllParameters(text, index, ref closingBracket);
+                modifiers.extraOffset.y += offY[0] * UIManager.ResourceYMultipier;
             }
             else if (tag == NGUIText.YAddOffset)
             {
-                Single[] allParameters3 = NGUIText.GetAllParameters(text, index, ref closingBracket);
-                extraOffset.y -= allParameters3[0] * UIManager.ResourceYMultipier;
+                Single[] offY = NGUIText.GetAllParameters(text, index, ref closingBracket);
+                modifiers.extraOffset.y -= offY[0] * UIManager.ResourceYMultipier;
             }
             else if (tag == NGUIText.MessageTab)
             {
-                Single[] allParameters4 = NGUIText.GetAllParameters(text, index, ref closingBracket);
-                if (allParameters4[0] == 224f)
-                {
-                    allParameters4[0] = 0f;
-                }
-                tabX = allParameters4[0] * UIManager.ResourceYMultipier;
+                Single[] tabCount = NGUIText.GetAllParameters(text, index, ref closingBracket);
+                if (tabCount[0] == 224f)
+                    tabCount[0] = 0f;
+                modifiers.tabX = tabCount[0] * UIManager.ResourceYMultipier;
             }
             else if (tag == NGUIText.CustomButtonIcon || tag == NGUIText.ButtonIcon || tag == NGUIText.JoyStickButtonIcon || tag == NGUIText.KeyboardButtonIcon)
             {
                 closingBracket = Array.IndexOf(text, ']', index + 4);
-                String parameterStr = new String(text, index + 6, closingBracket - index - 6);
+                String btnCode = new String(text, index + 6, closingBracket - index - 6);
                 Boolean checkConfig = tag == NGUIText.CustomButtonIcon || tag == NGUIText.JoyStickButtonIcon;
-                OnButton(out insertImage, index, checkConfig, tag, parameterStr);
+                OnButton(out modifiers.insertImage, index, checkConfig, tag, btnCode);
             }
             else if (tag == NGUIText.IconVar)
             {
-                Int32 oneParameterFromTag2 = NGUIText.GetOneParameterFromTag(text, index, ref closingBracket);
-                OnIcon(index, out insertImage, oneParameterFromTag2);
+                Int32 iconID = NGUIText.GetOneParameterFromTag(text, index, ref closingBracket);
+                OnIcon(index, out modifiers.insertImage, iconID);
             }
             else if (tag == NGUIText.NewIcon)
             {
-                Int32 oneParameterFromTag3 = NGUIText.GetOneParameterFromTag(text, index, ref closingBracket);
-                OnIconEx(index, out insertImage);
+                Int32 scriptID = NGUIText.GetOneParameterFromTag(text, index, ref closingBracket);
+                OnIconEx(index, out modifiers.insertImage);
             }
             else if (tag == NGUIText.MobileIcon)
             {
-                Int32 oneParameterFromTag4 = NGUIText.GetOneParameterFromTag(text, index, ref closingBracket);
-                OnMobileIcon(index, ref insertImage, oneParameterFromTag4);
+                Int32 iconID = NGUIText.GetOneParameterFromTag(text, index, ref closingBracket);
+                OnMobileIcon(index, ref modifiers.insertImage, iconID);
+            }
+            else if (tag == NGUIText.IconSprite)
+            {
+                closingBracket = Array.IndexOf(text, ']', index + 4);
+                String spriteCode = new String(text, index + 6, closingBracket - index - 6);
+                modifiers.insertImage = NGUIText.CreateSpriteImage(spriteCode);
+                modifiers.insertImage.TextPosition = index;
             }
             else if (tag == NGUIText.TextOffset)
             {
-                Single[] allParameters5 = NGUIText.GetAllParameters(text, index, ref closingBracket);
-                extraOffset.x += (allParameters5[0] - 4f) * UIManager.ResourceXMultipier;
-                extraOffset.y -= allParameters5[1] * UIManager.ResourceYMultipier;
+                Single[] offXY = NGUIText.GetAllParameters(text, index, ref closingBracket);
+                modifiers.extraOffset.x += (offXY[0] - 4f) * UIManager.ResourceXMultipier;
+                modifiers.extraOffset.y -= offXY[1] * UIManager.ResourceYMultipier;
             }
             else
             {
@@ -350,30 +353,20 @@ namespace Memoria.Assets
             insertImage.TextPosition = index;
         }
 
-        public static Boolean ProcessOriginalTag(Char[] text, ref Int32 index, ref Boolean highShadow, ref Boolean center, ref Int32 ff9Signal, ref Vector3 extraOffset, ref Single tabX, ref Dialog.DialogImage insertImage)
+        public static Boolean ProcessOriginalTag(Char[] text, ref Int32 index, FFIXTextModifier modifiers)
         {
             if (index + 6 > text.Length || text[index] != '[')
                 return false;
 
-            Int32 num = index;
-            String a = new String(text, index, 5);
-            String[] renderOpcodeSymbols = NGUIText.RenderOpcodeSymbols;
-            for (Int32 i = 0; i < (Int32)renderOpcodeSymbols.Length; i++)
-            {
-                String text2 = renderOpcodeSymbols[i];
-                if (a == "[" + text2)
-                {
-                    PhraseRenderOpcodeSymbol(text, index, ref num, text2, ref highShadow, ref center, ref ff9Signal, ref extraOffset, ref tabX, ref insertImage);
-                    break;
-                }
-            }
-            if (num == index)
-            {
+            Int32 processedIndex = index;
+            String tag = new String(text, index + 1, 4);
+            if (NGUIText.RenderOpcodeSymbols.Contains(tag))
+                PhraseRenderOpcodeSymbol(text, index, ref processedIndex, tag, modifiers);
+            if (processedIndex == index)
                 return false;
-            }
-            if (num != -1)
+            if (processedIndex != -1)
             {
-                index = num + 1;
+                index = processedIndex + 1;
                 return true;
             }
             index = text.Length;

--- a/Assembly-CSharp/Memoria/Assets/Text/Dialogs/FFIXTextModifier.cs
+++ b/Assembly-CSharp/Memoria/Assets/Text/Dialogs/FFIXTextModifier.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using UnityEngine;
+
+namespace Memoria.Assets
+{
+    public class FFIXTextModifier
+    {
+        public BetterList<Color> colors = new BetterList<Color>();
+        public Int32 sub;
+        public Boolean bold;
+        public Boolean italic;
+        public Boolean underline;
+        public Boolean strike;
+        public Boolean ignoreColor;
+        public Boolean highShadow;
+        public Boolean center;
+        public Boolean justified;
+        public Int32 ff9Signal;
+        public Vector3 extraOffset;
+        public Single tabX;
+        public Dialog.DialogImage insertImage;
+
+        public void Reset()
+        {
+            colors.Clear();
+            sub = 0;
+            bold = false;
+            italic = false;
+            underline = false;
+            strike = false;
+            ignoreColor = false;
+            highShadow = false;
+            center = false;
+            justified = false;
+            ff9Signal = 0;
+            extraOffset = Vector3.zero;
+            tabX = 0f;
+            insertImage = null;
+        }
+    }
+}

--- a/Assembly-CSharp/Memoria/Assets/Text/GraphicResources.cs
+++ b/Assembly-CSharp/Memoria/Assets/Text/GraphicResources.cs
@@ -25,21 +25,23 @@ namespace Memoria.Assets
         public static readonly Dictionary<String, String> AtlasList = new Dictionary<String, String>
         {
             // May not be complete and/or correct
-            { "EndGame Atlas",              "EmbeddedAsset/EndGame/Prefabs/EndGame Atlas" }, // resources.assets
-            { "QuadMist Text ES Atlas",     "EmbeddedAsset/QuadMist/Atlas/QuadMist_Text_ES" },
+            // resources.assets
+            { "EndGame Atlas",              "EmbeddedAsset/EndGame/Prefabs/EndGame Atlas" },
+            { "QuadMist Text ES Atlas",     "EmbeddedAsset/QuadMist/Atlas/QuadMist_Text_ES" }, // Custom atlas not currently supported: see EndGameResourceManager
             { "QuadMist Text FR Atlas",     "EmbeddedAsset/QuadMist/Atlas/QuadMist_Text_FR" },
             { "QuadMist Text GR Atlas",     "EmbeddedAsset/QuadMist/Atlas/QuadMist_Text_GR" },
             { "QuadMist Text JP Atlas",     "EmbeddedAsset/QuadMist/Atlas/QuadMist_Text_JP" },
             { "QuadMist Text UK Atlas",     "EmbeddedAsset/QuadMist/Atlas/QuadMist_Text_UK" },
-            { "Ending_Text_FR_IT_ES_Atlas", "EmbeddedAsset/UI/Atlas/Ending Text FR IT ES Atlas" },
-            { "Card_Image",                 "EmbeddedAsset/EndGame/Card_Image" }, // sharedassets2.assets
-            { "QuadMist Image Atlas 0",     "EmbeddedAsset/QuadMist/Atlas/QuadMist_Image0" },
+            { "Ending_Text_FR_IT_ES_Atlas", "EmbeddedAsset/UI/Atlas/Ending_Text_FR_IT_ES_Atlas" },
+            // sharedassets2.assets
+            { "Card_Image",                 "EmbeddedAsset/EndGame/Card_Image" }, // Custom atlas not currently supported: see EndGameMain
+            { "QuadMist Image Atlas 0",     "EmbeddedAsset/QuadMist/Atlas/QuadMist_Image0" }, // Custom atlas not currently supported: see QuadMistResourceManager and QuadMistCardCursor
             { "QuadMist Image Atlas 1",     "EmbeddedAsset/QuadMist/Atlas/QuadMist_Image1" },
             { "QuadMist Text IT Atlas",     "EmbeddedAsset/QuadMist/Atlas/QuadMist_Text_IT" },
             { "QuadMist Text US Atlas",     "EmbeddedAsset/QuadMist/Atlas/QuadMist_Text_US" },
             { "Blue Atlas",                 "EmbeddedAsset/UI/Atlas/Blue Atlas" },
             { "Chocograph Atlas",           "EmbeddedAsset/UI/Atlas/Chocograph Atlas" },
-            { "Ending_Text_US_JP_GR_Atlas", "EmbeddedAsset/UI/Atlas/Ending Text US JP GR Atlas" },
+            { "Ending_Text_US_JP_GR_Atlas", "EmbeddedAsset/UI/Atlas/Ending_Text_US_JP_GR_Atlas" },
             { "Face Atlas",                 "EmbeddedAsset/UI/Atlas/Face Atlas" },
             { "General Atlas",              "EmbeddedAsset/UI/Atlas/General Atlas" },
             { "Gray Atlas",                 "EmbeddedAsset/UI/Atlas/Gray Atlas" },
@@ -63,14 +65,10 @@ namespace Memoria.Assets
         {
             public static String GetAtlasPath(String atlasName)
             {
-                String path = Configuration.Export.Path;
-                StringBuilder sb = new StringBuilder(path.Length + 32);
-                sb.Append(path);
-                if (sb.Length > 0 && sb[sb.Length - 1] != '/' && sb[sb.Length - 1] != '\\')
-                    sb.Append('/');
-                sb.Append("/UI/Atlas/");
-                sb.Append(atlasName);
-                return sb.ToString();
+                String path = Configuration.Export.Path.Replace('\\', '/');
+                if (path.Length > 0 && path[path.Length - 1] != '/')
+                    path += "/";
+                return $"{path}UI/Atlas/{atlasName}";
             }
         }
 
@@ -78,14 +76,10 @@ namespace Memoria.Assets
         {
             public static String GetAtlasPath(String atlasName)
             {
-                String path = Configuration.Import.Path;
-                StringBuilder sb = new StringBuilder(path.Length + 32);
-                sb.Append(path);
-                if (sb.Length > 0 && sb[sb.Length - 1] != '/' && sb[sb.Length - 1] != '\\')
-                    sb.Append('/');
-                sb.Append("/UI/Atlas/");
-                sb.Append(atlasName);
-                return sb.ToString();
+                String path = Configuration.Import.Path.Replace('\\', '/');
+                if (path.Length > 0 && path[path.Length - 1] != '/')
+                    path += "/";
+                return $"{path}UI/Atlas/{atlasName}";
             }
         }
     }

--- a/Assembly-CSharp/Memoria/Assets/Text/LanguageMap.cs
+++ b/Assembly-CSharp/Memoria/Assets/Text/LanguageMap.cs
@@ -12,6 +12,7 @@ namespace Memoria.Assets
     {
         private const String LanguageKey = "KEY";
         private const String SymbolKey = "Symbol";
+        private const String ReadingDirectionKey = "ReadingDirection";
 
         private readonly String[] _knownLanguages;
         private readonly Dictionary<String, SortedList<String, String>> _languages;
@@ -93,6 +94,7 @@ namespace Memoria.Assets
                 Log.Error($"[LocalizationDictionary] Cannot find localisation data for the language [{language}].");
             }
             _currentSymbol = Get(SymbolKey);
+            NGUIText.readingDirection = Localization.GetWithDefault(ReadingDirectionKey) == UnicodeBIDI.DIRECTION_NAME_RIGHT_TO_LEFT ? UnicodeBIDI.LanguageReadingDirection.RightToLeft : UnicodeBIDI.LanguageReadingDirection.LeftToRight;
             UIRoot.Broadcast("OnLocalize");
         }
 
@@ -141,7 +143,7 @@ namespace Memoria.Assets
         {
             while (reader.canRead)
             {
-                BetterList<String> cells = reader.ReadCSV();
+                BetterList<String> cells = reader.ReadCSV(); // TODO: change to allow [OPCODES=0,0] with commas
                 if (cells == null || cells.size < 2)
                     continue;
 

--- a/Assembly-CSharp/Memoria/Assets/Text/Localization.cs
+++ b/Assembly-CSharp/Memoria/Assets/Text/Localization.cs
@@ -55,6 +55,18 @@ namespace Memoria.Assets
 
         private static Dictionary<String, Dictionary<String, String>> _defaultDictionary = new Dictionary<String, Dictionary<String, String>>()
         {
+            // The base reading direction of the language
+            { "ReadingDirection", new Dictionary<String, String>()
+                {
+                    { "US", UnicodeBIDI.DIRECTION_NAME_LEFT_TO_RIGHT },
+                    { "UK", UnicodeBIDI.DIRECTION_NAME_LEFT_TO_RIGHT },
+                    { "JP", UnicodeBIDI.DIRECTION_NAME_LEFT_TO_RIGHT },
+                    { "ES", UnicodeBIDI.DIRECTION_NAME_LEFT_TO_RIGHT },
+                    { "FR", UnicodeBIDI.DIRECTION_NAME_LEFT_TO_RIGHT },
+                    { "GR", UnicodeBIDI.DIRECTION_NAME_LEFT_TO_RIGHT },
+                    { "IT", UnicodeBIDI.DIRECTION_NAME_LEFT_TO_RIGHT }
+                }
+            },
             // Language name in the title menu's button
             { "NameShort", new Dictionary<String, String>()
                 {

--- a/Assembly-CSharp/Memoria/Assets/Text/Localization.cs
+++ b/Assembly-CSharp/Memoria/Assets/Text/Localization.cs
@@ -14,6 +14,7 @@ namespace Memoria.Assets
         }
 
         public static ICollection<String> KnownLanguages => Provider.KnownLanguages;
+        public static Dictionary<String, Dictionary<String, String>> DefaultDictionary => _defaultDictionary;
 
         public static String CurrentLanguage
         {
@@ -29,6 +30,17 @@ namespace Memoria.Assets
         public static String Get(String key)
         {
             return Provider.Get(key);
+        }
+
+        public static String ProcessEntryForCSVWriting(String entry)
+        {
+            entry = entry.Replace("\n", "\\n");
+            if (entry.Contains("\"") || entry.Contains(","))
+            {
+                entry = entry.Replace("\"", "\"\"");
+                entry = "\"" + entry + "\"";
+            }
+            return entry;
         }
 
         /// <summary>Might be useful in the future to base a translation mod on another language</summary>
@@ -82,7 +94,13 @@ namespace Memoria.Assets
             // Gil formatiing in multiple menu
             { "GilSymbol", new Dictionary<String, String>()
                 {
-                    { "US", "%[YSUB=1.3][sub]G" }
+                    { "US", "%[YSUB=1.3][sub]G" },
+                    { "UK", "%[YSUB=1.3][sub]G" },
+                    { "JP", "%[YSUB=1.3][sub]G" },
+                    { "ES", "%[YSUB=1.3][sub]G" },
+                    { "FR", "%[YSUB=1.3][sub]G" },
+                    { "GR", "%[YSUB=1.3][sub]G" },
+                    { "IT", "%[YSUB=1.3][sub]G" }
                 }
             },
             // New options in the config menu

--- a/Assembly-CSharp/Memoria/Assets/Text/ResourceExporter.cs
+++ b/Assembly-CSharp/Memoria/Assets/Text/ResourceExporter.cs
@@ -20,6 +20,7 @@ namespace Memoria.Assets
                 GraphicResourceExporter.ExportSafe();
                 FieldSceneExporter.ExportSafe();
                 BattleSceneExporter.ExportSafe();
+                TranslationExporter.ExportSafe();
                 Log.Message("[ResourceExporter] Application will now quit. Please disable Configuration.Export.Enabled and restart the game.");
                 UIManager.Input.ConfirmQuit();
             }

--- a/Assembly-CSharp/Memoria/Assets/Text/Strings/UnicodeBIDI.cs
+++ b/Assembly-CSharp/Memoria/Assets/Text/Strings/UnicodeBIDI.cs
@@ -9,7 +9,7 @@ namespace Memoria.Assets
     //  https://www.w3.org/International/articles/inline-bidi-markup/uba-basics (summary of the BIDI algorithm)
     //  https://www.unicode.org/reports/tr44/ (overall Unicode database algorithms)
     //  https://www.unicode.org/reports/tr9/ (BIDI algorithm)
-    //  https://www.unicode.org/versions/Unicode10.0.0/ch09.pdf#G28212 (Character joinings and ligatures algorithm)
+    //  https://www.unicode.org/versions/Unicode15.0.0/ch09.pdf#G26848 (Character joinings and ligatures algorithm)
     // Databases:
     //  https://www.unicode.org/Public/16.0.0/ucd/extracted/DerivedBidiClass.txt (BIDI classes)
     //  https://www.unicode.org/Public/16.0.0/ucd/BidiMirroring.txt (BIDI characters to be mirrored in RTL)
@@ -29,6 +29,7 @@ namespace Memoria.Assets
             FullText = text;
             Int32 textLength = text.Length;
             Int32 index = 0;
+            Int32 closeIndex = 0;
             Int32 isolateCount = 0;
             Int32 overrideCount = 0;
             DirectionalStatus currentState = new DirectionalStatus
@@ -117,7 +118,7 @@ namespace Memoria.Assets
                         else
                         {
                             while (!currentState.isIsolate && !currentState.isOverride && !currentState.ltr && currentState.parent != null)
-                                DirectionalStatus.Pop(ref currentState, index);
+                                DirectionalStatus.Pop(ref currentState, closeIndex);
                             if (!currentState.ltr)
                                 DirectionalStatus.Push(ref currentState, index, true, OVERRIDE_STATUS_LTR, false, false);
                         }
@@ -132,7 +133,7 @@ namespace Memoria.Assets
                         else
                         {
                             while (!currentState.isIsolate && !currentState.isOverride && currentState.ltr && currentState.parent != null)
-                                DirectionalStatus.Pop(ref currentState, index);
+                                DirectionalStatus.Pop(ref currentState, closeIndex);
                             if (!currentState.ltr)
                                 DirectionalStatus.Push(ref currentState, index, false, OVERRIDE_STATUS_RTL, false, false);
                         }
@@ -154,6 +155,8 @@ namespace Memoria.Assets
                         break;
                 }
                 index++;
+                if (bidiClass != CharacterClass.White_Space && bidiClass != CharacterClass.Common_Separator && bidiClass != CharacterClass.European_Separator && bidiClass != CharacterClass.European_Terminator && bidiClass != CharacterClass.Segment_Separator && bidiClass != CharacterClass.Other_Neutral)
+                    closeIndex = index;
             }
             HashSet<Int32> pairPositions = new HashSet<Int32>();
             MustMirror = new HashSet<Int32>();

--- a/Assembly-CSharp/Memoria/Assets/Text/Strings/UnicodeBIDI.cs
+++ b/Assembly-CSharp/Memoria/Assets/Text/Strings/UnicodeBIDI.cs
@@ -1,0 +1,1484 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Memoria.Assets
+{
+    // Bi-directional algorithm for displaying text in left-to-right, right-to-left and mixed reading directions
+    // Note that Unity doesn't support Unicode characters that require UTF-16 surrogates (code points 0x10000 and higher)
+    // Documentations:
+    //  https://www.w3.org/International/articles/inline-bidi-markup/uba-basics (summary of the BIDI algorithm)
+    //  https://www.unicode.org/reports/tr44/ (overall Unicode database algorithms)
+    //  https://www.unicode.org/reports/tr9/ (BIDI algorithm)
+    //  https://www.unicode.org/versions/Unicode10.0.0/ch09.pdf#G28212 (Character joinings and ligatures algorithm)
+    // Databases:
+    //  https://www.unicode.org/Public/16.0.0/ucd/extracted/DerivedBidiClass.txt (BIDI classes)
+    //  https://www.unicode.org/Public/16.0.0/ucd/BidiMirroring.txt (BIDI characters to be mirrored in RTL)
+    //  https://www.unicode.org/Public/16.0.0/ucd/extracted/DerivedJoiningType.txt (Character shaping types, for cursive languages)
+    public class UnicodeBIDI
+    {
+        public const String DIRECTION_NAME_LEFT_TO_RIGHT = "Left_To_Right";
+        public const String DIRECTION_NAME_RIGHT_TO_LEFT = "Right_To_Left";
+
+        public readonly Char[] FullText;
+        public readonly Int32[] Reposition;
+        public readonly HashSet<Int32> MustMirror;
+
+        public UnicodeBIDI(Char[] text, LanguageReadingDirection paragraphDirection)
+        {
+            // Non-compliant implementation of the algorithm
+            FullText = text;
+            Int32 textLength = text.Length;
+            Int32 index = 0;
+            Int32 isolateCount = 0;
+            Int32 overrideCount = 0;
+            DirectionalStatus currentState = new DirectionalStatus
+            {
+                ltr = paragraphDirection == LanguageReadingDirection.LeftToRight,
+                isIsolate = false,
+                isOverride = false,
+                overrideStatus = OVERRIDE_STATUS_NEUTRAL,
+                start = index,
+                end = textLength
+            };
+            DirectionalStackRoot.Clear();
+            DirectionalStackRoot.Add(currentState);
+            while (index < textLength)
+            {
+                CharacterClass bidiClass = GetBIDIClass(text[index]);
+                switch (bidiClass)
+                {
+                    case CharacterClass.Right_To_Left_Embedding:
+                    case CharacterClass.Left_To_Right_Embedding:
+                        DirectionalStatus.Push(ref currentState, index, bidiClass == CharacterClass.Left_To_Right_Embedding, OVERRIDE_STATUS_NEUTRAL, false, true);
+                        overrideCount++;
+                        break;
+                    case CharacterClass.Right_To_Left_Override:
+                        DirectionalStatus.Push(ref currentState, index, false, OVERRIDE_STATUS_RTL, false, true);
+                        overrideCount++;
+                        break;
+                    case CharacterClass.Left_To_Right_Override:
+                        DirectionalStatus.Push(ref currentState, index, true, OVERRIDE_STATUS_LTR, false, true);
+                        overrideCount++;
+                        break;
+                    case CharacterClass.Right_To_Left_Isolate:
+                    case CharacterClass.Left_To_Right_Isolate:
+                    case CharacterClass.First_Strong_Isolate:
+                        DirectionalStatus.Push(ref currentState, index, bidiClass == CharacterClass.Left_To_Right_Isolate || (bidiClass == CharacterClass.First_Strong_Isolate && paragraphDirection == LanguageReadingDirection.LeftToRight), OVERRIDE_STATUS_NEUTRAL, true, false);
+                        isolateCount++;
+                        break;
+                    case CharacterClass.Pop_Directional_Format:
+                        if (overrideCount == 0)
+                            break;
+                        while (!currentState.isIsolate && !currentState.isOverride)
+                            DirectionalStatus.Pop(ref currentState, index);
+                        if (currentState.isOverride)
+                        {
+                            DirectionalStatus.Pop(ref currentState, index);
+                            overrideCount--;
+                        }
+                        break;
+                    case CharacterClass.Pop_Directional_Isolate:
+                        if (isolateCount == 0)
+                            break;
+                        while (!currentState.isIsolate)
+                        {
+                            if (currentState.isOverride)
+                                overrideCount--;
+                            DirectionalStatus.Pop(ref currentState, index);
+                        }
+                        if (currentState.isOverride)
+                            overrideCount--;
+                        DirectionalStatus.Pop(ref currentState, index);
+                        isolateCount--;
+                        break;
+                    case CharacterClass.Boundary_Neutral:
+                    case CharacterClass.Paragraph_Separator:
+                        while (currentState.parent != null)
+                            DirectionalStatus.Pop(ref currentState, index);
+                        currentState.end = index;
+                        currentState = new DirectionalStatus
+                        {
+                            ltr = paragraphDirection == LanguageReadingDirection.LeftToRight,
+                            isIsolate = false,
+                            isOverride = false,
+                            overrideStatus = OVERRIDE_STATUS_NEUTRAL,
+                            start = index + 1,
+                            end = textLength
+                        };
+                        DirectionalStackRoot.Add(currentState);
+                        overrideCount = isolateCount = 0;
+                        break;
+                    case CharacterClass.Left_To_Right:
+                        if (currentState.overrideStatus == OVERRIDE_STATUS_NEUTRAL)
+                        {
+                            currentState.ltr = true;
+                            currentState.overrideStatus = OVERRIDE_STATUS_LTR;
+                        }
+                        else
+                        {
+                            while (!currentState.isIsolate && !currentState.isOverride && !currentState.ltr && currentState.parent != null)
+                                DirectionalStatus.Pop(ref currentState, index);
+                            if (!currentState.ltr)
+                                DirectionalStatus.Push(ref currentState, index, true, OVERRIDE_STATUS_LTR, false, false);
+                        }
+                        break;
+                    case CharacterClass.Right_To_Left:
+                    case CharacterClass.Arabic_Letter:
+                        if (currentState.overrideStatus == OVERRIDE_STATUS_NEUTRAL)
+                        {
+                            currentState.ltr = false;
+                            currentState.overrideStatus = OVERRIDE_STATUS_RTL;
+                        }
+                        else
+                        {
+                            while (!currentState.isIsolate && !currentState.isOverride && currentState.ltr && currentState.parent != null)
+                                DirectionalStatus.Pop(ref currentState, index);
+                            if (!currentState.ltr)
+                                DirectionalStatus.Push(ref currentState, index, false, OVERRIDE_STATUS_RTL, false, false);
+                        }
+                        break;
+                    case CharacterClass.Arabic_Number:
+                    case CharacterClass.European_Number:
+                        if (currentState.overrideStatus == OVERRIDE_STATUS_RTL)
+                        {
+                            DirectionalStatus.Push(ref currentState, index, true, OVERRIDE_STATUS_LTR, false, false);
+                        }
+                        else
+                        {
+                            currentState.ltr = true;
+                            currentState.overrideStatus = OVERRIDE_STATUS_LTR;
+                        }
+                        break;
+                    default:
+                        // TODO: everything else is handled like a white space (eg. multiple European_Separator and/or Common_Separator cannot increase the level depth)
+                        break;
+                }
+                index++;
+            }
+            HashSet<Int32> pairPositions = new HashSet<Int32>();
+            MustMirror = new HashSet<Int32>();
+            Reposition = new Int32[FullText.Length];
+            for (Int32 i = 0; i < textLength; i++)
+                Reposition[i] = i;
+            foreach (DirectionalStatus lineStatus in DirectionalStackRoot)
+            {
+                foreach (DirectionalStatus status in lineStatus.GetAllDirectionChanges(true))
+                {
+                    ChangeDirection(Reposition, status.start, status.end - 1);
+                    for (Int32 i = status.start; i < status.end; i++)
+                    {
+                        Char ch = FullText[i];
+                        if (MirroringCharacters.ContainsKey(ch))
+                        {
+                            if (status.ltr)
+                                pairPositions.Remove(i);
+                            else
+                                pairPositions.Add(i);
+                        }
+                        else if (MirroringCharactersNoEquivalent.Contains(ch))
+                        {
+                            if (status.ltr)
+                                MustMirror.Remove(i);
+                            else
+                                MustMirror.Add(i);
+                        }
+                    }
+                }
+            }
+            for (Int32 i = 0; i < textLength; i++)
+                if (pairPositions.Contains(i))
+                    FullText[i] = GetMirroredCharacter(FullText[i]);
+            for (Int32 i = 0; i < textLength;)
+                ApplyWordJoining(ref i);
+            DirectionalStackRoot.Clear();
+        }
+
+        public static Char GetMirroredCharacter(Char c)
+        {
+            // TODO: Maybe apply the algorithm BD16 (https://www.unicode.org/reports/tr9/#BD16) instead of mirroring every bracket character, paired or not, in RTL
+            if (MirroringCharacters.TryGetValue(c, out Char mirror))
+                return mirror;
+            return c;
+        }
+
+        public void ApplyWordJoining(ref Int32 index)
+        {
+            Int32 chPos = index;
+            Char ch = FullText[index++];
+            Char transform, transformNext;
+            Boolean canJoin = false;
+            if (BeforeJoiningCharacters.TryGetValue(ch, out transform) || DualJoiningCharacters.TryGetValue(ch, out transform))
+            {
+                canJoin = true;
+            }
+            else if (JoinCausingCharacters.Contains(ch))
+            {
+                transform = ch;
+                canJoin = true;
+            }
+            while (canJoin && index < FullText.Length)
+            {
+                ch = FullText[index];
+                if (DualJoiningCharacters.TryGetValue(ch, out transformNext))
+                {
+                    FullText[chPos] = transform;
+                    chPos = index++;
+                    transform = transformNext;
+                    canJoin = true;
+                }
+                else if (AfterJoiningCharacters.TryGetValue(ch, out transformNext))
+                {
+                    FullText[chPos] = transform;
+                    FullText[index++] = transformNext;
+                    canJoin = false;
+                }
+                else if (JoinCausingCharacters.Contains(ch))
+                {
+                    FullText[chPos] = transform;
+                    chPos = index++;
+                    transform = ch;
+                    canJoin = true;
+                }
+                else if (IsJoinTransparent(ch))
+                {
+                    canJoin = true;
+                    ++index;
+                }
+                else
+                {
+                    canJoin = false;
+                    ++index;
+                }
+            }
+        }
+
+        public static CharacterClass GetBIDIClass(Char c)
+        {
+            if (c <= 0x058F)
+            {
+                if (c == '[') // Brackets, used for text opcodes, force a left-to-right isolate
+                    return CharacterClass.Left_To_Right_Isolate;
+                if (c == ']') // The game uses the special characters【】(0x3010 and 0x3011) for non-opcode brackets
+                    return CharacterClass.Pop_Directional_Isolate;
+                if (c >= 0x0000 && c <= 0x0008)
+                    return CharacterClass.Boundary_Neutral;
+                if (c == 0x000C || c == 0x0020)
+                    return CharacterClass.White_Space;
+                if (c == 0x000A || c == 0x000D || c >= 0x001C && c <= 0x001E || c == 0x0085)
+                    return CharacterClass.Paragraph_Separator;
+                if (c == 0x0009 || c == 0x000B || c == 001F)
+                    return CharacterClass.Segment_Separator;
+                if (c >= 0x000E && c <= 0x001B)
+                    return CharacterClass.Boundary_Neutral;
+                if (c == 0x0021 || c == 0x0022)
+                    return CharacterClass.Other_Neutral;
+                if (c >= 0x0023 && c <= 0x0025)
+                    return CharacterClass.European_Terminator;
+                if (c >= 0x0026 && c <= 0x002A)
+                    return CharacterClass.Other_Neutral;
+                if (c == 0x002B || c == 0x002D)
+                    return CharacterClass.European_Separator;
+                if (c == 0x002C || c == 0x002E || c == 0x002F || c == 0x003A || c == 0x00A0)
+                    return CharacterClass.Common_Separator;
+                if (c >= 0x0030 && c <= 0x0039 || c == 0x00B2 || c == 0x00B3 || c == 0x00B9)
+                    return CharacterClass.European_Number;
+                if (c >= 0x003B && c <= 0x0040 || c >= 0x005B && c <= 0x0060 || c >= 0x007B && c <= 0x007E || c == 0x00A1)
+                    return CharacterClass.Other_Neutral;
+                if (c >= 0x007F && c <= 0x009F)
+                    return CharacterClass.Boundary_Neutral;
+                if (c >= 0x00A2 && c <= 0x00A5 || c == 0x00B0 || c == 0x00B1 || c == 0x058F)
+                    return CharacterClass.European_Terminator;
+                if (c >= 0x00A6 && c <= 0x00AF)
+                    return c == 0x00AD ? CharacterClass.Boundary_Neutral : c == 0x00AA ? CharacterClass.Left_To_Right : CharacterClass.Other_Neutral;
+                if (c == 0x00B4 || c >= 0x00B6 && c <= 0x00B8 || c >= 0x00BB && c <= 0x00BF || c == 0x00D7 || c == 0x00F7 || c >= 0x02C2 && c <= 0x02CF || c >= 0x02D2 && c <= 0x02DF)
+                    return CharacterClass.Other_Neutral;
+                if (c == 0x02B9 || c == 0x02BA)
+                    return CharacterClass.Other_Neutral;
+                if (c >= 0x02E5 && c <= 0x02FF)
+                    return c == 0x02EE ? CharacterClass.Left_To_Right : CharacterClass.Other_Neutral;
+                if (c >= 0x0300 && c <= 0x036F || c >= 0x0483 && c <= 0x0489)
+                    return CharacterClass.Nonspacing_Mark;
+                if (c == 0x0374 || c == 0x0375 || c == 0x037E || c == 0x0384 || c == 0x0385 || c == 0x0387 || c == 0x03F6 || c == 0x058A || c == 0x058D || c == 0x058E)
+                    return CharacterClass.Other_Neutral;
+                return CharacterClass.Left_To_Right;
+            }
+            //else if (c >= 0x0590 && c <= 0x05FF)
+            //{
+            //    if (c >= 0x0591 && c <= 0x05BD || c == 0x05BF || c == 0x05C1 || c == 0x05C2 || c == 0x05C4 || c == 0x05C5 || c == 0x05C7)
+            //        return CharacterClass.Nonspacing_Mark;
+            //    return CharacterClass.Right_To_Left;
+            //}
+            else if (c >= 0x0600 && c <= 0x07BF)
+            {
+                if (c >= 0x0600 && c <= 0x0605)
+                    return CharacterClass.Arabic_Number;
+                if (c == 0x0606 || c == 0x0607 || c == 0x060E || c == 0x060F)
+                    return CharacterClass.Other_Neutral;
+                if (c == 0x0609 || c == 0x060A)
+                    return CharacterClass.European_Terminator;
+                if (c == 0x060C)
+                    return CharacterClass.Common_Separator;
+                if (c >= 0x0610 && c <= 0x061A || c >= 0x064B && c <= 0x065F || c == 0x0670)
+                    return CharacterClass.Nonspacing_Mark;
+                if (c >= 0x0660 && c <= 0x066C)
+                    return c == 0x066A ? CharacterClass.European_Terminator : CharacterClass.Arabic_Number;
+                if (c == 0x06DE || c == 0x06E9)
+                    return CharacterClass.Other_Neutral;
+                if (c >= 0x06D6 && c <= 0x06E4)
+                    return c == 0x06DD ? CharacterClass.Arabic_Number : CharacterClass.Nonspacing_Mark;
+                if (c == 0x06E7 || c == 0x06E8 || c >= 0x06EA && c <= 0x06ED)
+                    return CharacterClass.Nonspacing_Mark;
+                if (c >= 0x06F0 && c <= 0x06F9)
+                    return CharacterClass.European_Number;
+                if (c == 0x0711 || c >= 0x0730 && c <= 0x074A || c >= 0x07A6 && c <= 0x07B0)
+                    return CharacterClass.Nonspacing_Mark;
+                return CharacterClass.Arabic_Letter;
+            }
+            else if (c >= 0x07C0 && c <= 0x085F)
+            {
+                if (c >= 0x07EB && c <= 0x07F3 || c == 0x07FD)
+                    return CharacterClass.Nonspacing_Mark;
+                if (c >= 0x07F6 && c <= 0x07F9)
+                    return CharacterClass.Other_Neutral;
+                if (c >= 0x0816 && c <= 0x0819 || c >= 0x081B && c <= 0x0823 || c >= 0x0825 && c <= 0x0827 || c >= 0x0829 && c <= 0x082D || c >= 0x0859 && c <= 0x085B)
+                    return CharacterClass.Nonspacing_Mark;
+                return CharacterClass.Right_To_Left;
+            }
+            else if (c >= 0x0860 && c <= 0x08FF)
+            {
+                if (c == 0x0890 || c == 0x0891 || c == 0x08E2)
+                    return CharacterClass.Arabic_Number;
+                if (c >= 0x0897 && c <= 0x089F || c >= 0x08CA && c <= 0x08E1 || c >= 0x08E3 && c <= 0x0902)
+                    return CharacterClass.Nonspacing_Mark;
+                return CharacterClass.Arabic_Letter;
+            }
+            else if (c >= 0x20A0 && c <= 0x20CF)
+            {
+                return CharacterClass.European_Terminator;
+            }
+            else if (c >= 0xFB00 && c <= 0xFB4F)
+            {
+                if (c == 0xFB1E)
+                    return CharacterClass.Nonspacing_Mark;
+                if (c == 0xFB29)
+                    return CharacterClass.European_Separator;
+                return CharacterClass.Right_To_Left;
+            }
+            else if (c >= 0xFB50 && c <= 0xFDFF)
+            {
+                if (c >= 0xFD3E && c <= 0xFD4F)
+                    return CharacterClass.Other_Neutral;
+                if (c >= 0xFDD0 && c <= 0xFDEF)
+                    return CharacterClass.Boundary_Neutral;
+                if (c == 0xFDCF || c >= 0xFDFD && c <= 0xFDFF)
+                    return CharacterClass.Other_Neutral;
+                return CharacterClass.Arabic_Letter;
+            }
+            else if (c >= 0xFE70 && c <= 0xFEFF)
+            {
+                if (c == 0xFEFF)
+                    return CharacterClass.Boundary_Neutral;
+                return CharacterClass.Arabic_Letter;
+            }
+            if (SingleCharClass.TryGetValue(c, out CharacterClass bidiClass))
+                return bidiClass;
+            if (c >= 0x0941 && c <= 0x0948 || c >= 0x0951 && c <= 0x0957 || c >= 0x09C1 && c <= 0x09C4 || c >= 0x0A41 && c <= 0x0A51 || c >= 0x0AC1 && c <= 0x0AC8 || c >= 0x0AFA && c <= 0x0AFF || c >= 0x0B41 && c <= 0x0B44)
+                return CharacterClass.Nonspacing_Mark;
+            if (c >= 0x0BF3 && c <= 0x0BFA)
+                return CharacterClass.Other_Neutral;
+            if (c >= 0x0C3E && c <= 0x0C40 || c >= 0x0C46 && c <= 0x0C56 || c >= 0x0D41 && c <= 0x0D44 || c >= 0x0DD2 && c <= 0x0DD6 || c >= 0x0E34 && c <= 0x0E3A || c >= 0x0E47 && c <= 0x0E4E || c >= 0x0EB4 && c <= 0x0EBC || c >= 0x0EC8 && c <= 0x0ECE || c >= 0x0F71 && c <= 0x0F7E)
+                return CharacterClass.Nonspacing_Mark;
+            if (c >= 0x0C78 && c <= 0x0C7E || c >= 0x0F3A && c <= 0x0F3D || c >= 0x1390 && c <= 0x1399 || c >= 0x17F0 && c <= 0x17F9 || c >= 0x1800 && c <= 0x180A || c >= 0x19DE && c <= 0x19FF)
+                return CharacterClass.Other_Neutral;
+            if (c >= 0x0F80 && c <= 0x0F87)
+                return c == 0x0F85 ? CharacterClass.Left_To_Right : CharacterClass.Nonspacing_Mark;
+            if (c >= 0x0F8D && c <= 0x0FBC || c >= 0x102D && c <= 0x1030 || c >= 0x1032 && c <= 0x1037 || c >= 0x105E && c <= 0x1060 || c >= 0x1071 && c <= 0x1074 || c >= 0x135D && c <= 0x135F || c >= 0x1712 && c <= 0x1714 || c >= 0x17B7 && c <= 0x17BD || c >= 0x17C9 && c <= 0x17D3)
+                return CharacterClass.Nonspacing_Mark;
+            if (c >= 0x180B && c <= 0x180D || c >= 0x1920 && c <= 0x1922 || c >= 0x1939 && c <= 0x193B || c >= 0x1A58 && c <= 0x1A60 || c >= 0x1A65 && c <= 0x1A6C || c >= 0x1A73 && c <= 0x1A7F || c >= 0x1AB0 && c <= 0x1ACE || c >= 0x1B00 && c <= 0x1B03 || c >= 0x1B36 && c <= 0x1B3A)
+                return CharacterClass.Nonspacing_Mark;
+            if (c >= 0x1B6B && c <= 0x1B73 || c >= 0x1BA2 && c <= 0x1BA5 || c >= 0x1BAB && c <= 0x1BAD || c >= 0x1BEF && c <= 0x1BF1 || c >= 0x1C2C && c <= 0x1C33 || c >= 0x1CD0 && c <= 0x1CD2 || c >= 0x1CD4 && c <= 0x1CE0 || c >= 0x1CE2 && c <= 0x1CE8 || c >= 0x1DC0 && c <= 0x1DFF)
+                return CharacterClass.Nonspacing_Mark;
+            if (c >= 0x1FBF && c <= 0x1FC1 || c >= 0x1FCD && c <= 0x1FCF || c >= 0x1FDD && c <= 0x1FDF || c >= 0x1FED && c <= 0x1FEF || c >= 0x1FFD && c <= 0x1FFF)
+                return CharacterClass.Other_Neutral;
+            if (c >= 0x2000 && c <= 0x200A)
+                return CharacterClass.White_Space;
+            if (c >= 0x200B && c <= 0x200D)
+                return CharacterClass.Boundary_Neutral;
+            if (c >= 0x2010 && c <= 0x2027)
+                return CharacterClass.Other_Neutral;
+            if (c >= 0x2030 && c <= 0x2034)
+                return CharacterClass.European_Terminator;
+            if (c >= 0x2035 && c <= 0x205E)
+                return CharacterClass.Other_Neutral;
+            if (c >= 0x2060 && c <= 0x206F)
+                return CharacterClass.Boundary_Neutral;
+            if (c >= 0x2070 && c <= 0x2079)
+                return c == 0x2071 ? CharacterClass.Left_To_Right : CharacterClass.European_Number;
+            if (c >= 0x2080 && c <= 0x2089)
+                return CharacterClass.European_Number;
+            if (c >= 0x20D0 && c <= 0x20F0)
+                return CharacterClass.Nonspacing_Mark;
+            if (c >= 0x2103 && c <= 0x2106 || c >= 0x211E && c <= 0x2123 || c >= 0x2140 && c <= 0x2144 || c >= 0x214A && c <= 0x214D || c >= 0x2150 && c <= 0x215F || c >= 0x2189 && c <= 0x218B || c >= 0x2190 && c <= 0x2335 || c >= 0x2116 && c <= 0x2118)
+                return CharacterClass.Other_Neutral;
+            if (c >= 0x237B && c <= 0x2429)
+                return c == 0x2395 ? CharacterClass.Left_To_Right : CharacterClass.Other_Neutral;
+            if (c >= 0x2440 && c <= 0x244A || c >= 0x2460 && c <= 0x2487)
+                return CharacterClass.Other_Neutral;
+            if (c >= 0x2488 && c <= 0x249B)
+                return CharacterClass.European_Number;
+            if (c >= 0x24EA && c <= 0x27FF)
+                return c == 0x26AC ? CharacterClass.Left_To_Right : CharacterClass.Other_Neutral;
+            if (c >= 0x2900 && c <= 0x2BFF || c >= 0x2CE5 && c <= 0x2CEA || c >= 0x2CF9 && c <= 0x2CFF || c >= 0x2E00 && c <= 0x2E5D || c >= 0x2E80 && c <= 0x3004 || c >= 0x3008 && c <= 0x3020 || c >= 0x303D && c <= 0x303F)
+                return CharacterClass.Other_Neutral;
+            if (c >= 0x2CEF && c <= 0x2CF1 || c >= 0x2DE0 && c <= 0x2DFF || c >= 0x302A && c <= 0x302D)
+                return CharacterClass.Nonspacing_Mark;
+            if (c >= 0x31C0 && c <= 0x31E5 || c >= 0x3250 && c <= 0x325F || c >= 0x327C && c <= 0x327E || c >= 0x32B1 && c <= 0x32BF || c >= 0x32CC && c <= 0x32CF || c >= 0x3377 && c <= 0x337A || c >= 0x4DC0 && c <= 0x4DFF)
+                return CharacterClass.Other_Neutral;
+            if (c >= 0xA490 && c <= 0xA4C6 || c >= 0xA60D && c <= 0xA60F || c >= 0xA700 && c <= 0xA721 || c >= 0xA828 && c <= 0xA82B || c >= 0xA874 && c <= 0xA877)
+                return CharacterClass.Other_Neutral;
+            if (c >= 0xA66F && c <= 0xA672 || c >= 0xA674 && c <= 0xA67D || c >= 0xA8E0 && c <= 0xA8F1 || c >= 0xA926 && c <= 0xA92D || c >= 0xA947 && c <= 0xA951 || c >= 0xA980 && c <= 0xA982 || c >= 0xA9B6 && c <= 0xA9B9 || c >= 0xAA29 && c <= 0xAA2E || c >= 0xAAB2 && c <= 0xAAB4)
+                return CharacterClass.Nonspacing_Mark;
+            if (c >= 0xFE00 && c <= 0xFE0F || c >= 0xFE20 && c <= 0xFE2F)
+                return CharacterClass.Nonspacing_Mark;
+            if (c >= 0xFE10 && c <= 0xFE19 || c >= 0xFE30 && c <= 0xFE4F || c >= 0xFE56 && c <= 0xFE6B)
+                return CharacterClass.Other_Neutral;
+            if (c >= 0xFF01 && c <= 0xFF0A)
+                return CharacterClass.Other_Neutral;
+            if (c >= 0xFF10 && c <= 0xFF19)
+                return CharacterClass.European_Number;
+            if (c >= 0xFF1B && c <= 0xFF20 || c >= 0xFF3B && c <= 0xFF40 || c >= 0xFF5B && c <= 0xFF65 || c >= 0xFFE2 && c <= 0xFFEE)
+                return CharacterClass.Other_Neutral;
+            if (c >= 0xFFF0 && c <= 0xFFF8)
+                return CharacterClass.Boundary_Neutral;
+            if (c >= 0xFFF9 && c <= 0xFFFD)
+                return CharacterClass.Other_Neutral;
+            return CharacterClass.Left_To_Right;
+        }
+
+        private static void ChangeDirection(Int32[] array, Int32 start, Int32 endInclusive)
+        {
+            Int32 count = (endInclusive - start + 1) / 2;
+            Int32 tmp;
+            for (Int32 i = 0; i < count; i++)
+            {
+                tmp = array[start + i];
+                array[start + i] = array[endInclusive - i];
+                array[endInclusive - i] = tmp;
+            }
+        }
+
+        // Only supports (most) common and arabic characters
+        private static Boolean IsJoinTransparent(Char c)
+        {
+            if (c == 0x00AD || c >= 0x0300 && c <= 0x036F || c >= 0x0483 && c <= 0x0489 || c >= 0x0591 && c <= 0x05BD)
+                return true;
+            if (c >= 0x0610 && c <= 0x061A || c == 0x061C || c >= 0x064B && c <= 0x065F || c == 0x0670 || c >= 0x06D6 && c <= 0x06DC || c >= 0x06DF && c <= 0x06E4 || c == 0x06E7 || c == 0x06E8 || c >= 0x06EA && c <= 0x06ED)
+                return true;
+            if (c >= 0x1AB0 && c <= 0x1ACE || c >= 0x1DC0 && c <= 0x1DFF || c == 0x200B || c == 0x200E || c == 0x200F || c >= 0x202A && c <= 0x202E || c >= 0x2060 && c <= 0x2064 || c >= 0x206A && c <= 0x206F || c == 0xFEFF || c == 0xFEFF || c >= 0xFFF9 && c <= 0xFFFB)
+                return true;
+            return false;
+        }
+
+        // Note: this dictionary is not even initialized if BIDI is never used (no call to constructor nor "GetBIDIClass")
+        // Use of BIDI enum types don't trigger its static initialization
+        private static Dictionary<Char, CharacterClass> SingleCharClass = new Dictionary<Char, CharacterClass>()
+        {
+            { (Char)0x093A, CharacterClass.Nonspacing_Mark },
+            { (Char)0x093C, CharacterClass.Nonspacing_Mark },
+            { (Char)0x094D, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0962, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0963, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0981, CharacterClass.Nonspacing_Mark },
+            { (Char)0x09BC, CharacterClass.Nonspacing_Mark },
+            { (Char)0x09CD, CharacterClass.Nonspacing_Mark },
+            { (Char)0x09E2, CharacterClass.Nonspacing_Mark },
+            { (Char)0x09E3, CharacterClass.Nonspacing_Mark },
+            { (Char)0x09F2, CharacterClass.European_Terminator },
+            { (Char)0x09F3, CharacterClass.European_Terminator },
+            { (Char)0x09FB, CharacterClass.European_Terminator },
+            { (Char)0x09FE, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0A01, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0A02, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0A3C, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0A70, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0A71, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0A75, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0A81, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0A82, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0ABC, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0ACD, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0AE2, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0AE3, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0AF1, CharacterClass.European_Terminator },
+            { (Char)0x0B01, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0B3C, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0B3F, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0B4D, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0B55, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0B56, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0B62, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0B63, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0B82, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0BC0, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0BCD, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0BF9, CharacterClass.European_Terminator },
+            { (Char)0x0C00, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0C04, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0C3C, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0C62, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0C63, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0C81, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0CBC, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0CCC, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0CCD, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0CE2, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0CE3, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0D00, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0D01, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0D3B, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0D3C, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0D4D, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0D62, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0D63, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0D81, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0DCA, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0E31, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0E3F, CharacterClass.European_Terminator },
+            { (Char)0x0EB1, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0F18, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0F19, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0F35, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0F37, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0F39, CharacterClass.Nonspacing_Mark },
+            { (Char)0x0FC6, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1039, CharacterClass.Nonspacing_Mark },
+            { (Char)0x103A, CharacterClass.Nonspacing_Mark },
+            { (Char)0x103D, CharacterClass.Nonspacing_Mark },
+            { (Char)0x103E, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1058, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1059, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1082, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1085, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1086, CharacterClass.Nonspacing_Mark },
+            { (Char)0x108D, CharacterClass.Nonspacing_Mark },
+            { (Char)0x109D, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1400, CharacterClass.Other_Neutral },
+            { (Char)0x1680, CharacterClass.White_Space },
+            { (Char)0x169B, CharacterClass.Other_Neutral },
+            { (Char)0x169C, CharacterClass.Other_Neutral },
+            { (Char)0x1732, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1733, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1752, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1753, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1772, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1773, CharacterClass.Nonspacing_Mark },
+            { (Char)0x17B4, CharacterClass.Nonspacing_Mark },
+            { (Char)0x17B5, CharacterClass.Nonspacing_Mark },
+            { (Char)0x17C6, CharacterClass.Nonspacing_Mark },
+            { (Char)0x17DB, CharacterClass.European_Terminator },
+            { (Char)0x17DD, CharacterClass.Nonspacing_Mark },
+            { (Char)0x180E, CharacterClass.Boundary_Neutral },
+            { (Char)0x180F, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1885, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1886, CharacterClass.Nonspacing_Mark },
+            { (Char)0x18A9, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1927, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1928, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1932, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1940, CharacterClass.Other_Neutral },
+            { (Char)0x1944, CharacterClass.Other_Neutral },
+            { (Char)0x1945, CharacterClass.Other_Neutral },
+            { (Char)0x1A17, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1A18, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1A1B, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1A56, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1A62, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1B34, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1B3C, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1B42, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1B80, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1B81, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1BA8, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1BA9, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1BE6, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1BE8, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1BE9, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1BED, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1C36, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1C37, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1CED, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1CF4, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1CF8, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1CF9, CharacterClass.Nonspacing_Mark },
+            { (Char)0x1FBD, CharacterClass.Other_Neutral },
+            { (Char)0x200F, CharacterClass.Right_To_Left },
+            { (Char)0x2028, CharacterClass.White_Space },
+            { (Char)0x2029, CharacterClass.Paragraph_Separator },
+            { (Char)0x202A, CharacterClass.Left_To_Right_Embedding },
+            { (Char)0x202B, CharacterClass.Right_To_Left_Embedding },
+            { (Char)0x202C, CharacterClass.Pop_Directional_Format },
+            { (Char)0x202D, CharacterClass.Left_To_Right_Override },
+            { (Char)0x202E, CharacterClass.Right_To_Left_Override },
+            { (Char)0x202F, CharacterClass.Common_Separator },
+            { (Char)0x2044, CharacterClass.Common_Separator },
+            { (Char)0x205F, CharacterClass.White_Space },
+            { (Char)0x2066, CharacterClass.Left_To_Right_Isolate },
+            { (Char)0x2067, CharacterClass.Right_To_Left_Isolate },
+            { (Char)0x2068, CharacterClass.First_Strong_Isolate },
+            { (Char)0x2069, CharacterClass.Pop_Directional_Isolate },
+            { (Char)0x207A, CharacterClass.European_Separator },
+            { (Char)0x207B, CharacterClass.European_Separator },
+            { (Char)0x207C, CharacterClass.Other_Neutral },
+            { (Char)0x207D, CharacterClass.Other_Neutral },
+            { (Char)0x207E, CharacterClass.Other_Neutral },
+            { (Char)0x208A, CharacterClass.European_Separator },
+            { (Char)0x208B, CharacterClass.European_Separator },
+            { (Char)0x208C, CharacterClass.Other_Neutral },
+            { (Char)0x208D, CharacterClass.Other_Neutral },
+            { (Char)0x208E, CharacterClass.Other_Neutral },
+            { (Char)0x2100, CharacterClass.Other_Neutral },
+            { (Char)0x2101, CharacterClass.Other_Neutral },
+            { (Char)0x2108, CharacterClass.Other_Neutral },
+            { (Char)0x2109, CharacterClass.Other_Neutral },
+            { (Char)0x2114, CharacterClass.Other_Neutral },
+            { (Char)0x2125, CharacterClass.Other_Neutral },
+            { (Char)0x2127, CharacterClass.Other_Neutral },
+            { (Char)0x2129, CharacterClass.Other_Neutral },
+            { (Char)0x212E, CharacterClass.European_Terminator },
+            { (Char)0x213A, CharacterClass.Other_Neutral },
+            { (Char)0x213B, CharacterClass.Other_Neutral },
+            { (Char)0x2212, CharacterClass.European_Separator },
+            { (Char)0x2213, CharacterClass.European_Terminator },
+            { (Char)0x2D7F, CharacterClass.Nonspacing_Mark },
+            { (Char)0x3000, CharacterClass.White_Space },
+            { (Char)0x3030, CharacterClass.Other_Neutral },
+            { (Char)0x3036, CharacterClass.Other_Neutral },
+            { (Char)0x3037, CharacterClass.Other_Neutral },
+            { (Char)0x3099, CharacterClass.Nonspacing_Mark },
+            { (Char)0x309A, CharacterClass.Nonspacing_Mark },
+            { (Char)0x309B, CharacterClass.Other_Neutral },
+            { (Char)0x309C, CharacterClass.Other_Neutral },
+            { (Char)0x30A0, CharacterClass.Other_Neutral },
+            { (Char)0x30FB, CharacterClass.Other_Neutral },
+            { (Char)0x31EF, CharacterClass.Other_Neutral },
+            { (Char)0x321D, CharacterClass.Other_Neutral },
+            { (Char)0x321E, CharacterClass.Other_Neutral },
+            { (Char)0x33DE, CharacterClass.Other_Neutral },
+            { (Char)0x33DF, CharacterClass.Other_Neutral },
+            { (Char)0x33FF, CharacterClass.Other_Neutral },
+            { (Char)0xA673, CharacterClass.Other_Neutral },
+            { (Char)0xA67E, CharacterClass.Other_Neutral },
+            { (Char)0xA67F, CharacterClass.Other_Neutral },
+            { (Char)0xA69E, CharacterClass.Nonspacing_Mark },
+            { (Char)0xA69F, CharacterClass.Nonspacing_Mark },
+            { (Char)0xA6F0, CharacterClass.Nonspacing_Mark },
+            { (Char)0xA6F1, CharacterClass.Nonspacing_Mark },
+            { (Char)0xA788, CharacterClass.Other_Neutral },
+            { (Char)0xA802, CharacterClass.Nonspacing_Mark },
+            { (Char)0xA806, CharacterClass.Nonspacing_Mark },
+            { (Char)0xA80B, CharacterClass.Nonspacing_Mark },
+            { (Char)0xA825, CharacterClass.Nonspacing_Mark },
+            { (Char)0xA826, CharacterClass.Nonspacing_Mark },
+            { (Char)0xA82C, CharacterClass.Nonspacing_Mark },
+            { (Char)0xA838, CharacterClass.European_Terminator },
+            { (Char)0xA839, CharacterClass.European_Terminator },
+            { (Char)0xA8C4, CharacterClass.Nonspacing_Mark },
+            { (Char)0xA8C5, CharacterClass.Nonspacing_Mark },
+            { (Char)0xA8FF, CharacterClass.Nonspacing_Mark },
+            { (Char)0xA9B3, CharacterClass.Nonspacing_Mark },
+            { (Char)0xA9BC, CharacterClass.Nonspacing_Mark },
+            { (Char)0xA9BD, CharacterClass.Nonspacing_Mark },
+            { (Char)0xA9E5, CharacterClass.Nonspacing_Mark },
+            { (Char)0xAA31, CharacterClass.Nonspacing_Mark },
+            { (Char)0xAA32, CharacterClass.Nonspacing_Mark },
+            { (Char)0xAA35, CharacterClass.Nonspacing_Mark },
+            { (Char)0xAA36, CharacterClass.Nonspacing_Mark },
+            { (Char)0xAA43, CharacterClass.Nonspacing_Mark },
+            { (Char)0xAA4C, CharacterClass.Nonspacing_Mark },
+            { (Char)0xAA7C, CharacterClass.Nonspacing_Mark },
+            { (Char)0xAAB0, CharacterClass.Nonspacing_Mark },
+            { (Char)0xAAB7, CharacterClass.Nonspacing_Mark },
+            { (Char)0xAAB8, CharacterClass.Nonspacing_Mark },
+            { (Char)0xAABE, CharacterClass.Nonspacing_Mark },
+            { (Char)0xAABF, CharacterClass.Nonspacing_Mark },
+            { (Char)0xAAC1, CharacterClass.Nonspacing_Mark },
+            { (Char)0xAAEC, CharacterClass.Nonspacing_Mark },
+            { (Char)0xAAED, CharacterClass.Nonspacing_Mark },
+            { (Char)0xAAF6, CharacterClass.Nonspacing_Mark },
+            { (Char)0xAB6A, CharacterClass.Other_Neutral },
+            { (Char)0xAB6B, CharacterClass.Other_Neutral },
+            { (Char)0xABE5, CharacterClass.Nonspacing_Mark },
+            { (Char)0xABE8, CharacterClass.Nonspacing_Mark },
+            { (Char)0xABED, CharacterClass.Nonspacing_Mark },
+            //{ (Char)0xFB29, CharacterClass.European_Separator },
+            { (Char)0xFE50, CharacterClass.Common_Separator },
+            { (Char)0xFE51, CharacterClass.Other_Neutral },
+            { (Char)0xFE52, CharacterClass.Common_Separator },
+            { (Char)0xFE54, CharacterClass.Other_Neutral },
+            { (Char)0xFE55, CharacterClass.Common_Separator },
+            { (Char)0xFE5F, CharacterClass.European_Terminator },
+            { (Char)0xFE62, CharacterClass.European_Separator },
+            { (Char)0xFE63, CharacterClass.European_Separator },
+            { (Char)0xFE69, CharacterClass.European_Terminator },
+            { (Char)0xFE6A, CharacterClass.European_Terminator },
+            { (Char)0xFF03, CharacterClass.European_Terminator },
+            { (Char)0xFF04, CharacterClass.European_Terminator },
+            { (Char)0xFF05, CharacterClass.European_Terminator },
+            { (Char)0xFF0B, CharacterClass.European_Separator },
+            { (Char)0xFF0C, CharacterClass.Common_Separator },
+            { (Char)0xFF0D, CharacterClass.European_Separator },
+            { (Char)0xFF0E, CharacterClass.Common_Separator },
+            { (Char)0xFF0F, CharacterClass.Common_Separator },
+            { (Char)0xFF1A, CharacterClass.Common_Separator },
+            { (Char)0xFFE0, CharacterClass.European_Terminator },
+            { (Char)0xFFE1, CharacterClass.European_Terminator },
+            { (Char)0xFFE5, CharacterClass.European_Terminator },
+            { (Char)0xFFE6, CharacterClass.European_Terminator },
+            { (Char)0xFFFE, CharacterClass.Boundary_Neutral },
+            { (Char)0xFFFF, CharacterClass.Boundary_Neutral }
+        };
+
+        private static Dictionary<Char, Char> MirroringCharacters = new Dictionary<Char, Char>()
+        {
+            { '(', ')' },
+            { ')', '(' },
+            { '<', '>' },
+            { '>', '<' },
+            //{ '[', ']' },
+            //{ ']', '[' },
+            { '{', '}' },
+            { '}', '{' },
+            { '«', '»' },
+            { '»', '«' },
+            { (Char)0x0F3A, (Char)0x0F3B },
+            { (Char)0x0F3B, (Char)0x0F3A },
+            { (Char)0x0F3C, (Char)0x0F3D },
+            { (Char)0x0F3D, (Char)0x0F3C },
+            { (Char)0x169B, (Char)0x169C },
+            { (Char)0x169C, (Char)0x169B },
+            { (Char)0x2039, (Char)0x203A },
+            { (Char)0x203A, (Char)0x2039 },
+            { (Char)0x2045, (Char)0x2046 },
+            { (Char)0x2046, (Char)0x2045 },
+            { (Char)0x207D, (Char)0x207E },
+            { (Char)0x207E, (Char)0x207D },
+            { (Char)0x208D, (Char)0x208E },
+            { (Char)0x208E, (Char)0x208D },
+            { (Char)0x2208, (Char)0x220B },
+            { (Char)0x2209, (Char)0x220C },
+            { (Char)0x220A, (Char)0x220D },
+            { (Char)0x220B, (Char)0x2208 },
+            { (Char)0x220C, (Char)0x2209 },
+            { (Char)0x220D, (Char)0x220A },
+            { (Char)0x2215, (Char)0x29F5 },
+            { (Char)0x221F, (Char)0x2BFE },
+            { (Char)0x2220, (Char)0x29A3 },
+            { (Char)0x2221, (Char)0x299B },
+            { (Char)0x2222, (Char)0x29A0 },
+            { (Char)0x2224, (Char)0x2AEE },
+            { (Char)0x223C, (Char)0x223D },
+            { (Char)0x223D, (Char)0x223C },
+            { (Char)0x2243, (Char)0x22CD },
+            { (Char)0x2245, (Char)0x224C },
+            { (Char)0x224C, (Char)0x2245 },
+            { (Char)0x2252, (Char)0x2253 },
+            { (Char)0x2253, (Char)0x2252 },
+            { (Char)0x2254, (Char)0x2255 },
+            { (Char)0x2255, (Char)0x2254 },
+            { (Char)0x2264, (Char)0x2265 },
+            { (Char)0x2265, (Char)0x2264 },
+            { (Char)0x2266, (Char)0x2267 },
+            { (Char)0x2267, (Char)0x2266 },
+            { (Char)0x2268, (Char)0x2269 },
+            { (Char)0x2269, (Char)0x2268 },
+            { (Char)0x226A, (Char)0x226B },
+            { (Char)0x226B, (Char)0x226A },
+            { (Char)0x226E, (Char)0x226F },
+            { (Char)0x226F, (Char)0x226E },
+            { (Char)0x2270, (Char)0x2271 },
+            { (Char)0x2271, (Char)0x2270 },
+            { (Char)0x2272, (Char)0x2273 },
+            { (Char)0x2273, (Char)0x2272 },
+            { (Char)0x2274, (Char)0x2275 },
+            { (Char)0x2275, (Char)0x2274 },
+            { (Char)0x2276, (Char)0x2277 },
+            { (Char)0x2277, (Char)0x2276 },
+            { (Char)0x2278, (Char)0x2279 },
+            { (Char)0x2279, (Char)0x2278 },
+            { (Char)0x227A, (Char)0x227B },
+            { (Char)0x227B, (Char)0x227A },
+            { (Char)0x227C, (Char)0x227D },
+            { (Char)0x227D, (Char)0x227C },
+            { (Char)0x227E, (Char)0x227F },
+            { (Char)0x227F, (Char)0x227E },
+            { (Char)0x2280, (Char)0x2281 },
+            { (Char)0x2281, (Char)0x2280 },
+            { (Char)0x2282, (Char)0x2283 },
+            { (Char)0x2283, (Char)0x2282 },
+            { (Char)0x2284, (Char)0x2285 },
+            { (Char)0x2285, (Char)0x2284 },
+            { (Char)0x2286, (Char)0x2287 },
+            { (Char)0x2287, (Char)0x2286 },
+            { (Char)0x2288, (Char)0x2289 },
+            { (Char)0x2289, (Char)0x2288 },
+            { (Char)0x228A, (Char)0x228B },
+            { (Char)0x228B, (Char)0x228A },
+            { (Char)0x228F, (Char)0x2290 },
+            { (Char)0x2290, (Char)0x228F },
+            { (Char)0x2291, (Char)0x2292 },
+            { (Char)0x2292, (Char)0x2291 },
+            { (Char)0x2298, (Char)0x29B8 },
+            { (Char)0x22A2, (Char)0x22A3 },
+            { (Char)0x22A3, (Char)0x22A2 },
+            { (Char)0x22A6, (Char)0x2ADE },
+            { (Char)0x22A8, (Char)0x2AE4 },
+            { (Char)0x22A9, (Char)0x2AE3 },
+            { (Char)0x22AB, (Char)0x2AE5 },
+            { (Char)0x22B0, (Char)0x22B1 },
+            { (Char)0x22B1, (Char)0x22B0 },
+            { (Char)0x22B2, (Char)0x22B3 },
+            { (Char)0x22B3, (Char)0x22B2 },
+            { (Char)0x22B4, (Char)0x22B5 },
+            { (Char)0x22B5, (Char)0x22B4 },
+            { (Char)0x22B6, (Char)0x22B7 },
+            { (Char)0x22B7, (Char)0x22B6 },
+            { (Char)0x22B8, (Char)0x27DC },
+            { (Char)0x22C9, (Char)0x22CA },
+            { (Char)0x22CA, (Char)0x22C9 },
+            { (Char)0x22CB, (Char)0x22CC },
+            { (Char)0x22CC, (Char)0x22CB },
+            { (Char)0x22CD, (Char)0x2243 },
+            { (Char)0x22D0, (Char)0x22D1 },
+            { (Char)0x22D1, (Char)0x22D0 },
+            { (Char)0x22D6, (Char)0x22D7 },
+            { (Char)0x22D7, (Char)0x22D6 },
+            { (Char)0x22D8, (Char)0x22D9 },
+            { (Char)0x22D9, (Char)0x22D8 },
+            { (Char)0x22DA, (Char)0x22DB },
+            { (Char)0x22DB, (Char)0x22DA },
+            { (Char)0x22DC, (Char)0x22DD },
+            { (Char)0x22DD, (Char)0x22DC },
+            { (Char)0x22DE, (Char)0x22DF },
+            { (Char)0x22DF, (Char)0x22DE },
+            { (Char)0x22E0, (Char)0x22E1 },
+            { (Char)0x22E1, (Char)0x22E0 },
+            { (Char)0x22E2, (Char)0x22E3 },
+            { (Char)0x22E3, (Char)0x22E2 },
+            { (Char)0x22E4, (Char)0x22E5 },
+            { (Char)0x22E5, (Char)0x22E4 },
+            { (Char)0x22E6, (Char)0x22E7 },
+            { (Char)0x22E7, (Char)0x22E6 },
+            { (Char)0x22E8, (Char)0x22E9 },
+            { (Char)0x22E9, (Char)0x22E8 },
+            { (Char)0x22EA, (Char)0x22EB },
+            { (Char)0x22EB, (Char)0x22EA },
+            { (Char)0x22EC, (Char)0x22ED },
+            { (Char)0x22ED, (Char)0x22EC },
+            { (Char)0x22F0, (Char)0x22F1 },
+            { (Char)0x22F1, (Char)0x22F0 },
+            { (Char)0x22F2, (Char)0x22FA },
+            { (Char)0x22F3, (Char)0x22FB },
+            { (Char)0x22F4, (Char)0x22FC },
+            { (Char)0x22F6, (Char)0x22FD },
+            { (Char)0x22F7, (Char)0x22FE },
+            { (Char)0x22FA, (Char)0x22F2 },
+            { (Char)0x22FB, (Char)0x22F3 },
+            { (Char)0x22FC, (Char)0x22F4 },
+            { (Char)0x22FD, (Char)0x22F6 },
+            { (Char)0x22FE, (Char)0x22F7 },
+            { (Char)0x2308, (Char)0x2309 },
+            { (Char)0x2309, (Char)0x2308 },
+            { (Char)0x230A, (Char)0x230B },
+            { (Char)0x230B, (Char)0x230A },
+            { (Char)0x2329, (Char)0x232A },
+            { (Char)0x232A, (Char)0x2329 },
+            { (Char)0x2768, (Char)0x2769 },
+            { (Char)0x2769, (Char)0x2768 },
+            { (Char)0x276A, (Char)0x276B },
+            { (Char)0x276B, (Char)0x276A },
+            { (Char)0x276C, (Char)0x276D },
+            { (Char)0x276D, (Char)0x276C },
+            { (Char)0x276E, (Char)0x276F },
+            { (Char)0x276F, (Char)0x276E },
+            { (Char)0x2770, (Char)0x2771 },
+            { (Char)0x2771, (Char)0x2770 },
+            { (Char)0x2772, (Char)0x2773 },
+            { (Char)0x2773, (Char)0x2772 },
+            { (Char)0x2774, (Char)0x2775 },
+            { (Char)0x2775, (Char)0x2774 },
+            { (Char)0x27C3, (Char)0x27C4 },
+            { (Char)0x27C4, (Char)0x27C3 },
+            { (Char)0x27C5, (Char)0x27C6 },
+            { (Char)0x27C6, (Char)0x27C5 },
+            { (Char)0x27C8, (Char)0x27C9 },
+            { (Char)0x27C9, (Char)0x27C8 },
+            { (Char)0x27CB, (Char)0x27CD },
+            { (Char)0x27CD, (Char)0x27CB },
+            { (Char)0x27D5, (Char)0x27D6 },
+            { (Char)0x27D6, (Char)0x27D5 },
+            { (Char)0x27DC, (Char)0x22B8 },
+            { (Char)0x27DD, (Char)0x27DE },
+            { (Char)0x27DE, (Char)0x27DD },
+            { (Char)0x27E2, (Char)0x27E3 },
+            { (Char)0x27E3, (Char)0x27E2 },
+            { (Char)0x27E4, (Char)0x27E5 },
+            { (Char)0x27E5, (Char)0x27E4 },
+            { (Char)0x27E6, (Char)0x27E7 },
+            { (Char)0x27E7, (Char)0x27E6 },
+            { (Char)0x27E8, (Char)0x27E9 },
+            { (Char)0x27E9, (Char)0x27E8 },
+            { (Char)0x27EA, (Char)0x27EB },
+            { (Char)0x27EB, (Char)0x27EA },
+            { (Char)0x27EC, (Char)0x27ED },
+            { (Char)0x27ED, (Char)0x27EC },
+            { (Char)0x27EE, (Char)0x27EF },
+            { (Char)0x27EF, (Char)0x27EE },
+            { (Char)0x2983, (Char)0x2984 },
+            { (Char)0x2984, (Char)0x2983 },
+            { (Char)0x2985, (Char)0x2986 },
+            { (Char)0x2986, (Char)0x2985 },
+            { (Char)0x2987, (Char)0x2988 },
+            { (Char)0x2988, (Char)0x2987 },
+            { (Char)0x2989, (Char)0x298A },
+            { (Char)0x298A, (Char)0x2989 },
+            { (Char)0x298B, (Char)0x298C },
+            { (Char)0x298C, (Char)0x298B },
+            { (Char)0x298D, (Char)0x2990 },
+            { (Char)0x298E, (Char)0x298F },
+            { (Char)0x298F, (Char)0x298E },
+            { (Char)0x2990, (Char)0x298D },
+            { (Char)0x2991, (Char)0x2992 },
+            { (Char)0x2992, (Char)0x2991 },
+            { (Char)0x2993, (Char)0x2994 },
+            { (Char)0x2994, (Char)0x2993 },
+            { (Char)0x2995, (Char)0x2996 },
+            { (Char)0x2996, (Char)0x2995 },
+            { (Char)0x2997, (Char)0x2998 },
+            { (Char)0x2998, (Char)0x2997 },
+            { (Char)0x299B, (Char)0x2221 },
+            { (Char)0x29A0, (Char)0x2222 },
+            { (Char)0x29A3, (Char)0x2220 },
+            { (Char)0x29A4, (Char)0x29A5 },
+            { (Char)0x29A5, (Char)0x29A4 },
+            { (Char)0x29A8, (Char)0x29A9 },
+            { (Char)0x29A9, (Char)0x29A8 },
+            { (Char)0x29AA, (Char)0x29AB },
+            { (Char)0x29AB, (Char)0x29AA },
+            { (Char)0x29AC, (Char)0x29AD },
+            { (Char)0x29AD, (Char)0x29AC },
+            { (Char)0x29AE, (Char)0x29AF },
+            { (Char)0x29AF, (Char)0x29AE },
+            { (Char)0x29B8, (Char)0x2298 },
+            { (Char)0x29C0, (Char)0x29C1 },
+            { (Char)0x29C1, (Char)0x29C0 },
+            { (Char)0x29C4, (Char)0x29C5 },
+            { (Char)0x29C5, (Char)0x29C4 },
+            { (Char)0x29CF, (Char)0x29D0 },
+            { (Char)0x29D0, (Char)0x29CF },
+            { (Char)0x29D1, (Char)0x29D2 },
+            { (Char)0x29D2, (Char)0x29D1 },
+            { (Char)0x29D4, (Char)0x29D5 },
+            { (Char)0x29D5, (Char)0x29D4 },
+            { (Char)0x29D8, (Char)0x29D9 },
+            { (Char)0x29D9, (Char)0x29D8 },
+            { (Char)0x29DA, (Char)0x29DB },
+            { (Char)0x29DB, (Char)0x29DA },
+            { (Char)0x29E8, (Char)0x29E9 },
+            { (Char)0x29E9, (Char)0x29E8 },
+            { (Char)0x29F5, (Char)0x2215 },
+            { (Char)0x29F8, (Char)0x29F9 },
+            { (Char)0x29F9, (Char)0x29F8 },
+            { (Char)0x29FC, (Char)0x29FD },
+            { (Char)0x29FD, (Char)0x29FC },
+            { (Char)0x2A2B, (Char)0x2A2C },
+            { (Char)0x2A2C, (Char)0x2A2B },
+            { (Char)0x2A2D, (Char)0x2A2E },
+            { (Char)0x2A2E, (Char)0x2A2D },
+            { (Char)0x2A34, (Char)0x2A35 },
+            { (Char)0x2A35, (Char)0x2A34 },
+            { (Char)0x2A3C, (Char)0x2A3D },
+            { (Char)0x2A3D, (Char)0x2A3C },
+            { (Char)0x2A64, (Char)0x2A65 },
+            { (Char)0x2A65, (Char)0x2A64 },
+            { (Char)0x2A79, (Char)0x2A7A },
+            { (Char)0x2A7A, (Char)0x2A79 },
+            { (Char)0x2A7B, (Char)0x2A7C },
+            { (Char)0x2A7C, (Char)0x2A7B },
+            { (Char)0x2A7D, (Char)0x2A7E },
+            { (Char)0x2A7E, (Char)0x2A7D },
+            { (Char)0x2A7F, (Char)0x2A80 },
+            { (Char)0x2A80, (Char)0x2A7F },
+            { (Char)0x2A81, (Char)0x2A82 },
+            { (Char)0x2A82, (Char)0x2A81 },
+            { (Char)0x2A83, (Char)0x2A84 },
+            { (Char)0x2A84, (Char)0x2A83 },
+            { (Char)0x2A85, (Char)0x2A86 },
+            { (Char)0x2A86, (Char)0x2A85 },
+            { (Char)0x2A87, (Char)0x2A88 },
+            { (Char)0x2A88, (Char)0x2A87 },
+            { (Char)0x2A89, (Char)0x2A8A },
+            { (Char)0x2A8A, (Char)0x2A89 },
+            { (Char)0x2A8B, (Char)0x2A8C },
+            { (Char)0x2A8C, (Char)0x2A8B },
+            { (Char)0x2A8D, (Char)0x2A8E },
+            { (Char)0x2A8E, (Char)0x2A8D },
+            { (Char)0x2A8F, (Char)0x2A90 },
+            { (Char)0x2A90, (Char)0x2A8F },
+            { (Char)0x2A91, (Char)0x2A92 },
+            { (Char)0x2A92, (Char)0x2A91 },
+            { (Char)0x2A93, (Char)0x2A94 },
+            { (Char)0x2A94, (Char)0x2A93 },
+            { (Char)0x2A95, (Char)0x2A96 },
+            { (Char)0x2A96, (Char)0x2A95 },
+            { (Char)0x2A97, (Char)0x2A98 },
+            { (Char)0x2A98, (Char)0x2A97 },
+            { (Char)0x2A99, (Char)0x2A9A },
+            { (Char)0x2A9A, (Char)0x2A99 },
+            { (Char)0x2A9B, (Char)0x2A9C },
+            { (Char)0x2A9C, (Char)0x2A9B },
+            { (Char)0x2A9D, (Char)0x2A9E },
+            { (Char)0x2A9E, (Char)0x2A9D },
+            { (Char)0x2A9F, (Char)0x2AA0 },
+            { (Char)0x2AA0, (Char)0x2A9F },
+            { (Char)0x2AA1, (Char)0x2AA2 },
+            { (Char)0x2AA2, (Char)0x2AA1 },
+            { (Char)0x2AA6, (Char)0x2AA7 },
+            { (Char)0x2AA7, (Char)0x2AA6 },
+            { (Char)0x2AA8, (Char)0x2AA9 },
+            { (Char)0x2AA9, (Char)0x2AA8 },
+            { (Char)0x2AAA, (Char)0x2AAB },
+            { (Char)0x2AAB, (Char)0x2AAA },
+            { (Char)0x2AAC, (Char)0x2AAD },
+            { (Char)0x2AAD, (Char)0x2AAC },
+            { (Char)0x2AAF, (Char)0x2AB0 },
+            { (Char)0x2AB0, (Char)0x2AAF },
+            { (Char)0x2AB1, (Char)0x2AB2 },
+            { (Char)0x2AB2, (Char)0x2AB1 },
+            { (Char)0x2AB3, (Char)0x2AB4 },
+            { (Char)0x2AB4, (Char)0x2AB3 },
+            { (Char)0x2AB5, (Char)0x2AB6 },
+            { (Char)0x2AB6, (Char)0x2AB5 },
+            { (Char)0x2AB7, (Char)0x2AB8 },
+            { (Char)0x2AB8, (Char)0x2AB7 },
+            { (Char)0x2AB9, (Char)0x2ABA },
+            { (Char)0x2ABA, (Char)0x2AB9 },
+            { (Char)0x2ABB, (Char)0x2ABC },
+            { (Char)0x2ABC, (Char)0x2ABB },
+            { (Char)0x2ABD, (Char)0x2ABE },
+            { (Char)0x2ABE, (Char)0x2ABD },
+            { (Char)0x2ABF, (Char)0x2AC0 },
+            { (Char)0x2AC0, (Char)0x2ABF },
+            { (Char)0x2AC1, (Char)0x2AC2 },
+            { (Char)0x2AC2, (Char)0x2AC1 },
+            { (Char)0x2AC3, (Char)0x2AC4 },
+            { (Char)0x2AC4, (Char)0x2AC3 },
+            { (Char)0x2AC5, (Char)0x2AC6 },
+            { (Char)0x2AC6, (Char)0x2AC5 },
+            { (Char)0x2AC7, (Char)0x2AC8 },
+            { (Char)0x2AC8, (Char)0x2AC7 },
+            { (Char)0x2AC9, (Char)0x2ACA },
+            { (Char)0x2ACA, (Char)0x2AC9 },
+            { (Char)0x2ACB, (Char)0x2ACC },
+            { (Char)0x2ACC, (Char)0x2ACB },
+            { (Char)0x2ACD, (Char)0x2ACE },
+            { (Char)0x2ACE, (Char)0x2ACD },
+            { (Char)0x2ACF, (Char)0x2AD0 },
+            { (Char)0x2AD0, (Char)0x2ACF },
+            { (Char)0x2AD1, (Char)0x2AD2 },
+            { (Char)0x2AD2, (Char)0x2AD1 },
+            { (Char)0x2AD3, (Char)0x2AD4 },
+            { (Char)0x2AD4, (Char)0x2AD3 },
+            { (Char)0x2AD5, (Char)0x2AD6 },
+            { (Char)0x2AD6, (Char)0x2AD5 },
+            { (Char)0x2ADE, (Char)0x22A6 },
+            { (Char)0x2AE3, (Char)0x22A9 },
+            { (Char)0x2AE4, (Char)0x22A8 },
+            { (Char)0x2AE5, (Char)0x22AB },
+            { (Char)0x2AEC, (Char)0x2AED },
+            { (Char)0x2AED, (Char)0x2AEC },
+            { (Char)0x2AEE, (Char)0x2224 },
+            { (Char)0x2AF7, (Char)0x2AF8 },
+            { (Char)0x2AF8, (Char)0x2AF7 },
+            { (Char)0x2AF9, (Char)0x2AFA },
+            { (Char)0x2AFA, (Char)0x2AF9 },
+            { (Char)0x2BFE, (Char)0x221F },
+            { (Char)0x2E02, (Char)0x2E03 },
+            { (Char)0x2E03, (Char)0x2E02 },
+            { (Char)0x2E04, (Char)0x2E05 },
+            { (Char)0x2E05, (Char)0x2E04 },
+            { (Char)0x2E09, (Char)0x2E0A },
+            { (Char)0x2E0A, (Char)0x2E09 },
+            { (Char)0x2E0C, (Char)0x2E0D },
+            { (Char)0x2E0D, (Char)0x2E0C },
+            { (Char)0x2E1C, (Char)0x2E1D },
+            { (Char)0x2E1D, (Char)0x2E1C },
+            { (Char)0x2E20, (Char)0x2E21 },
+            { (Char)0x2E21, (Char)0x2E20 },
+            { (Char)0x2E22, (Char)0x2E23 },
+            { (Char)0x2E23, (Char)0x2E22 },
+            { (Char)0x2E24, (Char)0x2E25 },
+            { (Char)0x2E25, (Char)0x2E24 },
+            { (Char)0x2E26, (Char)0x2E27 },
+            { (Char)0x2E27, (Char)0x2E26 },
+            { (Char)0x2E28, (Char)0x2E29 },
+            { (Char)0x2E29, (Char)0x2E28 },
+            { (Char)0x2E55, (Char)0x2E56 },
+            { (Char)0x2E56, (Char)0x2E55 },
+            { (Char)0x2E57, (Char)0x2E58 },
+            { (Char)0x2E58, (Char)0x2E57 },
+            { (Char)0x2E59, (Char)0x2E5A },
+            { (Char)0x2E5A, (Char)0x2E59 },
+            { (Char)0x2E5B, (Char)0x2E5C },
+            { (Char)0x2E5C, (Char)0x2E5B },
+            { (Char)0x3008, (Char)0x3009 },
+            { (Char)0x3009, (Char)0x3008 },
+            { (Char)0x300A, (Char)0x300B },
+            { (Char)0x300B, (Char)0x300A },
+            { (Char)0x300C, (Char)0x300D },
+            { (Char)0x300D, (Char)0x300C },
+            { (Char)0x300E, (Char)0x300F },
+            { (Char)0x300F, (Char)0x300E },
+            { (Char)0x3010, (Char)0x3011 },
+            { (Char)0x3011, (Char)0x3010 },
+            { (Char)0x3014, (Char)0x3015 },
+            { (Char)0x3015, (Char)0x3014 },
+            { (Char)0x3016, (Char)0x3017 },
+            { (Char)0x3017, (Char)0x3016 },
+            { (Char)0x3018, (Char)0x3019 },
+            { (Char)0x3019, (Char)0x3018 },
+            { (Char)0x301A, (Char)0x301B },
+            { (Char)0x301B, (Char)0x301A },
+            { (Char)0xFE59, (Char)0xFE5A },
+            { (Char)0xFE5A, (Char)0xFE59 },
+            { (Char)0xFE5B, (Char)0xFE5C },
+            { (Char)0xFE5C, (Char)0xFE5B },
+            { (Char)0xFE5D, (Char)0xFE5E },
+            { (Char)0xFE5E, (Char)0xFE5D },
+            { (Char)0xFE64, (Char)0xFE65 },
+            { (Char)0xFE65, (Char)0xFE64 },
+            { (Char)0xFF08, (Char)0xFF09 },
+            { (Char)0xFF09, (Char)0xFF08 },
+            { (Char)0xFF1C, (Char)0xFF1E },
+            { (Char)0xFF1E, (Char)0xFF1C },
+            { (Char)0xFF3B, (Char)0xFF3D },
+            { (Char)0xFF3D, (Char)0xFF3B },
+            { (Char)0xFF5B, (Char)0xFF5D },
+            { (Char)0xFF5D, (Char)0xFF5B },
+            { (Char)0xFF5F, (Char)0xFF60 },
+            { (Char)0xFF60, (Char)0xFF5F },
+            { (Char)0xFF62, (Char)0xFF63 },
+            { (Char)0xFF63, (Char)0xFF62 }
+        };
+
+        private static HashSet<Char> MirroringCharactersNoEquivalent = new HashSet<Char>()
+        {
+            (Char)0x2140,
+            (Char)0x2201,
+            (Char)0x2202,
+            (Char)0x2203,
+            (Char)0x2204,
+            (Char)0x2211,
+            (Char)0x2216,
+            (Char)0x221A,
+            (Char)0x221B,
+            (Char)0x221C,
+            (Char)0x221D,
+            (Char)0x2226,
+            (Char)0x222B,
+            (Char)0x222C,
+            (Char)0x222D,
+            (Char)0x222E,
+            (Char)0x222F,
+            (Char)0x2230,
+            (Char)0x2231,
+            (Char)0x2232,
+            (Char)0x2233,
+            (Char)0x2239,
+            (Char)0x223B,
+            (Char)0x223E,
+            (Char)0x223F,
+            (Char)0x2240,
+            (Char)0x2241,
+            (Char)0x2242,
+            (Char)0x2244,
+            (Char)0x2246,
+            (Char)0x2247,
+            (Char)0x2248,
+            (Char)0x2249,
+            (Char)0x224A,
+            (Char)0x224B,
+            (Char)0x225F,
+            (Char)0x2260,
+            (Char)0x2262,
+            (Char)0x226D,
+            (Char)0x228C,
+            (Char)0x22A7,
+            (Char)0x22AA,
+            (Char)0x22AC,
+            (Char)0x22AD,
+            (Char)0x22AE,
+            (Char)0x22AF,
+            (Char)0x22BE,
+            (Char)0x22BF,
+            (Char)0x22F5,
+            (Char)0x22F8,
+            (Char)0x22F9,
+            (Char)0x22FF,
+            (Char)0x2320,
+            (Char)0x2321,
+            (Char)0x27C0,
+            (Char)0x27CC,
+            (Char)0x27D3,
+            (Char)0x27D4,
+            (Char)0x299C,
+            (Char)0x299D,
+            (Char)0x299E,
+            (Char)0x299F,
+            (Char)0x29A2,
+            (Char)0x29A6,
+            (Char)0x29A7,
+            (Char)0x29C2,
+            (Char)0x29C3,
+            (Char)0x29C9,
+            (Char)0x29CE,
+            (Char)0x29DC,
+            (Char)0x29E1,
+            (Char)0x29E3,
+            (Char)0x29E4,
+            (Char)0x29E5,
+            (Char)0x29F4,
+            (Char)0x29F6,
+            (Char)0x29F7,
+            (Char)0x2A0A,
+            (Char)0x2A0B,
+            (Char)0x2A0C,
+            (Char)0x2A0D,
+            (Char)0x2A0E,
+            (Char)0x2A0F,
+            (Char)0x2A10,
+            (Char)0x2A11,
+            (Char)0x2A12,
+            (Char)0x2A13,
+            (Char)0x2A14,
+            (Char)0x2A15,
+            (Char)0x2A16,
+            (Char)0x2A17,
+            (Char)0x2A18,
+            (Char)0x2A19,
+            (Char)0x2A1A,
+            (Char)0x2A1B,
+            (Char)0x2A1C,
+            (Char)0x2A1E,
+            (Char)0x2A1F,
+            (Char)0x2A20,
+            (Char)0x2A21,
+            (Char)0x2A24,
+            (Char)0x2A26,
+            (Char)0x2A29,
+            (Char)0x2A3E,
+            (Char)0x2A57,
+            (Char)0x2A58,
+            (Char)0x2A6A,
+            (Char)0x2A6B,
+            (Char)0x2A6C,
+            (Char)0x2A6D,
+            (Char)0x2A6F,
+            (Char)0x2A70,
+            (Char)0x2A73,
+            (Char)0x2A74,
+            (Char)0x2AA3,
+            (Char)0x2ADC,
+            (Char)0x2AE2,
+            (Char)0x2AE6,
+            (Char)0x2AF3,
+            (Char)0x2AFB,
+            (Char)0x2AFD
+        };
+
+        private static Dictionary<Char, Char> DualJoiningCharacters = new Dictionary<Char, Char>()
+        {
+            { (Char)0x0628, (Char)0xFE92 },
+            { (Char)0x062A, (Char)0xFE98 },
+            { (Char)0x062B, (Char)0xFE9C },
+            { (Char)0x062C, (Char)0xFEA0 },
+            { (Char)0x062D, (Char)0xFEA4 },
+            { (Char)0x062E, (Char)0xFEA8 },
+            { (Char)0x0633, (Char)0xFEB4 },
+            { (Char)0x0634, (Char)0xFEB8 },
+            { (Char)0x0635, (Char)0xFEBC },
+            { (Char)0x0636, (Char)0xFEC0 },
+            { (Char)0x0637, (Char)0xFEC4 },
+            { (Char)0x0638, (Char)0xFEC8 },
+            { (Char)0x0639, (Char)0xFECC },
+            { (Char)0x063A, (Char)0xFED0 },
+            { (Char)0x0641, (Char)0xFED4 },
+            { (Char)0x0642, (Char)0xFED8 },
+            { (Char)0x0643, (Char)0xFEDC },
+            { (Char)0x0644, (Char)0xFEE0 },
+            { (Char)0x0645, (Char)0xFEE4 },
+            { (Char)0x0646, (Char)0xFEE8 },
+            { (Char)0x0647, (Char)0xFEEC },
+            { (Char)0x064A, (Char)0xFEF4 },
+        };
+
+        private static Dictionary<Char, Char> BeforeJoiningCharacters = new Dictionary<Char, Char>()
+        {
+            { (Char)0x0628, (Char)0xFE91 },
+            { (Char)0x062A, (Char)0xFE97 },
+            { (Char)0x062B, (Char)0xFE9B },
+            { (Char)0x062C, (Char)0xFE9F },
+            { (Char)0x062D, (Char)0xFEA3 },
+            { (Char)0x062E, (Char)0xFEA7 },
+            { (Char)0x0633, (Char)0xFEB3 },
+            { (Char)0x0634, (Char)0xFEB7 },
+            { (Char)0x0635, (Char)0xFEBB },
+            { (Char)0x0636, (Char)0xFEBF },
+            { (Char)0x0637, (Char)0xFEC3 },
+            { (Char)0x0638, (Char)0xFEC7 },
+            { (Char)0x0639, (Char)0xFECB },
+            { (Char)0x063A, (Char)0xFECF },
+            { (Char)0x0641, (Char)0xFED3 },
+            { (Char)0x0642, (Char)0xFED7 },
+            { (Char)0x0643, (Char)0xFEDB },
+            { (Char)0x0644, (Char)0xFEDF },
+            { (Char)0x0645, (Char)0xFEE3 },
+            { (Char)0x0646, (Char)0xFEE7 },
+            { (Char)0x0647, (Char)0xFEEB },
+            { (Char)0x064A, (Char)0xFEF3 },
+        };
+
+        private static Dictionary<Char, Char> AfterJoiningCharacters = new Dictionary<Char, Char>()
+        {
+            { (Char)0x0627, (Char)0xFE8E },
+            { (Char)0x0628, (Char)0xFE90 },
+            { (Char)0x062A, (Char)0xFE96 },
+            { (Char)0x062B, (Char)0xFE9A },
+            { (Char)0x062C, (Char)0xFE9E },
+            { (Char)0x062D, (Char)0xFEA2 },
+            { (Char)0x062E, (Char)0xFEA6 },
+            { (Char)0x062F, (Char)0xFEAA },
+            { (Char)0x0630, (Char)0xFEAC },
+            { (Char)0x0631, (Char)0xFEAE },
+            { (Char)0x0632, (Char)0xFEB0 },
+            { (Char)0x0633, (Char)0xFEB2 },
+            { (Char)0x0634, (Char)0xFEB6 },
+            { (Char)0x0635, (Char)0xFEBA },
+            { (Char)0x0636, (Char)0xFEBE },
+            { (Char)0x0637, (Char)0xFEC2 },
+            { (Char)0x0638, (Char)0xFEC6 },
+            { (Char)0x0639, (Char)0xFECA },
+            { (Char)0x063A, (Char)0xFECE },
+            { (Char)0x0641, (Char)0xFED2 },
+            { (Char)0x0642, (Char)0xFED6 },
+            { (Char)0x0643, (Char)0xFEDA },
+            { (Char)0x0644, (Char)0xFEDE },
+            { (Char)0x0645, (Char)0xFEE2 },
+            { (Char)0x0646, (Char)0xFEE6 },
+            { (Char)0x0647, (Char)0xFEEA },
+            { (Char)0x0648, (Char)0xFEEE },
+            { (Char)0x064A, (Char)0xFEF2 },
+            { (Char)0x0622, (Char)0xFE82 },
+            { (Char)0x0629, (Char)0xFE94 },
+            { (Char)0x0649, (Char)0xFEF0 },
+        };
+
+        private static HashSet<Char> JoinCausingCharacters = new HashSet<Char>()
+        {
+            (Char)0x0640,
+            (Char)0x07FA,
+            (Char)0x0883,
+            (Char)0x0884,
+            (Char)0x0885,
+            (Char)0x180A,
+            (Char)0x200D
+        };
+
+        private static List<DirectionalStatus> DirectionalStackRoot = new List<DirectionalStatus>();
+
+        private class DirectionalStatus
+        {
+            public Boolean ltr;
+            public Boolean isIsolate;
+            public Boolean isOverride;
+            public Int32 overrideStatus;
+            public Int32 start;
+            public Int32 end;
+            public List<DirectionalStatus> lowerLevels = new List<DirectionalStatus>();
+            public DirectionalStatus parent = null;
+
+            public static void Push(ref DirectionalStatus status, Int32 pos, Boolean leftToRight, Int32 overrideState, Boolean isolate, Boolean over)
+            {
+                DirectionalStatus nextState = new DirectionalStatus
+                {
+                    parent = status,
+                    ltr = leftToRight,
+                    overrideStatus = overrideState,
+                    isIsolate = isolate,
+                    isOverride = over,
+                    start = pos
+                };
+                status.lowerLevels.Add(nextState);
+                status = nextState;
+            }
+
+            public static void Pop(ref DirectionalStatus status, Int32 pos)
+            {
+                status.end = pos;
+                status = status.parent;
+            }
+
+            public IEnumerable<DirectionalStatus> GetAllDirectionChanges(Boolean parentIsLTR)
+            {
+                if (parentIsLTR != ltr)
+                    yield return this;
+                foreach (DirectionalStatus status in lowerLevels)
+                    foreach (DirectionalStatus lower in status.GetAllDirectionChanges(ltr))
+                        yield return lower;
+            }
+        }
+
+        private const Int32 OVERRIDE_STATUS_NEUTRAL = 0;
+        private const Int32 OVERRIDE_STATUS_RTL = 1;
+        private const Int32 OVERRIDE_STATUS_LTR = 2;
+
+        public enum LanguageReadingDirection
+        {
+            // TODO: improve the support of reading directions
+            LeftToRight,   // Supported
+            RightToLeft,   // Partly supported
+            Boustrophedon, // Not supported yet
+            TopToBottom    // Not supported yet
+        }
+
+        public enum CharacterClass
+        {
+            // Strong types
+            Left_To_Right,
+            Right_To_Left,
+            Arabic_Letter,
+            // Weak types
+            European_Number,
+            European_Separator,
+            European_Terminator,
+            Arabic_Number,
+            Common_Separator,
+            Nonspacing_Mark,
+            Boundary_Neutral,
+            // Neutral types
+            Paragraph_Separator,
+            Segment_Separator,
+            White_Space,
+            Other_Neutral,
+            // Explicit formatting types
+            Left_To_Right_Embedding,
+            Left_To_Right_Override,
+            Right_To_Left_Embedding,
+            Right_To_Left_Override,
+            Pop_Directional_Format,
+            Left_To_Right_Isolate,
+            Right_To_Left_Isolate,
+            First_Strong_Isolate,
+            Pop_Directional_Isolate
+        }
+    }
+}

--- a/Assembly-CSharp/Memoria/Assets/Text/TextureHelper.cs
+++ b/Assembly-CSharp/Memoria/Assets/Text/TextureHelper.cs
@@ -19,10 +19,20 @@ namespace Memoria.Assets
             return result;
         }
 
-        public static Texture2D CopyAsReadable(Texture texture)
+        public static Texture2D CopyAsReadable(Texture texture, Boolean destroyOld = false)
         {
             if (texture == null)
                 return null;
+
+            if (texture is Texture2D texture2d)
+            {
+                try
+                {
+                    Color firstPixel = texture2d.GetPixel(0, 0);
+                    return texture2d;
+                }
+                catch (Exception) {}
+            }
 
             Camera camera = Camera.main ?? GameObject.Find("FieldMap Camera")?.GetComponent<Camera>() ?? GameObject.Find("UI Camera")?.GetComponent<Camera>() ?? UICamera.mainCamera;
             RenderTexture oldTarget = camera.targetTexture;
@@ -39,6 +49,8 @@ namespace Memoria.Assets
 
                 RenderTexture.active = rt;
                 result.ReadPixels(new Rect(0, 0, texture.width, texture.height), 0, 0);
+                if (destroyOld)
+                    UnityEngine.Object.DestroyImmediate(texture);
             }
             finally
             {

--- a/Assembly-CSharp/Memoria/Configuration/Access/Export.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Access/Export.cs
@@ -20,6 +20,7 @@ namespace Memoria
             public static Boolean Audio => Enabled && Instance._export.Audio;
             public static Boolean Field => Enabled && Instance._export.Field;
             public static Boolean Battle => Enabled && Instance._export.Battle;
+            public static Boolean Translation => Enabled && Instance._export.Translation;
         }
     }
 }

--- a/Assembly-CSharp/Memoria/Configuration/Memoria.ini
+++ b/Assembly-CSharp/Memoria/Configuration/Memoria.ini
@@ -327,6 +327,7 @@ Graphics = 1
 Audio = 1
 Field = 0
 Battle = 0
+Translation = 0
 
 [Import]
 	; no effect in game

--- a/Assembly-CSharp/Memoria/Configuration/Structure/ExportSection.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Structure/ExportSection.cs
@@ -18,6 +18,7 @@ namespace Memoria
             public readonly IniValue<Boolean> Audio;
             public readonly IniValue<Boolean> Field;
             public readonly IniValue<Boolean> Battle;
+            public readonly IniValue<Boolean> Translation;
 
             public ExportSection() : base(nameof(ExportSection), false)
             {
@@ -29,6 +30,7 @@ namespace Memoria
                 Audio = BindBoolean(nameof(Audio), false);
                 Field = BindBoolean(nameof(Field), false);
                 Battle = BindBoolean(nameof(Battle), false);
+                Translation = BindBoolean(nameof(Translation), false);
             }
         }
     }

--- a/Memoria.Launcher/Ini/Memoria.ini
+++ b/Memoria.Launcher/Ini/Memoria.ini
@@ -327,6 +327,7 @@ Graphics = 1
 Audio = 1
 Field = 0
 Battle = 0
+Translation = 0
 
 [Import]
 	; no effect in game

--- a/Memoria.Patcher/StreamingAssets/Data/World/Environment.txt
+++ b/Memoria.Patcher/StreamingAssets/Data/World/Environment.txt
@@ -25,6 +25,8 @@
 ##  
 ##  Light -> Define ambiant light changes and locations, using one of the 4 different settings of WeatherColors.csv
 ##  
+##  Title -> Change the appearance of the continent titles
+##  
 ##  It is important for the keywords above to be written at the beginning of a new line in order to take effect
 ##  The parameter change instruction must be one-lined
 ##  
@@ -101,6 +103,12 @@
 ##    Light Add [Position=(128000, -202240)] [Radius=46080] [Light=1]
 ##  Have Memoria's surroundings use purple ambiant colors
 ##    Light Add [Condition=WorldDisc == 4] [Position=(196158, -81825)] [Radius=26080] [Light=3]
+##  
+##  Setup the default size and duration for all the title sprites in all languages
+##    Title MistContinent Any [Rect=(0, 144, 1024, 128)] [FadeIn=119] [Duration=1] [FadeOut=59]
+##    Title OuterContinent Any [Rect=(0, 144, 1024, 128)] [FadeIn=119] [Duration=1] [FadeOut=59]
+##    Title ForgottenContinent Any [Rect=(0, 144, 1024, 128)] [FadeIn=119] [Duration=1] [FadeOut=59]
+##    Title LostContinent Any [Rect=(0, 144, 1024, 128)] [FadeIn=119] [Duration=1] [FadeOut=59]
 ##  
 #####################################################################################################
 ##  


### PR DESCRIPTION
Improve a couple of thing regarding translations and support of other languages.

**Overview:**
1) Add support for many right-to-left reading languages
2) Add an option to convert a translation mod from a ``[Import]`` format to a mod folder format
3) The same option can also be used to generate the base files required for doing a translation mod (the texts, but also the textures containing texts)
4) Place titles (in fields, like "Iifa, the great tree of life" or the continent names on world map) are now easier to mod and can be resized to allow better displays (eg. for #832); it can also apply to layers like the South Gate map
5) It is now possible to provide a ``LocalizationPatch.txt`` that contains the texts for just 1 language instead of having to provide all the languages at once
6) Fix custom ``Ending_Text_US_JP_GR_Atlas`` and ``Ending_Text_FR_IT_ES_Atlas`` not being imported properly in mod folders
7) Fix a rare bug with wrongly placed icons when they were last on their line or with right-aligned texts (I think only modded texts could have one)

Also, I used the occasion for:
- Adding a text opcode ``[SPRT=...]`` which can be used to print a sprite, much like the ``[ICON=...]`` opcode, except that with ``SPRT`` you can specify the atlas in which the sprite is and optionally resize it:
```txt
[SPRT=ability_stone] The ability stone sprite from "Icon Atlas" (default)
[SPRT=GeneralAtlas,ate_selective_text01_us_uk_jp_fr_gr] The ATE sprite from "General Atlas"
[SPRT=IconAtlas,icon_equip_0,80,64] The weapon equip sprite resized to 80x64
```
- Support for ``BattleHUD.LibraInformation.StatusImmune`` (and ``StatusResist``): Scan can now display the statuses to which the target is immune
- Export a couple more of atlases and their default TPSHEET with ``[Export] Graphics = 1``
- Fix a bug in SPS texture export (``[Export] Graphics = 1``)
- Fix continent titles being permanent if the player leaves the world map before it completly fades out (only the "Mist Continent" title can do that in vanilla if you rush to the Ice Cavern)
- Continent title fade durations can now be customized in ``Data/World/Environment.txt``
- Fix the vertical alignment of the text opcode ``[u][/u]`` (underline)

I'll write a page on the wiki for some of these things eventually.