### PR TITLE
Custom battle effect glow (for BTL_DATA)

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -259,6 +259,7 @@
     <Compile Include="Global\battle\BattleMapCameraController.cs" />
     <Compile Include="Global\battle\BattlePlayerCharacter.cs" />
     <Compile Include="Global\battle\BattleRainRenderer.cs" />
+    <Compile Include="Global\EFFECT_GLOW.cs" />
     <Compile Include="Global\NormalSolver.cs" />
     <Compile Include="Global\SPS\BattleSPSSystem.cs" />
     <Compile Include="Global\battle\BattleStateSystem.cs" />

--- a/Assembly-CSharp/Global/BTL_DATA.cs
+++ b/Assembly-CSharp/Global/BTL_DATA.cs
@@ -292,7 +292,7 @@ public partial class BTL_DATA
     public Boolean bonus_given;
 
     public List<WEAPON_MODEL> weaponModels = new List<WEAPON_MODEL>();
-    public List<EFFECT_GLOW> GlowEffect = new List<EFFECT_GLOW>();
+    public List<EFFECT_GLOW> CustomGlowEffect = new List<EFFECT_GLOW>();
 
     public Boolean is_monster_transform;
     public MONSTER_TRANSFORM monster_transform;
@@ -329,15 +329,6 @@ public partial class BTL_DATA
         public List<BattleCommandId> disable_commands;
         public String[] motion_normal;
         public String[] motion_alternate;
-    }
-
-    public class EFFECT_GLOW
-    {
-        public int ID = -1;
-        public BattleStatusId Status = BattleStatusId.None;
-        public Int32 ColorKind = -1;
-        public Int32 ColorPriority = 0;
-        public Int32[] ColorBase = [0, 0, 0];
     }
 
     public class DelayedModifier

--- a/Assembly-CSharp/Global/BTL_DATA.cs
+++ b/Assembly-CSharp/Global/BTL_DATA.cs
@@ -292,6 +292,7 @@ public partial class BTL_DATA
     public Boolean bonus_given;
 
     public List<WEAPON_MODEL> weaponModels = new List<WEAPON_MODEL>();
+    public List<CUSTOM_GLOW> CustomGlowEffect = new List<CUSTOM_GLOW>();
 
     public Boolean is_monster_transform;
     public MONSTER_TRANSFORM monster_transform;
@@ -328,6 +329,15 @@ public partial class BTL_DATA
         public List<BattleCommandId> disable_commands;
         public String[] motion_normal;
         public String[] motion_alternate;
+    }
+
+    public class CUSTOM_GLOW
+    {
+        public int ID = -1;
+        public BattleStatusId Status = BattleStatusId.None;
+        public Int32 ColorKind = -1;
+        public Int32 ColorPriority = 0;
+        public Int32[] ColorBase = [0, 0, 0];
     }
 
     public class DelayedModifier

--- a/Assembly-CSharp/Global/BTL_DATA.cs
+++ b/Assembly-CSharp/Global/BTL_DATA.cs
@@ -292,7 +292,7 @@ public partial class BTL_DATA
     public Boolean bonus_given;
 
     public List<WEAPON_MODEL> weaponModels = new List<WEAPON_MODEL>();
-    public List<CUSTOM_GLOW> CustomGlowEffect = new List<CUSTOM_GLOW>();
+    public List<EFFECT_GLOW> GlowEffect = new List<EFFECT_GLOW>();
 
     public Boolean is_monster_transform;
     public MONSTER_TRANSFORM monster_transform;
@@ -331,7 +331,7 @@ public partial class BTL_DATA
         public String[] motion_alternate;
     }
 
-    public class CUSTOM_GLOW
+    public class EFFECT_GLOW
     {
         public int ID = -1;
         public BattleStatusId Status = BattleStatusId.None;

--- a/Assembly-CSharp/Global/EFFECT_GLOW.cs
+++ b/Assembly-CSharp/Global/EFFECT_GLOW.cs
@@ -2,7 +2,6 @@
 
 public class EFFECT_GLOW
 {
-    public int ID = -1;
     public Int32 ColorKind = -1;
     public Int32 ColorPriority = 0;
     public Int32[] ColorBase = [0, 0, 0];

--- a/Assembly-CSharp/Global/EFFECT_GLOW.cs
+++ b/Assembly-CSharp/Global/EFFECT_GLOW.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+public class EFFECT_GLOW
+{
+    public int ID = -1;
+    public Int32 ColorKind = -1;
+    public Int32 ColorPriority = 0;
+    public Int32[] ColorBase = [0, 0, 0];
+}

--- a/Assembly-CSharp/Global/btl_stat.cs
+++ b/Assembly-CSharp/Global/btl_stat.cs
@@ -339,7 +339,7 @@ public static class btl_stat
         }
         else if (data.bi.disappear == 0)
         {
-            data.CustomGlowEffect.Remove(data.CustomGlowEffect.FirstOrDefault(CustomGlowBTL => CustomGlowBTL.Status != BattleStatusId.None));
+            data.GlowEffect.Remove(data.GlowEffect.FirstOrDefault(CustomGlowBTL => CustomGlowBTL.Status != BattleStatusId.None));
             BBGINFO bbgInfoPtr = battlebg.nf_GetBbgInfoPtr();
             Int32 highestPriority = Int32.MinValue;
             Boolean useColor = false;
@@ -348,7 +348,7 @@ public static class btl_stat
                 BattleStatusDataEntry statusData = statusId.GetStatData();
                 if (statusData.ColorKind >= 0)
                 {
-                    BTL_DATA.CUSTOM_GLOW NewGlowEffect = new BTL_DATA.CUSTOM_GLOW()
+                    BTL_DATA.EFFECT_GLOW NewGlowEffect = new BTL_DATA.EFFECT_GLOW()
                     {
                         Status = statusId,
                         ColorKind = statusData.ColorKind,
@@ -358,28 +358,28 @@ public static class btl_stat
 
                     if (statusData.ColorPriority == highestPriority)
                     {
-                        data.CustomGlowEffect.Add(NewGlowEffect);
+                        data.GlowEffect.Add(NewGlowEffect);
                     }
                     else if (statusData.ColorPriority > highestPriority)
                     {
-                        data.CustomGlowEffect.Remove(data.CustomGlowEffect.FirstOrDefault(CustomGlowBTL => CustomGlowBTL.Status != BattleStatusId.None));
-                        data.CustomGlowEffect.Add(NewGlowEffect);
+                        data.GlowEffect.Remove(data.GlowEffect.FirstOrDefault(CustomGlowBTL => CustomGlowBTL.Status != BattleStatusId.None));
+                        data.GlowEffect.Add(NewGlowEffect);
                         highestPriority = statusData.ColorPriority;
                     }
                 }
             }
 
-            if (data.CustomGlowEffect.Count > 0)
+            if (data.GlowEffect.Count > 0)
             {
-                Int32 kind = data.CustomGlowEffect[0].ColorKind;
+                Int32 kind = data.GlowEffect[0].ColorKind;
                 useColor = true;
                 switch (kind)
                 {
                     case 0: // Like Freeze or Berserk
                     {
-                        Byte r = (Byte)Mathf.Clamp(bbgInfoPtr.chr_r + data.CustomGlowEffect[0].ColorBase[0], 0, Byte.MaxValue);
-                        Byte g = (Byte)Mathf.Clamp(bbgInfoPtr.chr_g + data.CustomGlowEffect[0].ColorBase[1], 0, Byte.MaxValue);
-                        Byte b = (Byte)Mathf.Clamp(bbgInfoPtr.chr_b + data.CustomGlowEffect[0].ColorBase[2], 0, Byte.MaxValue);
+                        Byte r = (Byte)Mathf.Clamp(bbgInfoPtr.chr_r + data.GlowEffect[0].ColorBase[0], 0, Byte.MaxValue);
+                        Byte g = (Byte)Mathf.Clamp(bbgInfoPtr.chr_g + data.GlowEffect[0].ColorBase[1], 0, Byte.MaxValue);
+                        Byte b = (Byte)Mathf.Clamp(bbgInfoPtr.chr_b + data.GlowEffect[0].ColorBase[2], 0, Byte.MaxValue);
                         if (!FF9StateSystem.Battle.isFade)
                             btl_util.GeoSetABR(data.gameObject, "PSX/BattleMap_StatusEffect", data);
                         btl_util.GeoSetColor2DrawPacket(data.gameObject, r, g, b, Byte.MaxValue);
@@ -389,12 +389,12 @@ public static class btl_stat
                     }
                     case 1: // Like Shell or Protect
                     {
-                        Int32 index = ff9Battle.btl_cnt / 24 % data.CustomGlowEffect.Count;
+                        Int32 index = ff9Battle.btl_cnt / 24 % data.GlowEffect.Count;
                         Byte counter = (Byte)(ff9Battle.btl_cnt % 24);
                         Byte strength = (Byte)(counter >= 8 ? (counter >= 16 ? (24 - counter) : 8) : counter);
-                        Int16 r = (Int16)((bbgInfoPtr.chr_r + data.CustomGlowEffect[index].ColorBase[0]) * strength >> 3);
-                        Int16 g = (Int16)((bbgInfoPtr.chr_g + data.CustomGlowEffect[index].ColorBase[1]) * strength >> 3);
-                        Int16 b = (Int16)((bbgInfoPtr.chr_b + data.CustomGlowEffect[index].ColorBase[2]) * strength >> 3);
+                        Int16 r = (Int16)((bbgInfoPtr.chr_r + data.GlowEffect[index].ColorBase[0]) * strength >> 3);
+                        Int16 g = (Int16)((bbgInfoPtr.chr_g + data.GlowEffect[index].ColorBase[1]) * strength >> 3);
+                        Int16 b = (Int16)((bbgInfoPtr.chr_b + data.GlowEffect[index].ColorBase[2]) * strength >> 3);
 
                         if (!FF9StateSystem.Battle.isFade)
                             btl_util.GeoSetABR(data.gameObject, "PSX/BattleMap_StatusEffect", data);
@@ -441,24 +441,24 @@ public static class btl_stat
             data.pos = pos;
         }
     }
-    public static void AddCustomGlowEffect(BTL_DATA btl, int ColorKind, int ColorPriority, int[] ColorBase, int ID)
+    public static void AddGlowEffect(BTL_DATA btl, int ColorKind, int ColorPriority, int[] ColorBase, int ID)
     {
-        BTL_DATA.CUSTOM_GLOW CustomGlowBTL = new BTL_DATA.CUSTOM_GLOW();
+        BTL_DATA.EFFECT_GLOW CustomGlowBTL = new BTL_DATA.EFFECT_GLOW();
         CustomGlowBTL.ID = ID;
         CustomGlowBTL.ColorKind = ColorKind;
         CustomGlowBTL.ColorPriority = ColorPriority;
         CustomGlowBTL.ColorBase = ColorBase;
-        btl.CustomGlowEffect.Add(CustomGlowBTL);
+        btl.GlowEffect.Add(CustomGlowBTL);
     }
 
-    public static void RemoveCustomGlowEffect(BTL_DATA btl, int ID)
+    public static void RemoveGlowEffect(BTL_DATA btl, int ID)
     {
-        btl.CustomGlowEffect.Remove(btl.CustomGlowEffect.FirstOrDefault(CustomGlowBTL => CustomGlowBTL.ID == ID));
+        btl.GlowEffect.Remove(btl.GlowEffect.FirstOrDefault(CustomGlowBTL => CustomGlowBTL.ID == ID));
     }
 
-    public static void ClearAllCustomGlowEffect(BTL_DATA btl)
+    public static void ClearAllGlowEffect(BTL_DATA btl)
     {
-        btl.CustomGlowEffect.Clear();
+        btl.GlowEffect.Clear();
     }
 
     public static void SetDefaultShader(BTL_DATA btl)

--- a/Assembly-CSharp/Global/btl_stat.cs
+++ b/Assembly-CSharp/Global/btl_stat.cs
@@ -448,19 +448,19 @@ public static class btl_stat
         }
     }
 
-    public static void AddGlowEffect(BTL_DATA btl, int ColorKind, int ColorPriority, int[] ColorBase, int ID)
+    public static EFFECT_GLOW AddCustomGlowEffect(BTL_DATA btl, int ColorKind, int ColorPriority, int[] ColorBase)
     {
         EFFECT_GLOW CustomGlowBTL = new EFFECT_GLOW();
-        CustomGlowBTL.ID = ID;
         CustomGlowBTL.ColorKind = ColorKind;
         CustomGlowBTL.ColorPriority = ColorPriority;
         CustomGlowBTL.ColorBase = ColorBase;
         btl.CustomGlowEffect.Add(CustomGlowBTL);
+        return CustomGlowBTL;
     }
 
-    public static void RemoveGlowEffect(BTL_DATA btl, int ID)
+    public static void RemoveGlowEffect(BTL_DATA btl, EFFECT_GLOW CustomGlowBTL)
     {
-        btl.CustomGlowEffect.Remove(btl.CustomGlowEffect.FirstOrDefault(CustomGlowBTL => CustomGlowBTL.ID == ID));
+        btl.CustomGlowEffect.Remove(CustomGlowBTL);
     }
 
     public static void ClearAllGlowEffect(BTL_DATA btl)

--- a/Assembly-CSharp/Memoria/Data/Battle/BattleStatusDataEntry.cs
+++ b/Assembly-CSharp/Memoria/Data/Battle/BattleStatusDataEntry.cs
@@ -24,9 +24,7 @@ namespace Memoria.Data
         public Int32 SHPAttach = 0;
         public Vector3 SHPExtraPos = default;
 
-        public Int32 ColorKind = -1;
-        public Int32 ColorPriority = 0;
-        public Int32[] ColorBase = [0, 0, 0];
+        public EFFECT_GLOW StatusGlowEffect = new EFFECT_GLOW();
 
         public void ParseEntry(String[] raw, CsvMetaData metadata)
         {
@@ -63,11 +61,12 @@ namespace Memoria.Data
                     SHPExtraPos = new Vector3(arrayf[0], 0f, arrayf[1]);
                 else if (arrayf.Length >= 3)
                     SHPExtraPos = new Vector3(arrayf[0], arrayf[1], arrayf[2]);
-                ColorKind = CsvParser.Int32(raw[index++]);
-                ColorPriority = CsvParser.Int32(raw[index++]);
-                ColorBase = CsvParser.Int32Array(raw[index++]);
-                if (ColorBase.Length < 3)
-                    Array.Resize(ref ColorBase, 3);
+
+                StatusGlowEffect.ColorKind = CsvParser.Int32(raw[index++]);
+                StatusGlowEffect.ColorPriority = CsvParser.Int32(raw[index++]);
+                StatusGlowEffect.ColorBase = CsvParser.Int32Array(raw[index++]);
+                if (StatusGlowEffect.ColorBase.Length < 3)
+                    Array.Resize(ref StatusGlowEffect.ColorBase, 3);
             }
             else
             {
@@ -93,20 +92,20 @@ namespace Memoria.Data
                         SHPExtraPos = new Vector3(92f, 0f, 0f);
                         break;
                     case BattleStatusId.Zombie:
-                        ColorKind = 0;
-                        ColorPriority = 100;
-                        ColorBase = [-48, -72, -88];
+                        StatusGlowEffect.ColorKind = 0;
+                        StatusGlowEffect.ColorPriority = 100;
+                        StatusGlowEffect.ColorBase = [-48, -72, -88];
                         break;
                     case BattleStatusId.Berserk:
                         SPSEffect = 7;
                         SPSAttach = 4;
-                        ColorKind = 0;
-                        ColorPriority = 95;
-                        ColorBase = [16, -40, -40];
+                        StatusGlowEffect.ColorKind = 0;
+                        StatusGlowEffect.ColorPriority = 95;
+                        StatusGlowEffect.ColorBase = [16, -40, -40];
                         break;
                     case BattleStatusId.Trance:
-                        ColorKind = 2;
-                        ColorPriority = 10;
+                        StatusGlowEffect.ColorKind = 2;
+                        StatusGlowEffect.ColorPriority = 10;
                         break;
                     case BattleStatusId.Poison:
                         SPSEffect = 0;
@@ -127,28 +126,28 @@ namespace Memoria.Data
                         SHPExtraPos = new Vector3(212f, 0f, 0f);
                         break;
                     case BattleStatusId.Shell:
-                        ColorKind = 1;
-                        ColorPriority = 50;
-                        ColorBase = [-64, 24, 72];
+                        StatusGlowEffect.ColorKind = 1;
+                        StatusGlowEffect.ColorPriority = 50;
+                        StatusGlowEffect.ColorBase = [-64, 24, 72];
                         break;
                     case BattleStatusId.Protect:
-                        ColorKind = 1;
-                        ColorPriority = 50;
-                        ColorBase = [40, 40, -80];
+                        StatusGlowEffect.ColorKind = 1;
+                        StatusGlowEffect.ColorPriority = 50;
+                        StatusGlowEffect.ColorBase = [40, 40, -80];
                         break;
                     case BattleStatusId.Heat:
                         SPSEffect = 3;
                         SPSAttach = 1;
-                        ColorKind = 0;
-                        ColorPriority = 90;
-                        ColorBase = [80, -16, -72];
+                        StatusGlowEffect.ColorKind = 0;
+                        StatusGlowEffect.ColorPriority = 90;
+                        StatusGlowEffect.ColorBase = [80, -16, -72];
                         break;
                     case BattleStatusId.Freeze:
                         SPSEffect = 4;
                         SPSAttach = 1;
-                        ColorKind = 0;
-                        ColorPriority = 85;
-                        ColorBase = [-48, 0, 96];
+                        StatusGlowEffect.ColorKind = 0;
+                        StatusGlowEffect.ColorPriority = 85;
+                        StatusGlowEffect.ColorBase = [-48, 0, 96];
                         break;
                     case BattleStatusId.Reflect:
                         SPSEffect = 5;
@@ -178,9 +177,9 @@ namespace Memoria.Data
                 sw.Int32(SHPEffect);
                 sw.Int32(SHPAttach);
                 sw.SingleArray([SHPExtraPos.x, SHPExtraPos.y, SHPExtraPos.z]);
-                sw.Int32(ColorKind);
-                sw.Int32(ColorPriority);
-                sw.Int32Array(ColorBase);
+                sw.Int32(StatusGlowEffect.ColorKind);
+                sw.Int32(StatusGlowEffect.ColorPriority);
+                sw.Int32Array(StatusGlowEffect.ColorBase);
             }
         }
     }


### PR DESCRIPTION
Just a little modification, to add custom effect glow for BTL_DATA!

Meaning you can simply create a custom aura or color skin on any units in battle, for more customisable visual effects for attacks or status!

Exemple :
`btl_stat.AddCustomGlowEffect(target, 0, 80, new int[]{ 250, 250, 250 }, 0);`

Here, create a white aura skin on the target.

You can remove them with their IDs or simply erase them all with `btl_stat.ClearAllCustomGlowEffect(target)`
