### PR TITLE
Add 4K Video Pack (Ultimate Remaster) to catalog 

### DIFF
--- a/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
+++ b/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
@@ -72,7 +72,7 @@ Snouz - syncronization</Description>
     Ultimate Remaster
   </Description>
   <Website>https://youtube.com/@UltimateRemasterGames</Website>
-  <DownloadUrl>https://ultimateremaster.com/download-ff09-4k-video-pack</DownloadUrl>
+  <DownloadUrl>https://gigenet.dl.sourceforge.net/project/ff09-4k-video-pack/v1.0/4K%20Video%20Pack%20-%20Ultimate%20Remaster.zip?viasf=1</DownloadUrl>
   <DownloadFormat>Zip</DownloadFormat>
   <PreviewFileUrl>https://raw.githubusercontent.com/UltimateRemaster/ultimate-remaster-assets/main/Ultimate%20Remaster%20-%204k%20Video%20Pack%20Memoria%20(1).png</PreviewFileUrl>
 </Mod>

--- a/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
+++ b/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
@@ -72,7 +72,7 @@ Snouz - syncronization</Description>
     Ultimate Remaster
   </Description>
   <Website>https://youtube.com/@UltimateRemasterGames</Website>
-  <DownloadUrl>https://www.moddb.com/downloads/start/295965</DownloadUrl>
+  <DownloadUrl>https://www.dropbox.com/scl/fi/1r9cf5t7o1534ekuzuex6/4K-Video-Pack-Ultimate-Remaster.zip?rlkey=f9oh2b2gyvddz0om2ga68wpcq&amp;st=mbhafkqv&amp;dl=1</DownloadUrl>
   <DownloadFormat>Zip</DownloadFormat>
   <PreviewFileUrl>https://raw.githubusercontent.com/UltimateRemaster/ultimate-remaster-assets/main/Ultimate%20Remaster%20-%204k%20Video%20Pack%20Memoria%20(1).png</PreviewFileUrl>
 </Mod>

--- a/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
+++ b/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
@@ -72,7 +72,7 @@ Snouz - syncronization</Description>
     Ultimate Remaster
   </Description>
   <Website>https://youtube.com/@UltimateRemasterGames</Website>
-  <DownloadUrl>https://gigenet.dl.sourceforge.net/project/ff09-4k-video-pack/v1.0/4K%20Video%20Pack%20-%20Ultimate%20Remaster.zip?viasf=1</DownloadUrl>
+  <DownloadUrl>https://www.moddb.com/downloads/start/295965</DownloadUrl>
   <DownloadFormat>Zip</DownloadFormat>
   <PreviewFileUrl>https://raw.githubusercontent.com/UltimateRemaster/ultimate-remaster-assets/main/Ultimate%20Remaster%20-%204k%20Video%20Pack%20Memoria%20(1).png</PreviewFileUrl>
 </Mod>

--- a/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
+++ b/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
@@ -65,7 +65,7 @@ Snouz - syncronization</Description>
     4) Optimize motion playback through encoding refinements, adjusting frame timing and keyframe placement to enhance smoothness.
 
     MOD PRIORITY:
-    This mod needs to be positioned above the Moguri Mods in the Installed Mods list here in Memory Launcher, otherwise Moguri Mod Motion Backgrouns and FMVs will bypass the 4k remastered videos and prevent them from being displayed.
+    This mod needs to be positioned above the Moguri Mods in the Installed Mods list here in Memoria Launcher, otherwise Moguri Mod Motion Backgrouns and FMVs will bypass the 4k remastered videos and prevent them from being displayed.
 
     I HOPE YOU ALL ENJOY IT!
     Best regards,

--- a/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
+++ b/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
@@ -45,15 +45,15 @@ Snouz - syncronization</Description>
 </Mod>
 
 <Mod>
-  <Name>4K Video Pack</Name>
-  <Version>1.0</Version>
-  <Priority>-31</Priority>
-  <InstallationPath>4K Video Pack - Ultimate Remaster</InstallationPath>
-  <Author>Ultimate Remaster</Author>
-  <Category>Visual</Category>
-  <ReleaseDateOriginal>2025-08-27</ReleaseDateOriginal>
-  <ReleaseDate>2025-08-27</ReleaseDate>
-  <Description>A QUARTER OF A CENTURY LATER, THE LEGEND SHINES BRIGHTER...
+	<Name>4K Video Pack</Name>
+	<Version>1.0</Version>
+	<Priority>-31</Priority>
+	<InstallationPath>4K Video Pack - Ultimate Remaster</InstallationPath>
+	<Author>Ultimate Remaster</Author>
+	<Category>Visual</Category>
+	<ReleaseDateOriginal>2025-08-27</ReleaseDateOriginal>
+	<ReleaseDate>2025-08-27</ReleaseDate>
+	<Description>A QUARTER OF A CENTURY LATER, THE LEGEND SHINES BRIGHTER...
 
     Today, in celebration of its 25th anniversary (July 7, 2025), this remaster transforms every FMV into true 4k high definition (2880x2160p 4:3) — restoring details lost over time to heavy compression, pixelation, noise, and blur, all while faithfully preserving the original artistic style with professional care, patience, hard work and a lot of time leveraging AI and handmade adjustments, to bring back the timeless beauty of a game that defined a generation, and that, to this day, lives in the hearts of thousands of people.
 
@@ -70,11 +70,11 @@ Snouz - syncronization</Description>
     I HOPE YOU ALL ENJOY IT!
     Best regards,
     Ultimate Remaster
-  </Description>
-  <Website>https://youtube.com/@UltimateRemasterGames</Website>
-  <DownloadUrl>https://www.dropbox.com/scl/fi/1r9cf5t7o1534ekuzuex6/4K-Video-Pack-Ultimate-Remaster.zip?rlkey=f9oh2b2gyvddz0om2ga68wpcq&amp;st=mbhafkqv&amp;dl=1</DownloadUrl>
-  <DownloadFormat>Zip</DownloadFormat>
-  <PreviewFileUrl>https://raw.githubusercontent.com/UltimateRemaster/ultimate-remaster-assets/main/Ultimate%20Remaster%20-%204k%20Video%20Pack%20Memoria%20(1).png</PreviewFileUrl>
+	</Description>
+	<Website>https://youtube.com/@UltimateRemasterGames</Website>
+	<DownloadUrl>https://www.dropbox.com/scl/fi/1r9cf5t7o1534ekuzuex6/4K-Video-Pack-Ultimate-Remaster.zip?rlkey=f9oh2b2gyvddz0om2ga68wpcq&amp;st=mbhafkqv&amp;dl=1</DownloadUrl>
+	<DownloadFormat>Zip</DownloadFormat>
+	<PreviewFileUrl>https://raw.githubusercontent.com/UltimateRemaster/ultimate-remaster-assets/main/Ultimate%20Remaster%20-%204k%20Video%20Pack%20Memoria%20(1).png</PreviewFileUrl>
 </Mod>
 
 <Mod>

--- a/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
+++ b/Memoria.Launcher/Catalogs/MemoriaCatalog.xml
@@ -45,6 +45,39 @@ Snouz - syncronization</Description>
 </Mod>
 
 <Mod>
+  <Name>4K Video Pack</Name>
+  <Version>1.0</Version>
+  <Priority>-31</Priority>
+  <InstallationPath>4K Video Pack - Ultimate Remaster</InstallationPath>
+  <Author>Ultimate Remaster</Author>
+  <Category>Visual</Category>
+  <ReleaseDateOriginal>2025-08-27</ReleaseDateOriginal>
+  <ReleaseDate>2025-08-27</ReleaseDate>
+  <Description>A QUARTER OF A CENTURY LATER, THE LEGEND SHINES BRIGHTER...
+
+    Today, in celebration of its 25th anniversary (July 7, 2025), this remaster transforms every FMV into true 4k high definition (2880x2160p 4:3) — restoring details lost over time to heavy compression, pixelation, noise, and blur, all while faithfully preserving the original artistic style with professional care, patience, hard work and a lot of time leveraging AI and handmade adjustments, to bring back the timeless beauty of a game that defined a generation, and that, to this day, lives in the hearts of thousands of people.
+
+    EACH SCENE HAS BEEN METICULOUSLY RESTORED TO:
+
+    1) Remove compression artifacts and visual noise, resulting in a cleaner, more polished image.
+    2) Sharpen and restore fine details in textures, architecture, and character models.
+    3) Improve overall clarity and color balance, giving each scene richer tones without oversaturation.
+    4) Optimize motion playback through encoding refinements, adjusting frame timing and keyframe placement to enhance smoothness.
+
+    MOD PRIORITY:
+    This mod needs to be positioned above the Moguri Mods in the Installed Mods list here in Memory Launcher, otherwise Moguri Mod Motion Backgrouns and FMVs will bypass the 4k remastered videos and prevent them from being displayed.
+
+    I HOPE YOU ALL ENJOY IT!
+    Best regards,
+    Ultimate Remaster
+  </Description>
+  <Website>https://youtube.com/@UltimateRemasterGames</Website>
+  <DownloadUrl>https://ultimateremaster.com/download-ff09-4k-video-pack</DownloadUrl>
+  <DownloadFormat>Zip</DownloadFormat>
+  <PreviewFileUrl>https://raw.githubusercontent.com/UltimateRemaster/ultimate-remaster-assets/main/Ultimate%20Remaster%20-%204k%20Video%20Pack%20Memoria%20(1).png</PreviewFileUrl>
+</Mod>
+
+<Mod>
 	<Name>Alternate Fantasy</Name>
 	<Version>6.8</Version>
 	<Priority>-17</Priority>


### PR DESCRIPTION
Hi! This PR adds a new entry to the Memoria mod catalog:

- Name: 4K Video Pack (Ultimate Remaster)
- InstallationPath: 4K Video Pack - Ultimate Remaster
- Version: 1.0
- Priority: -31 → needs to be loaded before Moguri so its FMVs don’t get overridden
- DownloadUrl: https://ultimateremaster.com/download-ff09-4k-video-pack (direct ZIP via redirect)
- DownloadFormat: Zip

What it does
Replaces every FMV with a true 4K (2880×2160, 4:3) remaster—cleaner image, restored detail, better color balance, and smoother playback.

Thanks for taking a look!
Best regards,
Ultimate Remaster