### PR TITLE
10 Random fixes

### DIFF
--- a/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
+++ b/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
@@ -2133,58 +2133,58 @@ public partial class EventEngine
                 Int32 destX = this.getv2();
                 Int32 destZ = -this.getv2();
                 Int32 destY = this.getv2();
-                if (this.gMode == 1 && po?.model != UInt16.MaxValue)
+                if (this.gMode == 1 && po?.model != UInt16.MaxValue && po != null)
                 {
-                    if (po != null)
+                    Log.Message("if (mapNo == " + mapNo + " && po.sid == " + po.sid + " && destX == " + destX + " && destY == " + destY + " && destZ == " + destZ + ")");
+                    FieldMapActorController actorController = po.go.GetComponent<FieldMapActorController>();
+                    if (actorController != null && actorController.walkMesh != null)
+                        actorController.walkMesh.BGI_charSetActive(actorController, 0u);
+                    if (mapNo == 563 && po.sid == 16 && destX == -1614) // Lindblum/T.D. Station, Zidane's initial position when arriving with Air Cab
+                        destX = -1635;
+                    else if (mapNo == 572 && po.sid == 16 && destX == -1750) // Lindblum/I.D. Station, Zidane's initial position when arriving with Air Cab
+                        destX = -1765;
+                    else if (mapNo == 1205 && po.sid == 6 && this.eBin.getVarManually(EBin.SC_COUNTER_SVR) == 4800 && destX == 418 && destY == 9733)
                     {
-                        FieldMapActorController actorController = po.go.GetComponent<FieldMapActorController>();
-                        if (actorController != null && actorController.walkMesh != null)
-                            actorController.walkMesh.BGI_charSetActive(actorController, 0u);
-                        if (mapNo == 1205 && po.sid == 6 && this.eBin.getVarManually(EBin.SC_COUNTER_SVR) == 4800 && destX == 418 && destY == 9733)
-                        {
-                            // A. Castle/Chapel, Thorn's initial position (fix in some languages)
-                            this._fixThornPosA = destX;
-                            this._fixThornPosB = destZ;
-                            this._fixThornPosC = destY;
-                            this._fixThornPosObj = po;
-                            destX = 600;
-                            destY = 9999;
-                        }
-                        else if (mapNo == 563 && po.sid == 16 && destX == -1614) // Lindblum/T.D. Station, Zidane's initial position when arriving with Air Cab
-                            destX = -1635;
-                        else if (mapNo == 572 && po.sid == 16 && destX == -1750) // Lindblum/I.D. Station, Zidane's initial position when arriving with Air Cab
-                            destX = -1765;
-                        else if (mapNo == 1310 && po.sid == 12 && destX == -1614) // Lindblum/T.D. Station, Zidane's initial position when arriving with Air Cab
-                            destX = -1635;
-                        else if (mapNo == 2110 && po.sid == 9 && destX == -1614) // Lindblum/T.D. Station, Zidane's initial position when arriving with Air Cab
-                            destX = -1635;
-                        else if (mapNo == 1607)
-                        {
-                            // Mdn. Sari/Kitchen, Cooked Fish and Stew Plate appearing on the foreground
-                            Int32 counter = this.eBin.getVarManually(EBin.SC_COUNTER_SVR);
-                            Int32 var9169 = this.eBin.getVarManually(9169);
-                            if ((po.model == 236 || po.model == 237) && counter >= 6640 && counter < 6690 && var9169 == 0)
-                                destZ += 50000;
-                        }
-                        else if (mapNo == 1606) // Mdn. Sari/Resting Room, initial position of moogles
-                        {
-                            if (po.uid == 9 && destX == -171 && destZ == 641 && destY == 1042
-                            || po.uid == 128 && destX == -574 && destZ == 624 && destY == 903
-                            || po.uid == 129 && destX == -226 && destZ == 639 && destY == 1009
-                            || po.uid == 130 && destX == -93 && destZ == 647 && destY == 1017
-                            || po.uid == 131 && destX == 123 && destZ == 667 && destY == 1006
-                            || po.uid == 132 && destX == -689 && destZ == 621 && destY == 859)
-                                gameObject.GetComponent<FieldMapActor>().SetRenderQueue(2000);
-                        }
-                        else if (mapNo == 1207 && actor.uid == 9 && actorController != null) // A. Castle/Garnet's Room, Dagger, fix for issue #666
-                            actorController._smoothUpdateRegistered = false;
+                        // A. Castle/Chapel, Thorn's initial position (fix in some languages)
+                        this._fixThornPosA = destX;
+                        this._fixThornPosB = destZ;
+                        this._fixThornPosC = destY;
+                        this._fixThornPosObj = po;
+                        destX = 600;
+                        destY = 9999;
                     }
-                    if (mapNo == 1756 && po.sid == 6 && destX == -3019 && destY == 1226) // Iifa Tree/Bottom, Soulcage when landing from above
+                    else if (mapNo == 1207 && actor.uid == 9 && actorController != null) // A. Castle/Garnet's Room, Dagger, fix for issue #666
+                        actorController._smoothUpdateRegistered = false;
+                    else if (mapNo == 1310 && po.sid == 12 && destX == -1614) // Lindblum/T.D. Station, Zidane's initial position when arriving with Air Cab
+                        destX = -1635;
+                    else if (mapNo == 1607)
+                    {
+                        // Mdn. Sari/Kitchen, Cooked Fish and Stew Plate appearing on the foreground
+                        Int32 counter = this.eBin.getVarManually(EBin.SC_COUNTER_SVR);
+                        Int32 var9169 = this.eBin.getVarManually(9169);
+                        if ((po.model == 236 || po.model == 237) && counter >= 6640 && counter < 6690 && var9169 == 0)
+                            destZ += 50000;
+                    }
+                    else if (mapNo == 1606) // Mdn. Sari/Resting Room, initial position of moogles
+                    {
+                        if (po.uid == 9 && destX == -171 && destZ == 641 && destY == 1042
+                        || po.uid == 128 && destX == -574 && destZ == 624 && destY == 903
+                        || po.uid == 129 && destX == -226 && destZ == 639 && destY == 1009
+                        || po.uid == 130 && destX == -93 && destZ == 647 && destY == 1017
+                        || po.uid == 131 && destX == 123 && destZ == 667 && destY == 1006
+                        || po.uid == 132 && destX == -689 && destZ == 621 && destY == 859)
+                            gameObject.GetComponent<FieldMapActor>().SetRenderQueue(2000);
+                    }
+                    else if (mapNo == 1756 && po.sid == 6 && destX == -3019 && destY == 1226) // Iifa Tree/Bottom, Soulcage when landing from above
                     {
                         destX = -3145;
                         destZ = -2035;
                         destY = 1274;
                     }
+                    else if (mapNo == 2110&& po.sid == 9 && destX == -1614) // Lindblum/T.D. Station, Zidane's initial position when arriving with Air Cab
+                        destX = -1635;
+                    else if (mapNo == 2209 && scCounter == 9520 && po.sid == 4 && destX == 1123 && destY == 1067 && destZ == 98) // Kuja to the right to fix surprise (#860)
+                        destX = 1323;
                     else if (mapNo == 2456 && actor.uid == 6) // Sligthy resize the rope in Alexandria/Steeple (CD3 & CD4)
                         geo.geoScaleSetXYZ(po.go, 66 << 24 >> 18, 66 << 24 >> 18, 66 << 24 >> 18);
                 }

--- a/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
+++ b/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
@@ -1149,17 +1149,13 @@ public partial class EventEngine
 
                 if (this.gMode == 1)
                 {
+                    //if (actor.uid == 5) Log.Message("mapNo == " + mapNo + " && angle == " + angle);// + " && actor.uid == " + actor.uid);
+                    if (mapNo == 103 && angle == 228 && po.model == 224 && actor.uid == 9) // Jump rope from little girls at Alexandria (before Alexandria destruction)
+                        angle = 229;
                     if (mapNo == 504 && (Int32)po.sid == 15 && (this.eBin.getVarManually(EBin.MAP_INDEX_SVR) == 4 && angle == 240))
                         angle = 128;
-
-                    if (mapNo == 103 && angle == 228 && po.model == 224 && actor.uid == 9) // Jump rope from little girls at Alexandria (before Alexandria destruction)
-                    {
-                        angle = 229;
-                    }
                     if (mapNo == 2456 && angle == 0 && po.model == 224 && actor.uid == 6) // Jump rope from little girls at Alexandria (after Alexandria destruction)
-                    {
                         angle = 1;
-                    }
                     Vector3 eulerAngles2 = po.go.transform.localRotation.eulerAngles;
                     eulerAngles2.y = EventEngineUtils.ConvertFixedPointAngleToDegree((Int16)(angle << 4));
                     po.rotAngle[1] = eulerAngles2.y;

--- a/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
+++ b/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
@@ -279,7 +279,7 @@ public partial class EventEngine
                 
                 if (isValid && po != null)
                 {
-                    Log.Message("mapNo == " + mapNo +  " && scCounter == " + scCounter + " && po.sid == " + po.sid + " && posX == " + posX + " && posZ == " + posZ);
+                    //Log.Message("mapNo == " + mapNo +  " && scCounter == " + scCounter + " && po.sid == " + po.sid + " && posX == " + posX + " && posZ == " + posZ);
                     FieldMapActorController actorController = po.go.GetComponent<FieldMapActorController>();
                     if (actorController != null && actorController.walkMesh != null)
                     {
@@ -313,12 +313,17 @@ public partial class EventEngine
                         ff9shadow.FF9ShadowOffField(po.uid);
                         po.isShadowOff = true;
                     }
-                    if (mapNo == 563 && po.sid == 16 && posX == -1614) // Lindblum/T.D. Station, Zidane's initial position when arriving with Air Cab
+                    if (mapNo == 257 && scCounter == 2300 && po.sid == 8 && posX == 96 && posZ == -736) // evil forest, steiner position (fix #892)
+                    {
+                        posX = 30;
+                        posZ = -716;
+                    }
+                    else if (mapNo == 563 && po.sid == 16 && posX == -1614) // Lindblum/T.D. Station, Zidane's initial position when arriving with Air Cab
                         posX = -1635;
                     else if (mapNo == 572 && po.sid == 16 && posX == -1750) // Lindblum/I.D. Station, Zidane's initial position when arriving with Air Cab
                         posX = -1765;
                     else if (mapNo == 850 && scCounter == 3118 && posX == 898 && posZ == -4972)
-                    { 
+                    {
                         if (po.sid == 16)
                             posZ = -5372;
                         if (po.sid == 2)

--- a/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
+++ b/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
@@ -1659,6 +1659,8 @@ public partial class EventEngine
                 Single dx = (Single)this.getv2(); // arg2: x movement
                 Single dy = (Single)this.getv2(); // arg3: y movement
                 Int16 dz = (Int16)this.getv2(); // arg4: depth, with higher value being further away from camera
+                if (mapNo == 2953 && overlayNdx == 26 && dx == 0 && dy == 48 && dz == 0) // fix chocobo dream title visibly scrolling on the screen
+                    SmoothFrameUpdater_Field.Skip = 1;
                 this.fieldmap.EBG_overlayMove(overlayNdx, dx, dy, dz);
                 return 0;
             }

--- a/Assembly-CSharp/Global/Field/Map/FieldMap.cs
+++ b/Assembly-CSharp/Global/Field/Map/FieldMap.cs
@@ -1474,7 +1474,9 @@ public class FieldMap : HonoBehavior
 
         foreach (int[] entry in FixDepthOfLayer)
         {
-            if (entry[0] == FF9StateSystem.Common.FF9.fldMapNo && entry[1] == this.camIdx && entry[2] == ovrNdx)
+            if (Configuration.Graphics.TileSize == 32 && (entry[0] == 562 || entry[0] == 1309 || entry[0] == 2109))
+            { }
+            else if (entry[0] == FF9StateSystem.Common.FF9.fldMapNo && entry[1] == this.camIdx && entry[2] == ovrNdx)
             {
                 bgOverlay.curZ = (ushort)entry[3];
                 bgOverlay.transform.localPosition = new Vector3(bgOverlay.transform.localPosition.x, bgOverlay.transform.localPosition.y, entry[3]);

--- a/Assembly-CSharp/Global/Field/Map/FieldMap.cs
+++ b/Assembly-CSharp/Global/Field/Map/FieldMap.cs
@@ -2524,6 +2524,9 @@ public class FieldMap : HonoBehavior
         [2207,0,5,0],       // Desert palace teleporter light 5
         [2209,0,0,0],       // Desert palace teleporter light
         [2211,0,8,400],     // Desert palace teleporter light
+        [2217,0,1,1847],    // Candle light
+        [2217,0,6,3000],    // Candle light
+        [2217,0,8,5000],    // Candle light
         [2221,0,17,2200],   // Candle light
         [2222,0,2,1000],    // Desert palace teleporter light
         [2502,0,14,1400],   // Ypsen, entrance light

--- a/Assembly-CSharp/Global/Field/Map/FieldMap.cs
+++ b/Assembly-CSharp/Global/Field/Map/FieldMap.cs
@@ -2540,7 +2540,7 @@ public class FieldMap : HonoBehavior
         [2600,0,13,8000],   // Branbal, background
         [2605,0,3,2200],    // Branbal, light of light net
         [2657,0,4,2040],    // Branbal, light in the room
-        [2800,0,26,1700],   // Dagguereo Zidane behind beckground on left path
+        //[2800,0,26,1700],   // Dagguereo Zidane behind beckground on left path
         [2922,0,8,4329],    // Crystal world (was not active on PSX)
         [2922,0,10,3179],   // Crystal world (was not active on PSX)
         [2922,0,11,3179],   // Crystal world (was not active on PSX)

--- a/Assembly-CSharp/Global/SPS/CommonSPSSystem.cs
+++ b/Assembly-CSharp/Global/SPS/CommonSPSSystem.cs
@@ -123,6 +123,8 @@ public class CommonSPSSystem
             pos = new Vector3(-1030, 1400, 1716);
         if (MapNo == 2304 && name == "SPS_0001" && pos.x == 830 && pos.y == 1479 && pos.z == 1516) // esto gaza flames
             pos = new Vector3(790, 1400, 2016);
+        if (MapNo == 303 && name == "SPS_0002")
+            pos = new Vector3(4330, -1227, -700);
         return pos;
     }
 

--- a/Assembly-CSharp/Global/SPS/CommonSPSSystem.cs
+++ b/Assembly-CSharp/Global/SPS/CommonSPSSystem.cs
@@ -131,6 +131,16 @@ public class CommonSPSSystem
             pos = new Vector3(845, 485, -82);
         if (MapNo == 262 && name == "SPS_0000" && pos.x == 355 && pos.y == 160 && pos.z == 4150)
             pos.x = 385;
+        if (MapNo == 162 && name == "SPS_0002" && pos.x == -340 && pos.y == 660 && pos.z == -314)
+            pos = new Vector3(-350, 640, -314);
+        if (MapNo == 162 && name == "SPS_0003" && pos.x == -460 && pos.y == 670 && pos.z == -314)
+            pos = new Vector3(-470, 650, -314);
+        if (MapNo == 162 && name == "SPS_0004" && pos.x == -570 && pos.y == 654 && pos.z == -314)
+            pos = new Vector3(-580, 640, -314);
+        if (MapNo == 163 && name == "SPS_0002" && pos.x == 821 && pos.y == 502 && pos.z == 4389)
+            pos = new Vector3(735, 475, 4000);
+        if (MapNo == 163 && name == "SPS_0001" && pos.x == 1150 && pos.y == 529 && pos.z == 4306)
+            pos = new Vector3(1060, 505, 4000);
         return pos;
     }
 

--- a/Assembly-CSharp/Global/SPS/CommonSPSSystem.cs
+++ b/Assembly-CSharp/Global/SPS/CommonSPSSystem.cs
@@ -129,6 +129,8 @@ public class CommonSPSSystem
             pos.x = -122;
         if (MapNo == 207 && name == "SPS_0000" && pos.x == 865 && pos.y == 465 && pos.z == -22) // prima vista candle
             pos = new Vector3(845, 485, -82);
+        if (MapNo == 262 && name == "SPS_0000" && pos.x == 355 && pos.y == 160 && pos.z == 4150)
+            pos.x = 385;
         return pos;
     }
 

--- a/Assembly-CSharp/Global/SPS/CommonSPSSystem.cs
+++ b/Assembly-CSharp/Global/SPS/CommonSPSSystem.cs
@@ -123,8 +123,12 @@ public class CommonSPSSystem
             pos = new Vector3(-1030, 1400, 1716);
         if (MapNo == 2304 && name == "SPS_0001" && pos.x == 830 && pos.y == 1479 && pos.z == 1516) // esto gaza flames
             pos = new Vector3(790, 1400, 2016);
-        if (MapNo == 303 && name == "SPS_0002")
+        if (MapNo == 303 && name == "SPS_0002") // Ice cave smoke
             pos = new Vector3(4330, -1227, -700);
+        if (MapNo == 205 && name == "SPS_0000" && pos.x == -110 && pos.y == 850 && pos.z == 510) // prima vista candle
+            pos.x = -122;
+        if (MapNo == 207 && name == "SPS_0000" && pos.x == 865 && pos.y == 465 && pos.z == -22) // prima vista candle
+            pos = new Vector3(845, 485, -82);
         return pos;
     }
 

--- a/Assembly-CSharp/Memoria/Application/SmoothFrameUpdater_Field.cs
+++ b/Assembly-CSharp/Memoria/Application/SmoothFrameUpdater_Field.cs
@@ -116,7 +116,7 @@ namespace Memoria
             {
                 foreach (BGOVERLAY_DEF bgLayer in fieldmap.scene.overlayList)
                 {
-                    if (bgLayer.transform != null && (bgLayer.flags & (BGOVERLAY_DEF.OVERLAY_FLAG.Loop | BGOVERLAY_DEF.OVERLAY_FLAG.ScrollWithOffset)) == 0)
+                    if (bgLayer.transform != null && ((bgLayer.flags & (BGOVERLAY_DEF.OVERLAY_FLAG.Loop | BGOVERLAY_DEF.OVERLAY_FLAG.ScrollWithOffset)) == 0 || FF9StateSystem.Common.FF9.fldMapNo == 2953))
                     {
                         if (bgLayer._smoothUpdateRegistered)
                             bgLayer._smoothUpdatePosPrevious = bgLayer._smoothUpdatePosActual;
@@ -193,7 +193,7 @@ namespace Memoria
             {
                 foreach (BGOVERLAY_DEF bgLayer in fieldmap.scene.overlayList)
                 {
-                    if (bgLayer.transform != null && bgLayer._smoothUpdateRegistered && (bgLayer.flags & (BGOVERLAY_DEF.OVERLAY_FLAG.Loop | BGOVERLAY_DEF.OVERLAY_FLAG.ScrollWithOffset)) == 0)
+                    if (bgLayer.transform != null && bgLayer._smoothUpdateRegistered && ((bgLayer.flags & (BGOVERLAY_DEF.OVERLAY_FLAG.Loop | BGOVERLAY_DEF.OVERLAY_FLAG.ScrollWithOffset)) == 0 || FF9StateSystem.Common.FF9.fldMapNo == 2953))
                     {
                         //Vector3 frameMove = bgLayer._smoothUpdatePosActual - bgLayer._smoothUpdatePosPrevious;
                         //if (frameMove.sqrMagnitude > 0f && frameMove.sqrMagnitude < OverlaySmoothMovementMaxSqr)
@@ -237,7 +237,7 @@ namespace Memoria
             }
             if (fieldmap?.scene?.overlayList != null)
                 foreach (BGOVERLAY_DEF bgLayer in fieldmap.scene.overlayList)
-                    if (bgLayer.transform != null && bgLayer._smoothUpdateRegistered && (bgLayer.flags & (BGOVERLAY_DEF.OVERLAY_FLAG.Loop | BGOVERLAY_DEF.OVERLAY_FLAG.ScrollWithOffset)) == 0)
+                    if (bgLayer.transform != null && bgLayer._smoothUpdateRegistered && ((bgLayer.flags & (BGOVERLAY_DEF.OVERLAY_FLAG.Loop | BGOVERLAY_DEF.OVERLAY_FLAG.ScrollWithOffset)) == 0 || FF9StateSystem.Common.FF9.fldMapNo == 2953))
                         bgLayer.transform.position = bgLayer._smoothUpdatePosActual;
             if (_cameraRegistered)
             {


### PR DESCRIPTION
- Field Foreground - Alexandria's candle fire animation does not overlap character #883
- Field Foreground - Daguerreo middle floor does not overlap character #874
- Field animation - just one candle was lit with fire animation, nothing on the other 2 candles #862
- Kuja must not show up early for more realistic Zidane surprise #860
- Area Text - Chocobo's Dream World stutter #854
- Ice cavern: mist cut by background #889
- Field animation - Misaligned candle fire at Prima Vista Crash Site #891
- Characters Scene - Zidane breaks through Garnet #892
- Field animation - Misaligned campfire flame outside Evil Forest #893
- Steiner transparent #896