### PR TITLE
Fix launcher crash

### DIFF
--- a/Memoria.Launcher/MainWindow_ModManager.cs
+++ b/Memoria.Launcher/MainWindow_ModManager.cs
@@ -1118,13 +1118,20 @@ namespace Memoria.Launcher
                     }
                     else if (tabCtrlMain.SelectedIndex == 0 && mod.PreviewFileUrl != null)
                     {
-                        mod.PreviewImage = new BitmapImage(new Uri(mod.PreviewFileUrl, UriKind.Absolute));
-                        mod.PreviewImage.DownloadCompleted += OnPreviewFileDownloaded;
+                        try
+                        {
+                            mod.PreviewImage = new BitmapImage(new Uri(mod.PreviewFileUrl, UriKind.Absolute));
+                            mod.PreviewImage.DownloadCompleted += OnPreviewFileDownloaded;
+                        } catch { }
                     }
                     else if (tabCtrlMain.SelectedIndex == 1 && mod.PreviewFileUrl != null)
                     {
-                        mod.PreviewImage = new BitmapImage(new Uri(mod.PreviewFileUrl, UriKind.Absolute));
-                        mod.PreviewImage.DownloadCompleted += OnPreviewFileDownloaded;
+                        try
+                        {
+                            mod.PreviewImage = new BitmapImage(new Uri(mod.PreviewFileUrl, UriKind.Absolute));
+                            mod.PreviewImage.DownloadCompleted += OnPreviewFileDownloaded;
+                        }
+                        catch { }
                     }
                 }
                 if (mod.PreviewImage == null)


### PR DESCRIPTION
Fix launcher crash when PreviewUrl is empty in the ModDescription.xml of a mod.