### PR TITLE
Fix CharacterSecondWeapon in Trance

### DIFF
--- a/Assembly-CSharp/Global/btl_vfx.cs
+++ b/Assembly-CSharp/Global/btl_vfx.cs
@@ -217,7 +217,10 @@ public static class btl_vfx
             btl.weaponModels[0].offset_pos = btlParam.WeaponOffsetPos.ToVector3(false);
             btl.weaponModels[0].offset_rot = btlParam.GetWeaponRotationFixed(btl.weapon.ModelId, false);
         }
-        geo.geoAttach(btl.weapon_geo, btl.gameObject, btl.weapon_bone);
+        foreach (BTL_DATA.WEAPON_MODEL weapon in btl.weaponModels)
+            if (weapon.geo != null && weapon.bone >= 0)
+                geo.geoAttach(weapon.geo, btl.gameObject, weapon.bone);
+
         btl2d.ShowMessages(true);
     }
 


### PR DESCRIPTION
If a character use the `CharacterSecondWeapon` option, like Zidane using the same daggers in each hands, he lost his second dagger when entering in Trance.

`CharacterSecondWeapon ZIDANE_DAGGER 6 SAME_AS_MAIN`

Seen with Tirlititi, this bug is back because of this fix :

> Fix a bug with Lani's weapon disappearing in trance (and other similar situations of a weapon disappearing in trance).

https://github.com/Albeoris/Memoria/commit/522a98148d8cf9a1b4249e8e652773aacf8ac81c#diff-fedcc7e8110f4fff72b2f29d4798f4e6d24b97556c4fe5708fe452b54a131d61

Just changed the geoAttach part in `btl_vfx.SetTranceModel()`, to take in account all weapons.
Works fine also with monsters (Maliris exemple used by Tir from November).

![image](https://github.com/user-attachments/assets/f5cd9485-2e76-43e8-842b-53e02400af85)
