### PR TITLE
Model Viewer QOL (+ bone modification) + other little things.

### DIFF
--- a/Assembly-CSharp/Global/EBin.cs
+++ b/Assembly-CSharp/Global/EBin.cs
@@ -1681,7 +1681,7 @@ public class EBin
 
     private Int32 GetMemoriaCustomVariable(memoria_variable varCode)
     {
-        switch (varCode)
+        switch (varCode) // Custom variables for HW (ScriptAPI.txt)
         {
             case memoria_variable.TETRA_MASTER_WIN:
                 return FF9StateSystem.MiniGame.SavedData.sWin;
@@ -1697,6 +1697,15 @@ public class EBin
                 return FF9StateSystem.EventState.GetTreasureHunterPoints();
             case memoria_variable.BATTLE_RUNAWAY:
                 return FF9StateSystem.Battle.FF9Battle.btl_scene.Info.Runaway ? 1 : 0;
+            case memoria_variable.BATTLE_NOGAMEOVER:
+                return FF9StateSystem.Battle.FF9Battle.btl_scene.Info.NoGameOver ? 1 : 0;
+            case memoria_variable.BATTLE_WINPOSE:
+                return FF9StateSystem.Battle.FF9Battle.btl_scene.Info.WinPose ? 1 : 0;
+            case memoria_variable.BATTLE_IPSENCURSE:
+                return FF9StateSystem.Battle.FF9Battle.btl_scene.Info.ReverseAttack ? 1 : 0;
+            case memoria_variable.BATTLE_AFTEREVENT:
+                return FF9StateSystem.Battle.FF9Battle.btl_scene.Info.AfterEvent ? 1 : 0;
+
         }
         return 0;
     }
@@ -1716,6 +1725,18 @@ public class EBin
                 break;
             case memoria_variable.BATTLE_RUNAWAY:
                 FF9StateSystem.Battle.FF9Battle.btl_scene.Info.Runaway = val != 0;
+                break;
+            case memoria_variable.BATTLE_NOGAMEOVER:
+                FF9StateSystem.Battle.FF9Battle.btl_scene.Info.NoGameOver = val != 0;
+                break;
+            case memoria_variable.BATTLE_WINPOSE:
+                FF9StateSystem.Battle.FF9Battle.btl_scene.Info.WinPose = val != 0;
+                break;
+            case memoria_variable.BATTLE_IPSENCURSE:
+                FF9StateSystem.Battle.FF9Battle.btl_scene.Info.ReverseAttack = val != 0;
+                break;
+            case memoria_variable.BATTLE_AFTEREVENT:
+                FF9StateSystem.Battle.FF9Battle.btl_scene.Info.AfterEvent = val != 0;
                 break;
         }
     }
@@ -2395,6 +2416,10 @@ public class EBin
         TETRA_MASTER_RANK,
         TREASURE_HUNTER_POINTS,
         BATTLE_RUNAWAY,
+        BATTLE_NOGAMEOVER,
+        BATTLE_WINPOSE,
+        BATTLE_IPSENCURSE,
+        BATTLE_AFTEREVENT
     }
 
     public enum op_binary

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -413,14 +413,32 @@ namespace Memoria.Assets
                     while (currentModel == null)
                         ChangeModel(--prevIndex);
                 }
-                if (shift && Input.GetKeyDown(KeyCode.B))
+                if (Input.GetKeyDown(KeyCode.B))
                 {
-                    displayBoneConnections = !displayBoneConnections;
-                }
-                else if (Input.GetKeyDown(KeyCode.B))
-                {
-                    displayBones = !displayBones;
-                    displayBoneNames = !displayBoneNames;
+                    if (shift)
+                        displayBoneConnections = !displayBoneConnections;
+                    else if (ctrl)
+                    {
+                        Transform builtInBone = currentModel.transform.GetChildByName("bone" + currentBoneIndex.ToString("D3"));
+                        if (!currentHiddenBonesID.Contains(currentBoneIndex))
+                        {
+                            currentHiddenBonesID.Add(currentBoneIndex);
+                        }
+                        else
+                        {
+                            currentHiddenBonesID.Remove(currentBoneIndex);
+                            if (builtInBone != null)
+                                builtInBone.localScale = Vector3.one;
+                            if (currentWeaponModel != null)
+                                currentWeaponModel.transform.localScale = Vector3.one;
+                        }
+                        currentHiddenBonesID.Sort();
+                    }
+                    else
+                    {
+                        displayBones = !displayBones;
+                        displayBoneNames = !displayBoneNames;
+                    }
                 }
                 if (Input.GetKeyDown(KeyCode.I))
                 {
@@ -692,12 +710,14 @@ namespace Memoria.Assets
                         WeaponTargetRot = currentWeaponModel.transform.localRotation.eulerAngles.ToString("F9");
                     }
                     string BoneSelectedPos = BoneSelected.localPosition.ToString("F9");
-                    string BoneSelectedRot = BoneSelected.localRotation.eulerAngles.ToString("F9");
+                    string BoneSelectedRot = BoneSelected.localRotation.ToString("F9");
+                    string BoneSelectedRotEuler = BoneSelected.localRotation.eulerAngles.ToString("F9");
+                    string BoneSelectedScale = BoneSelected.localScale.ToString("F9");
                     Log.Message("####### KEYPAD 5 PRESSED ! #######");
                     Log.Message("[MODEL] => " + geoList[currentGeoIndex].Name + ".offset = " + ModelTargetPos.Remove(ModelTargetPos.Length - 1) + ", " + ModelTargetRot.Remove(0, 1));
                     if (currentWeaponModel != null)
                         Log.Message("[WEAPON] => " + weapongeoList[currentWeaponGeoIndex].Name + ".offset = " + WeaponTargetPos.Remove(WeaponTargetPos.Length - 1) + ", " + WeaponTargetRot.Remove(0, 1));
-                    Log.Message("[BONE] => BoneID n°" + currentBoneIndex + " / Position = " + BoneSelectedPos + " ; Rotation = " + BoneSelectedRot);
+                    Log.Message("[BONE] => BoneID n°" + currentBoneIndex + " / Position = " + BoneSelectedPos + " ; Rotation(Quat) = " + BoneSelectedRot + " ; Rotation(Euler) = " + BoneSelectedRotEuler + " ; Scale = " + BoneSelectedScale);
                     Log.Message("##################################");
                     DontSpamMessage = true;
                 }
@@ -741,7 +761,11 @@ namespace Memoria.Assets
                 }
                 if (Input.GetKeyDown(KeyCode.R)) // Reset position/rotation
                 {
-                    if (partcontrolled == PartControlled.WEAPON)
+                    if (shift)
+                    {
+                        ChangeModel(currentGeoIndex);
+                    }
+                    else if (partcontrolled == PartControlled.WEAPON)
                     {
                         weaponmodel_Position = Vector3.zero;
                         weaponmodel_Rotation = Quaternion.identity;
@@ -768,23 +792,6 @@ namespace Memoria.Assets
 
                         if (partcontrolled > PartControlled.BONE)
                             partcontrolled = PartControlled.MODEL;
-                    }
-                    else if (ctrl && currentWeaponModel != null)
-                    {
-                        Transform builtInBone = currentModel.transform.GetChildByName("bone" + currentBoneIndex.ToString("D3"));
-                        if (!currentHiddenBonesID.Contains(currentBoneIndex))
-                        {
-                            currentHiddenBonesID.Add(currentBoneIndex);
-                        }
-                        else
-                        {
-                            currentHiddenBonesID.Remove(currentBoneIndex);
-                            if (builtInBone != null)
-                                builtInBone.localScale = Vector3.one;
-                            if (currentWeaponModel != null)
-                                currentWeaponModel.transform.localScale = Vector3.one;
-                        }
-                        currentHiddenBonesID.Sort();
                     }
                     else
                     {
@@ -1184,7 +1191,7 @@ namespace Memoria.Assets
                 else if (partcontrolled == PartControlled.BONE)
                     label += $"[FFFF00][⇧P][FFFFFF] Selected: [FF007F]Bone\n";
 
-                label += $"[FFFF00][^P][FFFFFF] BoneHidden: ";
+                label += $"[FFFF00][^B][FFFFFF] BoneHidden: ";
                 if (currentHiddenBonesID.Count > 0)
                 {
                     for (Int32 i = 0; i < currentHiddenBonesID.Count; i++)
@@ -1232,7 +1239,7 @@ namespace Memoria.Assets
                     Transform BoneSelected = currentModel.transform.GetChildByName("bone" + currentBoneIndex.ToString("D3"));
                     extraInfo += "[BONE] ¤ ";
                     extraInfo += UseModdedTextures ? "text_mod" : "text_orig";
-                    extraInfo += $"Pos: [x]{BoneSelected.localPosition.x} [y]{BoneSelected.localPosition.y} [z]{BoneSelected.localPosition.z}";
+                    extraInfo += $"Pos: [x]{BoneSelected.localPosition.x.ToString("F5")} [y]{BoneSelected.localPosition.y.ToString("F5")} [z]{BoneSelected.localPosition.z.ToString("F5")}";
                     extraInfo += $" Rot(Quat): [x]{Math.Round(BoneSelected.localRotation.x, 2)} [y]{Math.Round(BoneSelected.localRotation.y, 2)} [z]{Math.Round(BoneSelected.localRotation.z, 2)} [w]{Math.Round(BoneSelected.localRotation.w, 2)}";
                     extraInfo += $" Rot(Eul): {Math.Round(BoneSelected.localRotation.eulerAngles.x, 0)}/{Math.Round(BoneSelected.localRotation.eulerAngles.y, 0)}/{Math.Round(BoneSelected.localRotation.eulerAngles.z, 0)}";
                     extraInfo += $" Scale: {Math.Round(BoneSelected.localScale.x, 2)}";

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -546,7 +546,7 @@ namespace Memoria.Assets
                     UseModdedTextures = !UseModdedTextures;
                     ChangeModel(currentGeoIndex);
                 }
-
+          
                 Transform BoneSelected = currentModel.transform.GetChildByName("bone" + currentBoneIndex.ToString("D3"));
 
                 if (ctrl)
@@ -1167,7 +1167,7 @@ namespace Memoria.Assets
                     label += $"[FFFF00][␣][FFFFFF] {currentAnimName}";
                     label += "\n";
                     label += $"[FFFF00][S][FFFFFF] Shader: {spsEffect.materials[Math.Min((Int32)spsEffect.abr, 4)].shader.name} [FFFF00][^↓↑][FFFFFF] Fade: {spsEffect.fade}";
-                    label += "\n";
+                    label += "\n\n\n\n\n\n";
                 }
                 else if (animList.Count > 0)
                 {
@@ -1175,31 +1175,32 @@ namespace Memoria.Assets
                     label += "\n";
                     label += $"[CCCCCC]  - Anim name: {currentAnimName} ({animList[currentAnimIndex].Key})[FFFFFF]";
                     label += "\n";
+                    if (currentWeaponModel)
+                        label += $"[FFFF00][^Scroll][FFFFFF] Weapon: {weapongeoList[currentWeaponGeoIndex].Name} ({geoList[currentWeaponGeoIndex].Id})\n";
+
+                    label += $"[FFFF00][⇧Scroll][FFFFFF] Bone: {currentBoneIndex}\n";
+                    if (partcontrolled == PartControlled.MODEL)
+                        label += $"[FFFF00][⇧P][FFFFFF] Selected: [00FF00]Model\n";
+                    else if (partcontrolled == PartControlled.WEAPON)
+                        label += $"[FFFF00][⇧P][FFFFFF] Selected: [2BFAFA]Weapon\n";
+                    else if (partcontrolled == PartControlled.BONE)
+                        label += $"[FFFF00][⇧P][FFFFFF] Selected: [FF007F]Bone\n";
+
+                    label += $"[FFFF00][^B][FFFFFF] BoneHidden: ";
+                    if (currentHiddenBonesID.Count > 0)
+                    {
+                        for (Int32 i = 0; i < currentHiddenBonesID.Count; i++)
+                            label += $"{currentHiddenBonesID[i]} ";
+                        label += $"\n";
+                    }
+                    else
+                        label += "\n\n\n";
                 }
                 else
                 {
-                    label += "\n\n";
+                    label += "\n\n\n\n\n\n\n";
                 }
-                if (currentWeaponModel)
-                    label += $"[FFFF00][^Scroll][FFFFFF] Weapon: {weapongeoList[currentWeaponGeoIndex].Name} ({geoList[currentWeaponGeoIndex].Id})\n";
 
-                label += $"[FFFF00][⇧Scroll][FFFFFF] Bone: {currentBoneIndex}\n";
-                if (partcontrolled == PartControlled.MODEL)
-                    label += $"[FFFF00][⇧P][FFFFFF] Selected: [00FF00]Model\n";
-                else if (partcontrolled == PartControlled.WEAPON)
-                    label += $"[FFFF00][⇧P][FFFFFF] Selected: [2BFAFA]Weapon\n";
-                else if (partcontrolled == PartControlled.BONE)
-                    label += $"[FFFF00][⇧P][FFFFFF] Selected: [FF007F]Bone\n";
-
-                label += $"[FFFF00][^B][FFFFFF] BoneHidden: ";
-                if (currentHiddenBonesID.Count > 0)
-                {
-                    for (Int32 i = 0; i < currentHiddenBonesID.Count; i++)
-                        label += $"{currentHiddenBonesID[i]} ";
-                    label += $"\n";
-                }
-                else
-                    label += "\n\n\n";
                 if (!String.Equals(infoLabel.text, label))
                     infoLabel.text = label;
                 if (!infoPanel.Show)
@@ -1484,6 +1485,8 @@ namespace Memoria.Assets
                 currentAnimIndex = 0;
                 currentAnimName = animList.Count > 0 ? animList[0].Value : "";
                 currentModelBones = BoneHierarchyNode.CreateFromModel(currentModel);
+                if (geoList[index].Name.StartsWith("GEO_WEP"))
+                    partcontrolled = PartControlled.MODEL;
                 //replaceOnce = 4;
                 postRefresh = 6;
                 // Disable fog effect for World Map models
@@ -1494,6 +1497,7 @@ namespace Memoria.Assets
             }
             else if (geoList[index].Kind == MODEL_KIND_BBG)
             {
+                partcontrolled = PartControlled.MODEL;
                 currentModel.transform.position = Vector3.zero;
                 currentModel.transform.localScale = scaleFactor;
                 currentModel.transform.localRotation = Quaternion.Euler(20f, 0f, 0f);
@@ -1505,6 +1509,7 @@ namespace Memoria.Assets
             }
             else if (geoList[index].Kind == MODEL_KIND_BBG_OBJ)
             {
+                partcontrolled = PartControlled.MODEL;
                 currentModel.transform.position = Vector3.zero;
                 currentModel.transform.localScale = scaleFactor;
                 currentModel.transform.localRotation = Quaternion.Euler(20f, 0f, 0f);
@@ -1514,6 +1519,7 @@ namespace Memoria.Assets
             }
             else
             {
+                partcontrolled = PartControlled.MODEL;
                 currentAnimIndex = 0;
                 currentAnimName = $"Frame: {(spsEffect.curFrame >> 4) + 1}/{spsEffect.frameCount >> 4}";
                 currentModelBones = null;

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -48,11 +48,14 @@ namespace Memoria.Assets
         private static float model_Horizontal_Rotation = 0f;
         private static float model_Vertical_Rotation = 0f;
         private static Vector3 scaleFactor;
+        private static GameObject currentWeaponModel;
         private static Vector3 weaponmodel_Position = new Vector3(0f, 0f, 0f);
         private static Quaternion weaponmodel_Rotation = Quaternion.identity;
         private static Vector3 weaponmodel_scaleFactor = Vector3.one;
         private static Vector3 boneselected_scaleFactor = Vector3.one;
-        private static GameObject currentWeaponModel;
+        public static Dictionary<Int32, Vector3> OffsetBonesPos = new Dictionary<Int32, Vector3>();
+        public static Dictionary<Int32, Vector3> OffsetBonesRot = new Dictionary<Int32, Vector3>();
+        public static Dictionary<Int32, Vector3> OffsetBonesScale = new Dictionary<Int32, Vector3>();
         private static CommonSPSSystem spsUtility;
         private static SPSEffect spsEffect;
         private static Single speedFactor;
@@ -597,6 +600,11 @@ namespace Memoria.Assets
                     }
                     else if (partcontrolled == PartControlled.BONE)
                     {
+                        if (!OffsetBonesRot.ContainsKey(currentBoneIndex))
+                            OffsetBonesRot.Add(currentBoneIndex, Vector3.zero);
+
+                        Vector3 PreviousRot = BoneSelected.localRotation.eulerAngles;
+
                         if (Input.GetKey(KeyCode.Keypad6))
                             BoneSelected.localRotation *= Quaternion.Euler(0f, 1f, 0f);
                         if (Input.GetKey(KeyCode.Keypad4))
@@ -609,6 +617,8 @@ namespace Memoria.Assets
                             BoneSelected.localRotation *= Quaternion.Euler(0f, 0f, 1f);
                         if (Input.GetKey(KeyCode.Keypad1) || Input.GetKey(KeyCode.Keypad3))
                             BoneSelected.localRotation *= Quaternion.Euler(0f, 0f, -1f);
+
+                        OffsetBonesRot[currentBoneIndex] += (BoneSelected.localRotation.eulerAngles - PreviousRot);
                     }
                 }
                 else
@@ -650,17 +660,54 @@ namespace Memoria.Assets
                     else if (partcontrolled == PartControlled.BONE)
                     {
                         if (Input.GetKey(KeyCode.Keypad6))
+                        {
                             BoneSelected.localPosition += moveSpeed * Vector3.left;
+                            if (OffsetBonesPos.ContainsKey(currentBoneIndex))
+                                OffsetBonesPos[currentBoneIndex] += moveSpeed * Vector3.left;
+                            else
+                                OffsetBonesPos.Add(currentBoneIndex, moveSpeed * Vector3.left);
+                        }
                         if (Input.GetKey(KeyCode.Keypad4))
+                        {
                             BoneSelected.localPosition += moveSpeed * Vector3.right;
+                            if (OffsetBonesPos.ContainsKey(currentBoneIndex))
+                                OffsetBonesPos[currentBoneIndex] += moveSpeed * Vector3.right;
+                            else
+                                OffsetBonesPos.Add(currentBoneIndex, moveSpeed * Vector3.right);
+                        }
                         if (Input.GetKey(KeyCode.Keypad8))
+                        {
                             BoneSelected.localPosition += moveSpeed * Vector3.down;
+                            if (OffsetBonesPos.ContainsKey(currentBoneIndex))
+                                OffsetBonesPos[currentBoneIndex] += moveSpeed * Vector3.down;
+                            else
+                                OffsetBonesPos.Add(currentBoneIndex, moveSpeed * Vector3.down);
+                        }
                         if (Input.GetKey(KeyCode.Keypad2))
+                        {
                             BoneSelected.localPosition += moveSpeed * Vector3.up;
+                            if (OffsetBonesPos.ContainsKey(currentBoneIndex))
+                                OffsetBonesPos[currentBoneIndex] += moveSpeed * Vector3.up;
+                            else
+                                OffsetBonesPos.Add(currentBoneIndex, moveSpeed * Vector3.up);
+                        }
+
                         if (Input.GetKey(KeyCode.Keypad7) || Input.GetKey(KeyCode.Keypad9))
+                        {
                             BoneSelected.localPosition += moveSpeed * Vector3.back;
+                            if (OffsetBonesPos.ContainsKey(currentBoneIndex))
+                                OffsetBonesPos[currentBoneIndex] += moveSpeed * Vector3.back;
+                            else
+                                OffsetBonesPos.Add(currentBoneIndex, moveSpeed * Vector3.back);
+                        }
                         if (Input.GetKey(KeyCode.Keypad1) || Input.GetKey(KeyCode.Keypad3))
+                        {
                             BoneSelected.localPosition += moveSpeed * Vector3.forward;
+                            if (OffsetBonesPos.ContainsKey(currentBoneIndex))
+                                OffsetBonesPos[currentBoneIndex] += moveSpeed * Vector3.forward;
+                            else
+                                OffsetBonesPos.Add(currentBoneIndex, moveSpeed * Vector3.forward);
+                        }
                     }
                 }
                 if (Input.GetKey(KeyCode.KeypadPlus)) // Zoom in ; Increase Size
@@ -677,7 +724,11 @@ namespace Memoria.Assets
                     }
                     else if (partcontrolled == PartControlled.BONE)
                     {
+                        if (!OffsetBonesScale.ContainsKey(currentBoneIndex))
+                            OffsetBonesScale.Add(currentBoneIndex, Vector3.zero);
+
                         BoneSelected.localScale += new Vector3(0.01f, 0.01f, 0.01f);
+                        OffsetBonesRot[currentBoneIndex] += new Vector3(0.01f, 0.01f, 0.01f);
                     }
                 }
                 else if (Input.GetKey(KeyCode.KeypadMinus)) // Zoom out ; Reduce Size
@@ -694,7 +745,11 @@ namespace Memoria.Assets
                     }
                     else if (partcontrolled == PartControlled.BONE)
                     {
+                        if (!OffsetBonesScale.ContainsKey(currentBoneIndex))
+                            OffsetBonesScale.Add(currentBoneIndex, Vector3.zero);
+
                         BoneSelected.localScale -= new Vector3(0.01f, 0.01f, 0.01f);
+                        OffsetBonesRot[currentBoneIndex] -= new Vector3(0.01f, 0.01f, 0.01f);
                     }
                 }
 
@@ -761,7 +816,7 @@ namespace Memoria.Assets
                 }
                 if (Input.GetKeyDown(KeyCode.R)) // Reset position/rotation
                 {
-                    if (shift)
+                    if (shift) // Reset Model
                     {
                         ChangeModel(currentGeoIndex);
                     }
@@ -1451,6 +1506,9 @@ namespace Memoria.Assets
             currentModelBones = null;
             currentBonesID.Clear();
             currentHiddenBonesID.Clear();
+            OffsetBonesPos.Clear();
+            OffsetBonesRot.Clear();
+            OffsetBonesScale.Clear();
             currentBoneIndex = 0;
             if (currentModel == null)
             {

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -10,10 +10,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection.Emit;
 using System.Text.RegularExpressions;
 using UnityEngine;
-using static EventDelegate;
 
 namespace Memoria.Assets
 {

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -728,7 +728,7 @@ namespace Memoria.Assets
                             OffsetBonesScale.Add(currentBoneIndex, Vector3.zero);
 
                         BoneSelected.localScale += new Vector3(0.01f, 0.01f, 0.01f);
-                        OffsetBonesRot[currentBoneIndex] += new Vector3(0.01f, 0.01f, 0.01f);
+                        OffsetBonesScale[currentBoneIndex] = BoneSelected.localScale;
                     }
                 }
                 else if (Input.GetKey(KeyCode.KeypadMinus)) // Zoom out ; Reduce Size
@@ -749,7 +749,7 @@ namespace Memoria.Assets
                             OffsetBonesScale.Add(currentBoneIndex, Vector3.zero);
 
                         BoneSelected.localScale -= new Vector3(0.01f, 0.01f, 0.01f);
-                        OffsetBonesRot[currentBoneIndex] -= new Vector3(0.01f, 0.01f, 0.01f);
+                        OffsetBonesScale[currentBoneIndex] = BoneSelected.localScale;
                     }
                 }
 
@@ -772,8 +772,25 @@ namespace Memoria.Assets
                     Log.Message("[MODEL] => " + geoList[currentGeoIndex].Name + ".offset = " + ModelTargetPos.Remove(ModelTargetPos.Length - 1) + ", " + ModelTargetRot.Remove(0, 1));
                     if (currentWeaponModel != null)
                         Log.Message("[WEAPON] => " + weapongeoList[currentWeaponGeoIndex].Name + ".offset = " + WeaponTargetPos.Remove(WeaponTargetPos.Length - 1) + ", " + WeaponTargetRot.Remove(0, 1));
-                    Log.Message("[BONE] => BoneID n°" + currentBoneIndex + " / Position = " + BoneSelectedPos + " ; Rotation(Quat) = " + BoneSelectedRot + " ; Rotation(Euler) = " + BoneSelectedRotEuler + " ; Scale = " + BoneSelectedScale);
-                    Log.Message("##################################");
+                    if (OffsetBonesPos.Count > 0 || OffsetBonesRot.Count > 0 || OffsetBonesScale.Count > 0)
+                    {
+                        Log.Message("[BONES] ");
+                        if (OffsetBonesPos.Count > 0)
+                            foreach (int BoneID in OffsetBonesPos.Keys)
+                            {
+                                Log.Message("   └> Bone n°"+ BoneID +" / Position / " + OffsetBonesPos[BoneID]);
+                            }
+                        if (OffsetBonesRot.Count > 0)
+                            foreach (int BoneID in OffsetBonesRot.Keys)
+                            {
+                                Log.Message("   └> Bone n°" + BoneID + " / Rotation (Euler) / " + OffsetBonesRot[BoneID]);
+                            }
+                        if (OffsetBonesScale.Count > 0)
+                            foreach (int BoneID in OffsetBonesScale.Keys)
+                            {
+                                Log.Message("   └> Bone n°" + BoneID + " / Scale / " + OffsetBonesScale[BoneID]);
+                            }
+                    }
                     DontSpamMessage = true;
                 }
                 if (Input.GetKeyUp(KeyCode.Keypad5))
@@ -879,6 +896,10 @@ namespace Memoria.Assets
                         else if (partcontrolled == PartControlled.BONE)
                         {
                             BoneSelected.localPosition -= mouseSensibility * new Vector3(mouseDelta.x, mouseDelta.y, mouseDelta.z);
+                            if (OffsetBonesPos.ContainsKey(currentBoneIndex))
+                                OffsetBonesPos[currentBoneIndex] -= mouseSensibility * new Vector3(mouseDelta.x, mouseDelta.y, mouseDelta.z);
+                            else
+                                OffsetBonesPos.Add(currentBoneIndex, mouseSensibility * new Vector3(mouseDelta.x, mouseDelta.y, mouseDelta.z));
                         }
                         if (geoList[currentGeoIndex].Kind == MODEL_KIND_SPS)
                             spsEffect.pos = currentModel.transform.localPosition;
@@ -943,6 +964,11 @@ namespace Memoria.Assets
                         }
                         else if (partcontrolled == PartControlled.BONE)
                         {
+                            if (!OffsetBonesRot.ContainsKey(currentBoneIndex))
+                                OffsetBonesRot.Add(currentBoneIndex, Vector3.zero);
+
+                            Vector3 PreviousRot = BoneSelected.localRotation.eulerAngles;
+
                             if (Math.Abs(mouseDelta.x) >= Math.Abs(mouseDelta.y))
                             {
                                 BoneSelected.localRotation *= Quaternion.Euler(0f, mouseDelta.x, 0f);
@@ -958,6 +984,8 @@ namespace Memoria.Assets
                                 if (horizontalFactor > 0.5f)
                                     BoneSelected.localRotation *= performedRot;
                             }
+
+                            OffsetBonesRot[currentBoneIndex] += (BoneSelected.localRotation.eulerAngles - PreviousRot);
                         }
                     }
                     mouseLeftPressed = true;
@@ -1022,7 +1050,11 @@ namespace Memoria.Assets
                         }
                         else if (partcontrolled == PartControlled.BONE)
                         {
+                            if (!OffsetBonesScale.ContainsKey(currentBoneIndex))
+                                OffsetBonesScale.Add(currentBoneIndex, Vector3.zero);
+
                             Single scrollMax = 10f;
+                            Vector3 PreviousValue = boneselected_scaleFactor;
                             if (Input.mouseScrollDelta.y > 0f)
                                 boneselected_scaleFactor *= 1f + scrollSpeed * Input.mouseScrollDelta.y;
                             else
@@ -1030,6 +1062,7 @@ namespace Memoria.Assets
                             boneselected_scaleFactor.x = Mathf.Clamp(boneselected_scaleFactor.x, scrollMin, scrollMax);
                             boneselected_scaleFactor.y = boneselected_scaleFactor.z = boneselected_scaleFactor.x;
                             BoneSelected.localScale = boneselected_scaleFactor;
+                            OffsetBonesScale[currentBoneIndex] = boneselected_scaleFactor;
                         }
                     }
                 }

--- a/Memoria.Patcher/StreamingAssets/Data/Characters/Abilities/AbilityFeatures.txt
+++ b/Memoria.Patcher/StreamingAssets/Data/Characters/Abilities/AbilityFeatures.txt
@@ -200,7 +200,7 @@
 ##    GetPartyMemberLevel(number)      -> Return the level of the n-th party member, with n being between 0 and 3 inclusively
 ##    GetPartyMemberIndex(number)      -> Return the Character Index of the n-th party member (see the different "CharacterId" below)
 ##    GetUnitProperty(CharacterIndex, 'Formula')
-##									   └> Retrieve properties of neither the caster nor the target.
+##                                     └> Retrieve properties of neither the caster nor the target.
 ##										Works also with CustomStatus to read specific variables.
 ##										Eg : GetUnitProperty(CharacterId_Steiner, 'StatusProperty CustomStatus21 Duelist')
 ##	  IsCharacterInParty(CharacterIndex) -> Check if the character is present in the current party.
@@ -212,7 +212,7 @@
 ##    GetMemoriaVector(ID, index)      -> Return the value from a vector (from the MemoriaDictionary HW function)
 ##    GetMemoriaDictionary(ID, index)  -> Return the value from a dictionary (from the MemoriaDictionary HW function)
 ##    HasKilledCharacter(killerID, CharacterIndexkilled)			   
-##									   └> Check if the unit (based on BattleUunit.Id) has K.Oed a player in battle.
+##                                     └> Check if the unit (based on BattleUunit.Id) has K.Oed a player in battle.
 ##    Gil                              -> The number of gil owned by the player
 ##    FrogCount                        -> The number of frogs catched
 ##    StealCount                       -> The number of successful steals

--- a/Memoria.Patcher/StreamingAssets/Data/Characters/Abilities/AbilityFeatures.txt
+++ b/Memoria.Patcher/StreamingAssets/Data/Characters/Abilities/AbilityFeatures.txt
@@ -155,7 +155,7 @@
 ##    EffectCasterFlags, CasterHPDamage, CasterMPDamage, EffectTargetFlags, HPDamage, MPDamage,
 ##    FigureInfo, Power, AbilityStatus, AbilityElement, AbilityElementForBonus, IsShortRanged,
 ##    AbilityCategory, AbilityFlags, Attack, AttackPower, DefencePower, StatusRate, HitRate,
-##    Evade, EffectFlags, DamageModifierCount, TranceIncrease, ItemSteal, Gil, IsDrain,
+##    Evade, EffectFlags, DamageModifierCount, TranceIncrease, ItemSteal, Gil, IsDrain, EatResult
 ##    BattleBonusAP,
 ##    Counter (formula defines the Ability ID of the counter),
 ##    ReturnMagic (formula should return 0),
@@ -184,6 +184,7 @@
 ##    GetRandomBit(number)             -> Return a random bit of the number seen as a binary number
 ##    GetAbilityUsageCount(ability ID) -> Return the number of times the player used an ability
 ##    GetItemCount(item ID)            -> Return the number of items owned by the player (works also on cards and key items)
+##    HasKeyItem(item ID)              -> Return if the player has a specific key item
 ##    CheckAnyStatus(list, condition)  -> Check if any status of the conditions is in the list (same as "(list & condition) != 0")
 ##    CheckAllStatus(list, condition)  -> Check if all the statuses of the conditions are in the list (same as "(list & condition) == condition")
 ##    CombineStatuses(list, addition)  -> Add all the additional statuses to the list (same as "list | addition")
@@ -198,10 +199,20 @@
 ##                                   "status filter" must be a list of filtering out statuses (eg. BattleStatus_Death will filter out dead units)
 ##    GetPartyMemberLevel(number)      -> Return the level of the n-th party member, with n being between 0 and 3 inclusively
 ##    GetPartyMemberIndex(number)      -> Return the Character Index of the n-th party member (see the different "CharacterId" below)
+##    GetUnitProperty(CharacterIndex, 'Formula')
+##									   └> Retrieve properties of neither the caster nor the target.
+##										Works also with CustomStatus to read specific variables.
+##										Eg : GetUnitProperty(CharacterId_Steiner, 'StatusProperty CustomStatus21 Duelist')
+##	  IsCharacterInParty(CharacterIndex) -> Check if the character is present in the current party.
 ##    GetCategoryKillCount(category)   -> Return the number of enemies of the specified category that were defeated by the player
 ##                                   0 for Humanoids, 1 for Beasts, 2 for Devils,     3 for Dragons,
 ##                                   4 for Undeads,   5 for Stones, 6 for Souls/Bugs, 7 for Flying/Birds
 ##    GetModelKillCount(model ID)      -> Return the number of enemies with a specific model that were defeated by the player
+##    GetEventGlobalByte(ID)		   -> Return the value from a global variable (eg. GetEventGlobalByte(1500) to read VARL_GenUInt8_1500)
+##    GetMemoriaVector(ID, index)      -> Return the value from a vector (from the MemoriaDictionary HW function)
+##    GetMemoriaDictionary(ID, index)  -> Return the value from a dictionary (from the MemoriaDictionary HW function)
+##    HasKilledCharacter(killerID, CharacterIndexkilled)			   
+##									   └> Check if the unit (based on BattleUunit.Id) has K.Oed a player in battle.
 ##    Gil                              -> The number of gil owned by the player
 ##    FrogCount                        -> The number of frogs catched
 ##    StealCount                       -> The number of successful steals
@@ -225,11 +236,14 @@
 ##    IsGarnetDepressed                -> Whether Garnet is in a depression state
 ##    BattleBonusAP                    -> The AP given by the current battle
 ##    UseSFXRework                     -> Whether the SFX Rework system is activated or not
+##    MemoriaLog(formula)              -> To debug your expression, in the Memoria.Log file.
 ##  
 ##  Permanent:
 ##    HP, MP, Level, Exp, CharacterIndex, SerialNumber, WeaponId, HeadId, WristId, ArmorId, AccessoryId
 ##    HasSA(support ability ID),
 ##    CanUseAbility(ability ID),
+##    HasLearntAbility(ability ID),
+##    HasLearntSupport(support ability ID),
 ##    (+ modifiable properties)
 ##  
 ##  BattleStart: only the common informations
@@ -244,7 +258,9 @@
 ##    IsMagicDefenceModified, IsMagicEvadeModified, CriticalRateBonus, CriticalRateWeakening,
 ##    IsAlternateStand,
 ##    HasSA(support ability ID),
-##    CanUseAbility(ability ID)
+##    CanUseAbility(ability ID),
+##    HasLearntAbility(ability ID),
+##    HasLearntSupport(support ability ID)
 ##  
 ##  Ability:
 ##    All those of "StatusInit" for both the caster and the target (eg. CasterMaxHP or TargetMaxHP),
@@ -271,6 +287,8 @@
 ##    AccessoryId, IsFlee, IsFleeByLuck,
 ##    HasSA(support ability ID),
 ##    CanUseAbility(ability ID),
+##    HasLearntAbility(ability ID),
+##    HasLearntSupport(support ability ID),
 ##    (+ modifiable properties)
 ##  
 #####################################################################################################
@@ -495,6 +513,8 @@
 ##    CasterMaxDamageLimit, CasterMaxMPDamageLimit,
 ##    CasterHasSA(support ability ID),
 ##    CasterCanUseAbility(ability ID),
+##    CasterHasLearntAbility(ability ID),
+##    CasterHasLearntSupport(support ability ID)
 ##    CommandId, AbilityId, ScriptId, Power, AbilityStatus, AbilityElement, AbilityElementForBonus,
 ##    ItemUseId, WeaponThrowShape, SpecialEffectId, TargetType, IsATBCommand, IsAbilityMultiTarget, IsShortSummon,
 ##    IsSpellReflected, IsCovered, IsDodged, IsShortRanged, IsReflectNull, IsMeteorMiss, AbilityCategory, MPCost,


### PR DESCRIPTION
Some features asked => https://github.com/Albeoris/Memoria/issues/390#issuecomment-2593754469 + some QOLs added for the Model Viewer.

- The Model Viewer stores the following new informations: 

Weapon_Model
Weapon_GeoIndex
Weapon_BoneIndex
Weapon_Position
Weapon_Rotation
Weapon_Scale

![image](https://github.com/user-attachments/assets/5d341ebf-ae6f-4dc4-98d3-70cab0b20081)

- It's now possible to change the size of a weapon.
![image](https://github.com/user-attachments/assets/0a86b831-92e8-4fb3-87ec-747ff23abf3f)

- When changing a weapon, the coordinates are kept.
- `Shift + R` => Reload the model.
- Now, it's possible to modify any of these 3 "parts" : the model, the weapon or the selected bone.
![image](https://github.com/user-attachments/assets/7a0474fc-6d4d-4835-a338-0ca900cfa920)

- Each parts can be modified by using the mouse or the keypad, on `position, rotation or scale`.
![image](https://github.com/user-attachments/assets/6e32ef50-9025-4f31-85b6-cb1a1f2d2d48)
![image](https://github.com/user-attachments/assets/78c2dac3-6564-409d-b362-002f9e467a39)
![image](https://github.com/user-attachments/assets/43c789d7-a9ea-40ad-83dd-9108026a95c9)
![image](https://github.com/user-attachments/assets/81bfbf36-2c46-4584-9894-cc78de792b9d)

The informations are also displayed at the top right, depend which part you control : 
![image](https://github.com/user-attachments/assets/3f516fe5-090e-4447-a986-35b430f5ee1c)
![image](https://github.com/user-attachments/assets/19860166-cbba-4be4-b20f-012a73f76a9a)
![image](https://github.com/user-attachments/assets/a4148c65-1656-454c-8fe4-f6e85c4dce11)

- New format when you press the `KeyPad 5` :
![image](https://github.com/user-attachments/assets/bbd75f8d-f441-4069-8b38-020413ab5a59)

- Some little fixes and code cleaning.
