### PR TITLE
Kupo Heroes Pack Maintenance Update + 1 Option

### DIFF
--- a/MemoriaCatalog.xml
+++ b/MemoriaCatalog.xml
@@ -1034,15 +1034,14 @@ This mod was initially introduced as the Exp challenge tweaks within Kupo Mods, 
 
 <Mod>
 	<Name>Kupo Heroes Pack</Name>
-	<Version>4.2</Version>
+	<Version>4.3</Version>
 	<Priority>-14</Priority>
 	<InstallationPath>KupoHeroPack</InstallationPath>
-	<ReleaseDate>2025-06-30</ReleaseDate>
+	<ReleaseDate>2025-10-01</ReleaseDate>
 	<ReleaseDateOriginal>2024-05-10</ReleaseDateOriginal>
 	<Author>faospark</Author>
 	<Description>
 A set of character enhancements that empower your party and reduce grinding. Ideal for players seeking a fresh character experience without significantly altering the core game.
-
 See the readme.txt for more details.
 
 Mod Order:
@@ -1051,12 +1050,10 @@ Mod Order:
 
 Part of Kupo Mods, formerly Mog Add-ons.
 	</Description>
-	<PatchNotes>- Expanded Photons: Now known as the Lumi spells for Garnet (Holy single-target spells).
-- Enhanced Quina's abilities in Alternate Fantasy: Eat now works at 90% enemy HP; Cook is not included in AF.
-- Fixed Save the Queen abilities for Alternate Fantasy compatibility.
-- Added status effects for Wind (Confusion) and Earth (Trouble) spells in Alternate Fantasy.
-- Corrected Italian translation for Vivi's spells.
-- Special: Visit Daguerreo and speak to the character name changer for new features (note: not all users utilize Kupo modern labels). 
+	<PatchNotes>- Fixed Missing translation folder for Vivi 
+- Fixed Garnet's Lumi Spells translation IDs
+- Corrected Lumina and Luminaga Spelling for Consistency
+- Added Option to Only allow Zidane and Kuja increase their trance Bar  
 	</PatchNotes>
 	<Category>Gameplay</Category>
 	<IncompatibleWith>Trance Seek</IncompatibleWith>
@@ -1088,6 +1085,12 @@ Part of Kupo Mods, formerly Mog Add-ons.
 		<Description>Have Zidane Equip identical daggers (For Aesthetics)</Description>
 		<Default/>
 	</SubMod>
+	<SubMod>
+		<Name>Only Terran's can do Trance</Name>
+		<InstallationPath>Features/TranceBlock</InstallationPath>
+		<Description>Only Zidane and Kuja can do Trance</Description>
+		<Default/>
+	</SubMod>	
 	<Header>Transportation</Header>
 	<SubMod>
 		<Name>Faster travel </Name>


### PR DESCRIPTION
- Fixed Missing translation folder for Vivi 
- Fixed Garnet's Lumi Spells translation IDs
- Corrected Lumina and Luminaga Spelling for Consistency
- Added Option to Only allow Zidane and Kuja increase their trance Bar