### PR TITLE
Fix for dialog cursor offset when using PSX font.

### DIFF
--- a/Assembly-CSharp/Global/Dialog/Dialog.cs
+++ b/Assembly-CSharp/Global/Dialog/Dialog.cs
@@ -28,7 +28,15 @@ public class Dialog : MonoBehaviour
     {
         // Note: this type is marked as 'beforefieldinit'.
         Dialog.DialogGroupButton = "Dialog.Choice";
-        Dialog.DefaultOffset = new Vector2(36f, 0f);
+
+        float xOffset = 36f;
+
+        if (Configuration.Font.Enabled && Configuration.Font.Names?.FirstOrDefault() == "Alexandria")
+        {
+            xOffset = 8f;
+        }
+
+        Dialog.DefaultOffset = new Vector2(xOffset, 0f);
     }
 
     public Int32 StartChoiceRow


### PR DESCRIPTION
Hey, another tiny fix, this time for #790. If you don't want to merge, that's okay. There might be a better way to do it. This was just the first thing I came up with. I've only tested it in this one scene. 


Before:
![Screenshot 2024-12-30 005950](https://github.com/user-attachments/assets/c44b1309-f997-4070-9bab-88a94546a8b8)


After:
![Screenshot 2024-12-30 005849](https://github.com/user-attachments/assets/dad84c05-55c6-4eb2-b177-70d242f15cf6)

