### PR TITLE
Errors on bones text (Model Viewer)

### DIFF
--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -1,6 +1,5 @@
 ﻿using Assets.Scripts.Common;
 using Assets.Sources.Scripts.UI.Common;
-using FF9;
 using Memoria.Data;
 using Memoria.Prime;
 using Memoria.Scenes;
@@ -1198,7 +1197,7 @@ namespace Memoria.Assets
                             {
                                 if ((BonePos - boneDialogs[i].transform.localPosition).sqrMagnitude < 1 && boneDialogs[i].Phrase.Length > 8)
                                 {
-                                    String IDBone = boneDialogs[i].Phrase.Remove(0, 17);
+                                    String IDBone = boneDialogs[i].Phrase.Remove(0, 15);
                                     ID += $",{IDBone}[ENDN]";
                                     boneDialogs[i].Phrase = "";
                                     boneDialogs[boneDialogCount].Phrase = "";


### PR DESCRIPTION
Seems the bones text was broken since Text Rework by Tir : just change a value ;)

Before : 
![image](https://github.com/user-attachments/assets/34b09c2a-45cf-412a-b1a3-e0fa3195ce42)

After : 
![image](https://github.com/user-attachments/assets/a304f17d-e9b1-44ad-85fe-f9ecd6dcc3c1)
