### PR TITLE
fix(BattleHUD): correct post-menu stat delta (use btl as base instead of player)

### DIFF
--- a/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
+++ b/Assembly-CSharp/Global/battle/BattleHUD/BattleHUD.cs
@@ -2700,10 +2700,10 @@ public partial class BattleHUD : UIScene
 
                 btl.max.hp = Math.Max(1, btl.max.hp + player.max.hp - beforeMenu.max.hp);
                 btl.max.mp = Math.Max(0, btl.max.mp + player.max.mp - beforeMenu.max.mp);
-                btl.elem.dex = (Byte)Mathf.Clamp(player.elem.dex + player.elem.dex - beforeMenu.elem.dex, 0, Byte.MaxValue);
-                btl.elem.str = (Byte)Mathf.Clamp(player.elem.str + player.elem.str - beforeMenu.elem.str, 0, Byte.MaxValue);
-                btl.elem.mgc = (Byte)Mathf.Clamp(player.elem.mgc + player.elem.mgc - beforeMenu.elem.mgc, 0, Byte.MaxValue);
-                btl.elem.wpr = (Byte)Mathf.Clamp(player.elem.wpr + player.elem.wpr - beforeMenu.elem.wpr, 0, Byte.MaxValue);
+                btl.elem.dex = (Byte)Mathf.Clamp(btl.elem.dex + player.elem.dex - beforeMenu.elem.dex, 0, Byte.MaxValue);
+                btl.elem.str = (Byte)Mathf.Clamp(btl.elem.str + player.elem.str - beforeMenu.elem.str, 0, Byte.MaxValue);
+                btl.elem.mgc = (Byte)Mathf.Clamp(btl.elem.mgc + player.elem.mgc - beforeMenu.elem.mgc, 0, Byte.MaxValue);
+                btl.elem.wpr = (Byte)Mathf.Clamp(btl.elem.wpr + player.elem.wpr - beforeMenu.elem.wpr, 0, Byte.MaxValue);
                 btl.defence.PhysicalDefence = Math.Max(0, btl.defence.PhysicalDefence + player.defence.PhysicalDefence - beforeMenu.defence.PhysicalDefence);
                 btl.defence.PhysicalEvade = Math.Max(0, btl.defence.PhysicalEvade + player.defence.PhysicalEvade - beforeMenu.defence.PhysicalEvade);
                 btl.defence.MagicalDefence = Math.Max(0, btl.defence.MagicalDefence + player.defence.MagicalDefence - beforeMenu.defence.MagicalDefence);


### PR DESCRIPTION
**Summary**
Fixes the stat delta applied after closing the battle menu when equipment is changed.

**Background**
With `[Battle] AvailableMenus` enabled, `BattleHUD.UpdateBattleAfterMainMenu` recalculates battle stats.
The code used `player + player - beforeMenu`, which effectively applied the equipment bonus twice.

**Change**
Use the current battle value as the base:
`btl + player - beforeMenu` for STR/MAG/WPR/DEX. No other logic or stats are touched.

**Verification**
1. Enable `[Battle] AvailableMenus`.
2. Equip an item that grants +5 to STR/MAG/WPR/DEX.
3. Open/close the battle menu: `btl` stats increase by +5 (not +10).
4. Reopen the menu again: values remain stable. No regressions observed.

**Compatibility**
No API changes; local logic fix only.

Fixes #1282