### PR TITLE
Mod Catalog Update : Kupo Heroes Pack 

### DIFF
--- a/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
+++ b/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
@@ -711,23 +711,30 @@ This mod was initially introduced as the Exp challenge tweaks within Kupo Mods, 
 
 <Mod>
 	<Name>Kupo Heroes Pack</Name>
-	<Version>4.1.8</Version>
+	<Version>4.2</Version>
 	<Priority>-13</Priority>
 	<InstallationPath>KupoHeroPack</InstallationPath>
-	<ReleaseDate>2025-06-03</ReleaseDate>
+	<ReleaseDate>2025-06-30</ReleaseDate>
 	<ReleaseDateOriginal>2024-05-10</ReleaseDateOriginal>
 	<Author>faospark</Author>
-	<Description>A set of Character enhancements that powers up characters and reduces grind. Ideal for players seeking 
-a fresh character experience without changing the story, flow, or core gameplay mechanics.
-See the readme.txt for more details.
-Mod Order:
-- Place above Beatrix and Tantalus mods.
+	<Description>
+A set of character enhancements that empower your party and reduce grinding. Ideal for players seeking a fresh character experience without significantly altering the core game.
 
-Part of Kupo Mods formerly Mog Add-ons.
+See the readme.txt for more details.
+
+Mod Order:
+- Place above the Beatrix (Compatible), Tantalus (Compatible), Alternate Fantasy (Compatible), and Playable Character Pack (Compatible) mods.
+- Must be placed below FernySupportTweaks (Compatible).
+
+Part of Kupo Mods, formerly Mog Add-ons.
 	</Description>
-	<PatchNotes>
-	- Fixed mod group issue to ensure modularity. 
-	- Added Compatibility with Alternate fantasy and playable character pack </PatchNotes>
+	<PatchNotes>- Expanded Photons: Now known as the Lumi spells for Garnet (Holy single-target spells).
+- Enhanced Quina's abilities in Alternate Fantasy: Eat now works at 90% enemy HP; Cook is not included in AF.
+- Fixed Save the Queen abilities for Alternate Fantasy compatibility.
+- Added status effects for Wind (Confusion) and Earth (Trouble) spells in Alternate Fantasy.
+- Corrected Italian translation for Vivi's spells.
+- Special: Visit Daguerreo and speak to the character name changer for new features (note: not all users utilize Kupo modern labels). 
+	</PatchNotes>
 	<Category>Gameplay</Category>
 	<IncompatibleWith>Trance Seek</IncompatibleWith>
 	<Website>https://www.nexusmods.com/finalfantasy9/mods/78</Website>
@@ -740,7 +747,7 @@ Part of Kupo Mods formerly Mog Add-ons.
 		<Name>Add Resistance to Zombie and Virus </Name>
 		<InstallationPath>Features/All</InstallationPath>
 		<Description>Auto-life resists Zombie, Anti-body Resists Virus </Description>
-		<Default/>		
+		<Default/>
 	</SubMod>
 	<SubMod>
 		<Name>Bye Auto-Potion </Name>
@@ -777,11 +784,10 @@ Part of Kupo Mods formerly Mog Add-ons.
 		<Group>g-wm</Group>
 	</SubMod>
 	<Header>Character Tweaks</Header>
-	<Header>Eiko</Header>
 	<SubMod>
 		<Name>[Eiko] The Summoner  </Name>
 		<InstallationPath>Features/Eiko</InstallationPath>
-		<Description>Splits Titan and Fenrir as their won independent summon</Description>
+		<Description>Splits Titan and Fenrir as their own independent summon</Description>
 		<Group>g-eiko</Group>
 	</SubMod>
 	<SubMod>
@@ -812,7 +818,7 @@ Part of Kupo Mods formerly Mog Add-ons.
 		<Name>[Garnet] The White Mage</Name>
 		<InstallationPath>Features/Garnet</InstallationPath>
 		<Description>Adds A White Magic Ability to Garnet that causes damage</Description>
-		<Group>g-garnet</Group>		
+		<Group>g-garnet</Group>
 	</SubMod>
 	<SubMod>
 		<Name>[Amaranth] The Genius Nomad </Name>
@@ -832,57 +838,57 @@ Part of Kupo Mods formerly Mog Add-ons.
 		<Description>Add Basic stat Support for Beatrix based of the Beatrix mod  </Description>
 		<Group>g-beatrix</Group>
 	</SubMod>
-	<Header>Compatability for Alternate Fantasy</Header>
+	<Header>Compatibility for Alternate Fantasy</Header>
 	<SubMod>
-		<Name>[Eiko] The Summoner</Name>
+		<Name>[Eiko-AF] The Summoner</Name>
 		<InstallationPath>Features/Eiko-AF</InstallationPath>
 		<Description>Splits Titan and Fenrir as their own independent summon</Description>
 		<Group>g-eiko</Group>
 	</SubMod>
 	<SubMod>
-		<Name>[Freya] The Dragoon  </Name>
+		<Name>[Freya-AF] The Dragoon  </Name>
 		<InstallationPath>Features/Freya-AF</InstallationPath>
 		<Description>Make Freya's High Jump do 3x damage, Early Access to High Jump and Taharka drops Kain Lance </Description>
 		<Group>g-freya</Group>
 	</SubMod>
 	<SubMod>
-		<Name>[Quina] The Chef</Name>
+		<Name>[Quina-AF] The Chef</Name>
 		<InstallationPath>Features/Quina-AF</InstallationPath>
-		<Description>Easy Eat with Gastro Fork. WARNING simply cant be identical as the feature above</Description>
+		<Description>Easy Eat with all Forks. WARNING simply cant be identical as the Vanilla Version</Description>
 		<Group>g-quina</Group>
 	</SubMod>
 	<SubMod>
-		<Name>[Steiner] The Queens Knight</Name>
+		<Name>[Steiner-AF] The Queens Knight</Name>
 		<InstallationPath>Features/Steiner-AF</InstallationPath>
 		<Description>Steiner can Equip Save the Queen, has access to all Vivi's additional spell </Description>
 		<Group>g-steiner</Group>
 	</SubMod>
 	<SubMod>
-		<Name>[Vivi] The Warlock</Name>
+		<Name>[Vivi-AF] The Warlock</Name>
 		<InstallationPath>Features/Vivi-AF</InstallationPath>
 		<Description>Vivi and Steiner can Cast Aero, Quake, Water to RA to AGA spells </Description>
 		<Group>g-vivi</Group>
 	</SubMod>
 	<SubMod>
-		<Name>[Garnet] The White Mage</Name>
+		<Name>[Garnet-AF] The White Mage</Name>
 		<InstallationPath>Features/Garnet-AF</InstallationPath>
 		<Description>Adds A White Magic Ability to Garnet that causes damage</Description>
 		<Group>g-garnet</Group>
 	</SubMod>
 	<SubMod>
-		<Name>[Amaranth] The Genius Nomad</Name>
+		<Name>[Amaranth-AF] The Genius Nomad</Name>
 		<InstallationPath>Features/Amaranth-AF</InstallationPath>
 		<Description>Amaranth learns the Passive Tensai which makes him Learn and Level UP fast</Description>
 		<Group>g-amaranth</Group>
 	</SubMod>
 	<SubMod>
-		<Name>[Zidane] The Pillager</Name>
+		<Name>[Zidane-AF] The Pillager</Name>
 		<InstallationPath>Features/Zidane-AF</InstallationPath>
 		<Description>Boosts damage of thievery, Doubles items received after battle</Description>
 		<Group>g-zidane</Group>
-	</SubMod>	
+	</SubMod>
 	<SubMod>
-		<Name>[Beatrix] The Paladin </Name>
+		<Name>[Beatrix-AF] The Paladin </Name>
 		<InstallationPath>Features/Beatrix-AF</InstallationPath>
 		<Description>Add Basic stat Support for Beatrix based of the Beatrix mod  </Description>
 		<Group>g-beatrix</Group>
@@ -2551,7 +2557,7 @@ Ideal for those who were introduced to the series post final fantasy 12. Simply 
 For now the primary focus of the mod is the US and UK translation of the game so non english language players feel free to message me if you have something you want to change in your 
 Language of choice. 
 	</Description>
-	<PatchNotes>Added default Intended default names of Amarant and Freja</PatchNotes>
+	<PatchNotes>Added Intended default names of Amarant and Freya</PatchNotes>
 	<Category>Translation</Category>
 	<Website>https://www.nexusmods.com/finalfantasy9/mods/74</Website>
 	<DownloadUrl>https://www.dropbox.com/scl/fi/mi4qmy3h2qqoa57bf8wzu/KupoModernLabels.zip?rlkey=hfbawmgaiijosth1u6wcomwbk&amp;st=zcvbfu94&amp;dl=1</DownloadUrl>

--- a/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
+++ b/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
@@ -2572,7 +2572,7 @@ Language of choice.
 		<Default/>
 	</SubMod>
 		<SubMod>
-		<Name>Freija and Salamader</Name>
+		<Name>Freija and Salamander</Name>
 		<InstallationPath>Names</InstallationPath>
 		<Description>Changes the default names of Freya and Amarant for both English Translations</Description>
 		<Priority>2</Priority>


### PR DESCRIPTION
A new update for Kupo Heroes Pack 
- Expanded Photons: Now known as the Lumi spells for Garnet (Holy single-target spells).
- Enhanced Quina's abilities in Alternate Fantasy: Eat now works at 90% enemy HP; Cook is not included in AF.
- Fixed Save the Queen abilities for Alternate Fantasy compatibility.
- Added status effects for Wind (Confusion) and Earth (Trouble) spells in Alternate Fantasy.
- Corrected Italian translation for Vivi's spells.
- Special: Visit Daguerreo and speak to the character name changer for new features (note: not all users utilize Kupo modern labels).

Fixed Typo for Kupo Modern Labels