### PR TITLE
New animation editing functionality in Model Viewer

### DIFF
--- a/Assembly-CSharp/Assets/Sources/Scripts/UI/Common/FF9UIDataTool.cs
+++ b/Assembly-CSharp/Assets/Sources/Scripts/UI/Common/FF9UIDataTool.cs
@@ -66,7 +66,7 @@ namespace Assets.Sources.Scripts.UI.Common
             Int32 columnIndex = 0;
             IEnumerable<KeyValuePair<RegularItem, Int32>> enumerator = items;
             if (items.Count == 1 && items.First().Value == 2)
-                enumerator = new List<KeyValuePair<RegularItem, Int32>>([new(items.First().Key, 1), new(items.First().Key, 1)]);
+                enumerator = new List<KeyValuePair<RegularItem, Int32>>() { new(items.First().Key, 1), new(items.First().Key, 1) };
             foreach (KeyValuePair<RegularItem, Int32> kvp in enumerator)
             {
                 if (kvp.Key == RegularItem.NoItem || kvp.Value <= 0)

--- a/Assembly-CSharp/Memoria/Assets/3DModel/AnimationClipReader.cs
+++ b/Assembly-CSharp/Memoria/Assets/3DModel/AnimationClipReader.cs
@@ -182,6 +182,17 @@ namespace Memoria.Assets
                             List<Keyframe> keys_y = new List<Keyframe>();
                             List<Keyframe> keys_z = new List<Keyframe>();
                             List<Keyframe> keys_w = new List<Keyframe>();
+
+                            List<Keyframe> keys_xIT = new List<Keyframe>();
+                            List<Keyframe> keys_yIT = new List<Keyframe>();
+                            List<Keyframe> keys_zIT = new List<Keyframe>();
+                            List<Keyframe> keys_wIT = new List<Keyframe>();
+
+                            List<Keyframe> keys_xOT = new List<Keyframe>();
+                            List<Keyframe> keys_yOT = new List<Keyframe>();
+                            List<Keyframe> keys_zOT = new List<Keyframe>();
+                            List<Keyframe> keys_wOT = new List<Keyframe>();
+
                             ta.transformType = localType;
                             foreach (JSONNode frameNode in rotArray.Childs)
                             {
@@ -216,7 +227,48 @@ namespace Memoria.Assets
                                     fa.pos.w = keyNode.AsFloat;
                                     keys_w.Add(new Keyframe(time, fa.pos.w));
                                 }
-                                // TODO: read inward/outward tangent (with keys "xInnerTangent", "xOuterTangent", etc.)
+
+                                if (frameClass.Dict.TryGetValue("xInnerTangent", out keyNode))
+                                {
+                                    fa.posInnerTangent.x = keyNode.AsFloat;
+                                    keys_xIT.Add(new Keyframe(time, fa.posInnerTangent.x));
+                                }
+                                if (frameClass.Dict.TryGetValue("yInnerTangent", out keyNode))
+                                {
+                                    fa.posInnerTangent.y = keyNode.AsFloat;
+                                    keys_yIT.Add(new Keyframe(time, fa.posInnerTangent.y));
+                                }
+                                if (frameClass.Dict.TryGetValue("zInnerTangent", out keyNode))
+                                {
+                                    fa.posInnerTangent.z = keyNode.AsFloat;
+                                    keys_zIT.Add(new Keyframe(time, fa.posInnerTangent.z));
+                                }
+                                if (frameClass.Dict.TryGetValue("wInnerTangent", out keyNode))
+                                {
+                                    fa.posInnerTangent.w = keyNode.AsFloat;
+                                    keys_wIT.Add(new Keyframe(time, fa.posInnerTangent.w));
+                                }
+
+                                if (frameClass.Dict.TryGetValue("xOuterTangent", out keyNode))
+                                {
+                                    fa.posOuterTangent.x = keyNode.AsFloat;
+                                    keys_xOT.Add(new Keyframe(time, fa.posOuterTangent.x));
+                                }
+                                if (frameClass.Dict.TryGetValue("yOuterTangent", out keyNode))
+                                {
+                                    fa.posOuterTangent.y = keyNode.AsFloat;
+                                    keys_yOT.Add(new Keyframe(time, fa.posOuterTangent.y));
+                                }
+                                if (frameClass.Dict.TryGetValue("zOuterTangent", out keyNode))
+                                {
+                                    fa.posOuterTangent.z = keyNode.AsFloat;
+                                    keys_zOT.Add(new Keyframe(time, fa.posOuterTangent.z));
+                                }
+                                if (frameClass.Dict.TryGetValue("wOuterTangent", out keyNode))
+                                {
+                                    fa.posOuterTangent.w = keyNode.AsFloat;
+                                    keys_wOT.Add(new Keyframe(time, fa.posOuterTangent.w));
+                                }
                             }
                             if (!keys_x.IsNullOrEmpty())
                             {
@@ -238,6 +290,49 @@ namespace Memoria.Assets
                                 animCurve = new AnimationCurve(keys_w.ToArray());
                                 clip.SetCurve(boneName, typeof(Transform), localType + ".w", animCurve);
                             }
+
+                            if (!keys_xIT.IsNullOrEmpty())
+                            {
+                                animCurve = new AnimationCurve(keys_xIT.ToArray());
+                                clip.SetCurve(boneName, typeof(Transform), localType + ".xInnerTangent", animCurve);
+                            }
+                            if (!keys_yIT.IsNullOrEmpty())
+                            {
+                                animCurve = new AnimationCurve(keys_yIT.ToArray());
+                                clip.SetCurve(boneName, typeof(Transform), localType + ".yInnerTangent", animCurve);
+                            }
+                            if (!keys_zIT.IsNullOrEmpty())
+                            {
+                                animCurve = new AnimationCurve(keys_zIT.ToArray());
+                                clip.SetCurve(boneName, typeof(Transform), localType + ".zInnerTangent", animCurve);
+                            }
+                            if (!keys_wIT.IsNullOrEmpty())
+                            {
+                                animCurve = new AnimationCurve(keys_wIT.ToArray());
+                                clip.SetCurve(boneName, typeof(Transform), localType + ".wInnerTangent", animCurve);
+                            }
+
+                            if (!keys_xOT.IsNullOrEmpty())
+                            {
+                                animCurve = new AnimationCurve(keys_xOT.ToArray());
+                                clip.SetCurve(boneName, typeof(Transform), localType + ".xOuterTangent", animCurve);
+                            }
+                            if (!keys_yOT.IsNullOrEmpty())
+                            {
+                                animCurve = new AnimationCurve(keys_yOT.ToArray());
+                                clip.SetCurve(boneName, typeof(Transform), localType + ".yOuterTangent", animCurve);
+                            }
+                            if (!keys_zOT.IsNullOrEmpty())
+                            {
+                                animCurve = new AnimationCurve(keys_zOT.ToArray());
+                                clip.SetCurve(boneName, typeof(Transform), localType + ".zOuterTangent", animCurve);
+                            }
+                            if (!keys_wOT.IsNullOrEmpty())
+                            {
+                                animCurve = new AnimationCurve(keys_wOT.ToArray());
+                                clip.SetCurve(boneName, typeof(Transform), localType + ".wOuterTangent", animCurve);
+                            }
+
                             ta.frameAnimList.AddRange(faDict.Values);
                             ba.transformAnimList.Add(ta);
                         }

--- a/Assembly-CSharp/Memoria/Assets/3DModel/FbxBinary.cs
+++ b/Assembly-CSharp/Memoria/Assets/3DModel/FbxBinary.cs
@@ -77,7 +77,8 @@ namespace Memoria.Assets
 
         const string timePath1 = "FBXHeaderExtension";
         const string timePath2 = "CreationTimeStamp";
-        static readonly Stack<string> timePath = new Stack<string>([timePath1, timePath2]);
+        static string[] timePaths = [ timePath1, timePath2 ];
+        static readonly Stack<string> timePath = new Stack<string>(timePaths);
 
         // Gets a single timestamp component
         static int GetTimestampVar(FbxNode timestamp, string element)

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -149,7 +149,7 @@ namespace Memoria.Assets
             extraInfoPanel = new ControlPanel(PersistenSingleton<UIManager>.Instance.transform, "");
             extraInfoLabel = extraInfoPanel.AddSimpleLabel("", NGUIText.Alignment.Center, 1);
             extraInfoPanel.EndInitialization(UIWidget.Pivot.BottomRight);
-            extraInfoPanel.BasePanel.SetRect(-50f, 0f, 1500f, 580f);
+            extraInfoPanel.BasePanel.SetRect(-50f, 0f, 1750f, 580f);
 
             InsertTextGUI = UnityEngine.Object.Instantiate(PersistenSingleton<UIManager>.Instance.NameSettingScene.NameInputField.gameObject);
             input = InsertTextGUI.GetComponent<UIInput>();
@@ -1359,6 +1359,11 @@ namespace Memoria.Assets
                         else camera.backgroundColor = Color.black;
                     }
                 }
+                if (Input.GetKeyDown(KeyCode.K) && isAnimStopped && currentAnimName == "CUSTOM_CLIP")
+                {
+                    AddKeyframeToCustomAnimation();
+                }
+
                 Animation animation = currentModel.GetComponent<Animation>();
                 if (animation != null && (!animation.IsPlaying(currentAnimName) || isAnimStopped) && toggleAnim) // make animation a loop by default
                 {
@@ -1574,10 +1579,15 @@ namespace Memoria.Assets
                     controlist += $"{entry.Value} [FFFF00][{entry.Key}][FFFFFF]\r\n";
                 controlLabel.rawText = controlist;
 
-                String extraInfo = "";
-                if (partcontrolled == PartControlled.MODEL && currentModel != null)
+                Animation animation = null;
+                if (currentModel != null)
                 {
-                    Animation animation = currentModel.GetComponent<Animation>();
+                    animation = currentModel.GetComponent<Animation>();
+                }
+
+                String extraInfo = "";
+                if (partcontrolled == PartControlled.MODEL && currentModel != null && animation != null)
+                {
                     if (currentModelWrapper == null)
                         currentModelWrapper = new GameObject("CurrentModelWrapper");
                     currentModel.transform.SetParent(currentModelWrapper.transform);
@@ -1587,14 +1597,11 @@ namespace Memoria.Assets
                     extraInfo += $" Rot(Quat): [x]{Math.Round(currentModelWrapper.transform.localRotation.x, 2)} [y]{Math.Round(currentModelWrapper.transform.localRotation.y, 2)} [z]{Math.Round(currentModelWrapper.transform.localRotation.z, 2)} [w]{Math.Round(currentModelWrapper.transform.localRotation.w, 2)}";
                     extraInfo += $" Rot(Eul): {Math.Round(currentModelWrapper.transform.localRotation.eulerAngles.x, 0)}/{Math.Round(currentModelWrapper.transform.localRotation.eulerAngles.y, 0)}/{Math.Round(currentModelWrapper.transform.localRotation.eulerAngles.z, 0)}";
                     extraInfo += $" Scale: {Math.Round(currentModelWrapper.transform.localScale.x, 2)}/{Math.Round(currentModelWrapper.transform.localScale.y, 2)}/{Math.Round(currentModelWrapper.transform.localScale.z, 2)}";
-
-                    int currentKeyFrame = (int)Math.Round((animation[currentAnimName].time % 1) * animation[currentAnimName].clip.frameRate);
-                    int maxKeyFrame = (int)Math.Round(animation[currentAnimName].clip.length * animation[currentAnimName].clip.frameRate);
-                    extraInfo += $" Frame: {currentKeyFrame}/{maxKeyFrame}";
+                    extraInfo += $" Frame: {Math.Round((animation[currentAnimName].time % 1) * animation[currentAnimName].clip.frameRate)}/{Math.Round(animation[currentAnimName].clip.length * animation[currentAnimName].clip.frameRate)}";
                     extraInfoLabel.color = Color.green;
                     //extraInfo += $" | Rot(Eul): {Math.Round(currentModelWrapper.transform.localRotation.eulerAngles.x,0)}/{Math.Round(currentModelWrapper.transform.localRotation.eulerAngles.y, 0)}/{Math.Round(currentModelWrapper.transform.localRotation.eulerAngles.z, 0)}";
                 }
-                if (partcontrolled == PartControlled.WEAPON && currentWeaponModel != null)
+                if (partcontrolled == PartControlled.WEAPON && currentWeaponModel != null && animation != null)
                 {
                     extraInfo += "[WEAPON] ¤ ";
                     extraInfo += UseModdedTextures ? "text_mod | " : "text_orig | ";
@@ -1602,9 +1609,10 @@ namespace Memoria.Assets
                     extraInfo += $" Rot(Quat): [x]{Math.Round(currentWeaponModel.transform.localRotation.x, 2)} [y]{Math.Round(currentWeaponModel.transform.localRotation.y, 2)} [z]{Math.Round(currentWeaponModel.transform.localRotation.z, 2)} [w]{Math.Round(currentWeaponModel.transform.localRotation.w, 2)}";
                     extraInfo += $" Rot(Eul): {Math.Round(currentWeaponModel.transform.localRotation.eulerAngles.x, 0)}/{Math.Round(currentWeaponModel.transform.localRotation.eulerAngles.y, 0)}/{Math.Round(currentWeaponModel.transform.localRotation.eulerAngles.z, 0)}";
                     extraInfo += $" Scale: {Math.Round(currentWeaponModel.transform.localScale.x, 2)}/{Math.Round(currentWeaponModel.transform.localScale.y, 2)}/{Math.Round(currentWeaponModel.transform.localScale.z, 2)}";
+                    extraInfo += $" Frame: {Math.Round((animation[currentAnimName].time % 1) * animation[currentAnimName].clip.frameRate)}/{Math.Round(animation[currentAnimName].clip.length * animation[currentAnimName].clip.frameRate)}";
                     extraInfoLabel.color = Color.cyan;
                 }
-                else if (partcontrolled == PartControlled.BONE && currentModel != null)
+                else if (partcontrolled == PartControlled.BONE && currentModel != null && animation != null)
                 {
                     Transform BoneSelected = currentModel.transform.GetChildByName("bone" + currentBoneIndex.ToString("D3"));
                     extraInfo += "[BONE] ¤ ";
@@ -1613,6 +1621,7 @@ namespace Memoria.Assets
                     extraInfo += $" Rot(Quat): [x]{Math.Round(BoneSelected.localRotation.x, 2)} [y]{Math.Round(BoneSelected.localRotation.y, 2)} [z]{Math.Round(BoneSelected.localRotation.z, 2)} [w]{Math.Round(BoneSelected.localRotation.w, 2)}";
                     extraInfo += $" Rot(Eul): {Math.Round(BoneSelected.localRotation.eulerAngles.x, 0)}/{Math.Round(BoneSelected.localRotation.eulerAngles.y, 0)}/{Math.Round(BoneSelected.localRotation.eulerAngles.z, 0)}";
                     extraInfo += $" Scale: {Math.Round(BoneSelected.localScale.x, 2)}/{Math.Round(BoneSelected.localScale.y, 2)}/{Math.Round(BoneSelected.localScale.z, 2)}";
+                    extraInfo += $" Frame: {Math.Round((animation[currentAnimName].time % 1) * animation[currentAnimName].clip.frameRate)}/{Math.Round(animation[currentAnimName].clip.length * animation[currentAnimName].clip.frameRate)}";
                     extraInfoLabel.color = new Color(0.85865f, 0.00327f, 0.48478f, 1f); // Deep Red
                 }
                 else if (partcontrolled == PartControlled.FLOOR && currentFloorModel != null)
@@ -1645,6 +1654,7 @@ namespace Memoria.Assets
                 //    controlist += $"\r\n";
                 //controlLabel.text = controlist;
             }
+
             infoPanel.BasePanel.transform.localPosition = new Vector3(0 + InfoPanelPosX, 0, 0);
             controlPanel.BasePanel.transform.localPosition = new Vector3(1000 + ControlPanelPosX, 0, 0);
             controlLabel.fontSize = 22;
@@ -1734,6 +1744,7 @@ namespace Memoria.Assets
             {"⇧R", "Full Reset"},
             {"Z", "Decrement Keyframe"},
             {"X", "Increment Keyframe"},
+            {"K", "Add New Keyframe"},
         };
 
         private static Camera GetCamera()
@@ -2944,6 +2955,158 @@ namespace Memoria.Assets
 
                 }
 
+                anim.RemoveClip("CUSTOM_CLIP");
+                anim.AddClip(clip, "CUSTOM_CLIP");
+                anim.Play("CUSTOM_CLIP");
+            }
+        }
+
+        private static void AddKeyframeToCustomAnimation()
+        {
+            if (isAnimStopped && currentAnimName == "CUSTOM_CLIP" && savedAnimationClip != null)
+            {
+                Animation anim = currentModel.GetComponent<Animation>();
+                AnimationClip clip = anim[currentAnimName].clip;
+                // Already at max animation length
+                if (clip.length >= 1.0f)
+                {
+                    FF9Sfx.FF9SFX_Play(102);
+                    return;
+                }
+
+                clip.legacy = true;
+                clip.frameRate = 30.0f;
+                clip.name = "CUSTOM_CLIP";
+
+                foreach (AnimationClipReader.BoneAnimation boneAnim in savedAnimationClip.boneAnimList)
+                {
+                    String boneName = boneAnim.boneNameInHierarchy;
+
+                    foreach (String localType in new String[] { "localRotation", "localPosition", "localScale" })
+                    {
+                        List<Keyframe> keys_x = new List<Keyframe>();
+                        List<Keyframe> keys_y = new List<Keyframe>();
+                        List<Keyframe> keys_z = new List<Keyframe>();
+                        List<Keyframe> keys_w = new List<Keyframe>();
+
+                        List<Keyframe> keys_xIT = new List<Keyframe>();
+                        List<Keyframe> keys_yIT = new List<Keyframe>();
+                        List<Keyframe> keys_zIT = new List<Keyframe>();
+                        List<Keyframe> keys_wIT = new List<Keyframe>();
+
+                        List<Keyframe> keys_xOT = new List<Keyframe>();
+                        List<Keyframe> keys_yOT = new List<Keyframe>();
+                        List<Keyframe> keys_zOT = new List<Keyframe>();
+                        List<Keyframe> keys_wOT = new List<Keyframe>();
+
+                        foreach (AnimationClipReader.BoneAnimation.TransformAnimation ta in boneAnim.transformAnimList)
+                        {
+                            if (ta.transformType == localType)
+                            {
+                                int keyFrame = 0;
+                                AnimationClipReader.BoneAnimation.TransformAnimation.FrameAnimation keyframeAnim = ta.frameAnimList[currentPausedKeyFrame];
+                                AnimationClipReader.BoneAnimation.TransformAnimation.FrameAnimation duplicateKeyframeAnim = new AnimationClipReader.BoneAnimation.TransformAnimation.FrameAnimation();
+
+                                // copy to the frame directly after current
+                                duplicateKeyframeAnim.pos = new Vector4(keyframeAnim.pos.x, keyframeAnim.pos.y, keyframeAnim.pos.z, keyframeAnim.pos.w);
+                                duplicateKeyframeAnim.posInnerTangent = new Vector4(keyframeAnim.posInnerTangent.x, keyframeAnim.posInnerTangent.y, keyframeAnim.posInnerTangent.z, keyframeAnim.posInnerTangent.w);
+                                duplicateKeyframeAnim.posOuterTangent = new Vector4(keyframeAnim.posOuterTangent.x, keyframeAnim.posOuterTangent.y, keyframeAnim.posOuterTangent.z, keyframeAnim.posOuterTangent.w);
+
+                                ta.frameAnimList.Insert(currentPausedKeyFrame + 1, duplicateKeyframeAnim);
+
+                                foreach (AnimationClipReader.BoneAnimation.TransformAnimation.FrameAnimation fa in ta.frameAnimList)
+                                {
+                                    // Recalculate frame times
+                                    fa.time = (float)(Math.Round(keyFrame / clip.frameRate, 6));
+
+                                    keys_x.Add(new Keyframe(fa.time, fa.pos.x));
+                                    keys_y.Add(new Keyframe(fa.time, fa.pos.y));
+                                    keys_z.Add(new Keyframe(fa.time, fa.pos.z));
+                                    keys_w.Add(new Keyframe(fa.time, fa.pos.w));
+
+                                    keys_xIT.Add(new Keyframe(fa.time, fa.posInnerTangent.x));
+                                    keys_yIT.Add(new Keyframe(fa.time, fa.posInnerTangent.y));
+                                    keys_zIT.Add(new Keyframe(fa.time, fa.posInnerTangent.z));
+                                    keys_wIT.Add(new Keyframe(fa.time, fa.posInnerTangent.w));
+
+                                    keys_xOT.Add(new Keyframe(fa.time, fa.posOuterTangent.x));
+                                    keys_yOT.Add(new Keyframe(fa.time, fa.posOuterTangent.y));
+                                    keys_zOT.Add(new Keyframe(fa.time, fa.posOuterTangent.z));
+                                    keys_wOT.Add(new Keyframe(fa.time, fa.posOuterTangent.w));
+                                    keyFrame++;
+                                }
+
+                                animStoppedTime = duplicateKeyframeAnim.time;
+                            }
+                        }
+
+                        AnimationCurve animCurve;
+                        if (!keys_x.IsNullOrEmpty())
+                        {
+                            animCurve = new AnimationCurve(keys_x.ToArray());
+                            clip.SetCurve(boneName, typeof(Transform), localType + ".x", animCurve);
+                        }
+                        if (!keys_y.IsNullOrEmpty())
+                        {
+                            animCurve = new AnimationCurve(keys_y.ToArray());
+                            clip.SetCurve(boneName, typeof(Transform), localType + ".y", animCurve);
+                        }
+                        if (!keys_z.IsNullOrEmpty())
+                        {
+                            animCurve = new AnimationCurve(keys_z.ToArray());
+                            clip.SetCurve(boneName, typeof(Transform), localType + ".z", animCurve);
+                        }
+                        if (!keys_w.IsNullOrEmpty())
+                        {
+                            animCurve = new AnimationCurve(keys_w.ToArray());
+                            clip.SetCurve(boneName, typeof(Transform), localType + ".w", animCurve);
+                        }
+
+                        if (!keys_xIT.IsNullOrEmpty())
+                        {
+                            animCurve = new AnimationCurve(keys_xIT.ToArray());
+                            clip.SetCurve(boneName, typeof(Transform), localType + ".xInnerTangent", animCurve);
+                        }
+                        if (!keys_yIT.IsNullOrEmpty())
+                        {
+                            animCurve = new AnimationCurve(keys_yIT.ToArray());
+                            clip.SetCurve(boneName, typeof(Transform), localType + ".yInnerTangent", animCurve);
+                        }
+                        if (!keys_zIT.IsNullOrEmpty())
+                        {
+                            animCurve = new AnimationCurve(keys_zIT.ToArray());
+                            clip.SetCurve(boneName, typeof(Transform), localType + ".zInnerTangent", animCurve);
+                        }
+                        if (!keys_wIT.IsNullOrEmpty())
+                        {
+                            animCurve = new AnimationCurve(keys_wIT.ToArray());
+                            clip.SetCurve(boneName, typeof(Transform), localType + ".wInnerTangent", animCurve);
+                        }
+
+                        if (!keys_xOT.IsNullOrEmpty())
+                        {
+                            animCurve = new AnimationCurve(keys_xOT.ToArray());
+                            clip.SetCurve(boneName, typeof(Transform), localType + ".xOuterTangent", animCurve);
+                        }
+                        if (!keys_yOT.IsNullOrEmpty())
+                        {
+                            animCurve = new AnimationCurve(keys_yOT.ToArray());
+                            clip.SetCurve(boneName, typeof(Transform), localType + ".yOuterTangent", animCurve);
+                        }
+                        if (!keys_zOT.IsNullOrEmpty())
+                        {
+                            animCurve = new AnimationCurve(keys_zOT.ToArray());
+                            clip.SetCurve(boneName, typeof(Transform), localType + ".zOuterTangent", animCurve);
+                        }
+                        if (!keys_wOT.IsNullOrEmpty())
+                        {
+                            animCurve = new AnimationCurve(keys_wOT.ToArray());
+                            clip.SetCurve(boneName, typeof(Transform), localType + ".wOuterTangent", animCurve);
+                        }
+                    }
+                }
+
+                currentPausedKeyFrame++;
                 anim.RemoveClip("CUSTOM_CLIP");
                 anim.AddClip(clip, "CUSTOM_CLIP");
                 anim.Play("CUSTOM_CLIP");

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -1546,8 +1546,8 @@ namespace Memoria.Assets
                     extraInfo += $" Rot(Eul): {Math.Round(currentModelWrapper.transform.localRotation.eulerAngles.x, 0)}/{Math.Round(currentModelWrapper.transform.localRotation.eulerAngles.y, 0)}/{Math.Round(currentModelWrapper.transform.localRotation.eulerAngles.z, 0)}";
                     extraInfo += $" Scale: {Math.Round(currentModelWrapper.transform.localScale.x, 2)}/{Math.Round(currentModelWrapper.transform.localScale.y, 2)}/{Math.Round(currentModelWrapper.transform.localScale.z, 2)}";
 
-                    int currentKeyFrame = (int)Math.Round(animation[currentAnimName].clip.length * (animation[currentAnimName].time % 1) * animation[currentAnimName].clip.frameRate);
-                    int maxKeyFrame = (int)Math.Round(animation[currentAnimName].clip.length * (animation[currentAnimName].length % 1) * animation[currentAnimName].clip.frameRate);
+                    int currentKeyFrame = (int)Math.Round((animation[currentAnimName].time % 1) * animation[currentAnimName].clip.frameRate);
+                    int maxKeyFrame = (int)Math.Round(animation[currentAnimName].clip.length * animation[currentAnimName].clip.frameRate);
                     extraInfo += $" Frame: {currentKeyFrame}/{maxKeyFrame}";
                     extraInfoLabel.color = Color.green;
                     //extraInfo += $" | Rot(Eul): {Math.Round(currentModelWrapper.transform.localRotation.eulerAngles.x,0)}/{Math.Round(currentModelWrapper.transform.localRotation.eulerAngles.y, 0)}/{Math.Round(currentModelWrapper.transform.localRotation.eulerAngles.z, 0)}";
@@ -2779,15 +2779,15 @@ namespace Memoria.Assets
                 AnimationClip clip = animationState.clip;
                 if (clip != null)
                 {
-                    int currentKeyFrame = (int)Math.Round(clip.length * (animationState.time % 1) * clip.frameRate);
-                    int maxKeyFrame = (int)Math.Round(clip.length * animationState.length * clip.frameRate);
+                    int currentKeyFrame = (int)Math.Round((animationState.time % 1) * clip.frameRate);
+                    int maxKeyFrame = (int)Math.Round(clip.length * clip.frameRate);
                     int nextKeyFrame = ((currentKeyFrame + frames) % (maxKeyFrame + 1));
                     if (nextKeyFrame < 0)
                     {
                         nextKeyFrame += maxKeyFrame + 1;
                     }
 
-                    float nextAnimTime = nextKeyFrame / (clip.length * clip.frameRate);
+                    float nextAnimTime = nextKeyFrame / clip.frameRate;
                     if (nextAnimTime > animationState.length)
                     {
                         nextAnimTime = animationState.length;


### PR DESCRIPTION
At the request of @WarpedEdge I have begun working on adding some new functionality to the model viewer so that animations can be edited/added/saved in a format compatible with the game. This will include:
- the ability to pause and iterate over all of the animations key frames
- editing model bone position/rotation/scale
- saving new animations
- adding new keyframes to these custom animations

This is still a work in progress at the moment but the first 3 bullet points above are currently working.
The .anim files must first be exported from Hades Workshop and placed in the `StreamingAssets\Assets\Resources\Animations\` folder, then in the Model Viewer, first press `E` to generate an export file and `E` again to export the existing animation. Then press `L` to load that animation as a custom clip. Once the custom clip is loaded, you can press `Space` to pause the animation and use `Z` and `X` to decrement/increment the current paused keyframe. From here, you can select and bone and modify it and then press `Space` again to view the modified animation. Pressing `E` twice again to export will save this custom animation into a new .anim file (from the export configuration file).


https://github.com/user-attachments/assets/729811ab-15cc-49a7-8bba-b8d6702ba3aa


https://github.com/user-attachments/assets/e08d4ad2-1a7a-4a0a-99ae-4696ebf6149d

