### PR TITLE
1px border fix

### DIFF
--- a/Assembly-CSharp/Global/PillarBoxOverrideManager.cs
+++ b/Assembly-CSharp/Global/PillarBoxOverrideManager.cs
@@ -32,10 +32,10 @@ public class PillarBoxOverrideManager : MonoBehaviour
 
     private void UpdatePillarSize()
     {
-        this.topRect.sizeDelta = new Vector2(0f, Mathf.Max(UIManager.UIPillarBoxSize.y, 0f));
-        this.bottomRect.sizeDelta = new Vector2(0f, Mathf.Max(UIManager.UIPillarBoxSize.y, 0f));
-        this.leftRect.sizeDelta = new Vector2(Mathf.Max(UIManager.UIPillarBoxSize.x, 0f), 0f);
-        this.rightRect.sizeDelta = new Vector2(Mathf.Max(UIManager.UIPillarBoxSize.x, 0f), 0f);
+        this.topRect.sizeDelta = new Vector2(0f, UIManager.UIPillarBoxSize.y);
+        this.bottomRect.sizeDelta = new Vector2(0f, UIManager.UIPillarBoxSize.y);
+        this.leftRect.sizeDelta = new Vector2(UIManager.UIPillarBoxSize.x, 0f);
+        this.rightRect.sizeDelta = new Vector2(UIManager.UIPillarBoxSize.x, 0f);
     }
 
     private RectTransform topRect;

--- a/Assembly-CSharp/Global/PillarBoxOverrideManager.cs
+++ b/Assembly-CSharp/Global/PillarBoxOverrideManager.cs
@@ -32,10 +32,10 @@ public class PillarBoxOverrideManager : MonoBehaviour
 
     private void UpdatePillarSize()
     {
-        this.topRect.sizeDelta = new Vector2(0f, Mathf.Max(UIManager.UIPillarBoxSize.y, 1f));
-        this.bottomRect.sizeDelta = new Vector2(0f, Mathf.Max(UIManager.UIPillarBoxSize.y, 1f));
-        this.leftRect.sizeDelta = new Vector2(Mathf.Max(UIManager.UIPillarBoxSize.x, 1f), 0f);
-        this.rightRect.sizeDelta = new Vector2(Mathf.Max(UIManager.UIPillarBoxSize.x, 1f), 0f);
+        this.topRect.sizeDelta = new Vector2(0f, Mathf.Max(UIManager.UIPillarBoxSize.y, 0f));
+        this.bottomRect.sizeDelta = new Vector2(0f, Mathf.Max(UIManager.UIPillarBoxSize.y, 0f));
+        this.leftRect.sizeDelta = new Vector2(Mathf.Max(UIManager.UIPillarBoxSize.x, 0f), 0f);
+        this.rightRect.sizeDelta = new Vector2(Mathf.Max(UIManager.UIPillarBoxSize.x, 0f), 0f);
         this.leftImage.color = this.leftRect.sizeDelta.x <= 1f ? Color.black : Color.white;
         this.rightImage.color = this.rightRect.sizeDelta.x <= 1f ? Color.black : Color.white;
     }

--- a/Assembly-CSharp/Global/PillarBoxOverrideManager.cs
+++ b/Assembly-CSharp/Global/PillarBoxOverrideManager.cs
@@ -36,8 +36,6 @@ public class PillarBoxOverrideManager : MonoBehaviour
         this.bottomRect.sizeDelta = new Vector2(0f, Mathf.Max(UIManager.UIPillarBoxSize.y, 0f));
         this.leftRect.sizeDelta = new Vector2(Mathf.Max(UIManager.UIPillarBoxSize.x, 0f), 0f);
         this.rightRect.sizeDelta = new Vector2(Mathf.Max(UIManager.UIPillarBoxSize.x, 0f), 0f);
-        this.leftImage.color = this.leftRect.sizeDelta.x <= 1f ? Color.black : Color.white;
-        this.rightImage.color = this.rightRect.sizeDelta.x <= 1f ? Color.black : Color.white;
     }
 
     private RectTransform topRect;


### PR DESCRIPTION
Hey, I tried to fix this issue here #572 and here #789.

@SamsamTS was right that the borders were being shrunk down to 1px minimum and always showing even when they shouldn't have.

I also removed the hiding of the left and right images at very small sizes. I assume this was added because they were never disappearing and it was to just make them black bars instead of the grey sprite. I don't think it's necessary now that the sprite will disappear completely. Add those lines back in if there was some other reason for them.

I have no idea why the borders were set to always have a minimum width of 1. I've not tested this a lot, but it seems to be working fine.

