### PR TITLE
Commiting PR that Canite made in draft a while ago; He gave me permission to re-submit PR

### DIFF
--- a/Assembly-CSharp/Assets/Sources/Scripts/UI/Common/FF9UIDataTool.cs
+++ b/Assembly-CSharp/Assets/Sources/Scripts/UI/Common/FF9UIDataTool.cs
@@ -66,7 +66,7 @@ namespace Assets.Sources.Scripts.UI.Common
             Int32 columnIndex = 0;
             IEnumerable<KeyValuePair<RegularItem, Int32>> enumerator = items;
             if (items.Count == 1 && items.First().Value == 2)
-                enumerator = new List<KeyValuePair<RegularItem, Int32>>([new(items.First().Key, 1), new(items.First().Key, 1)]);
+                enumerator = new List<KeyValuePair<RegularItem, Int32>>() { new(items.First().Key, 1), new(items.First().Key, 1) };
             foreach (KeyValuePair<RegularItem, Int32> kvp in enumerator)
             {
                 if (kvp.Key == RegularItem.NoItem || kvp.Value <= 0)

--- a/Assembly-CSharp/Memoria/Assets/3DModel/AnimationClipReader.cs
+++ b/Assembly-CSharp/Memoria/Assets/3DModel/AnimationClipReader.cs
@@ -182,6 +182,17 @@ namespace Memoria.Assets
                             List<Keyframe> keys_y = new List<Keyframe>();
                             List<Keyframe> keys_z = new List<Keyframe>();
                             List<Keyframe> keys_w = new List<Keyframe>();
+
+                            List<Keyframe> keys_xIT = new List<Keyframe>();
+                            List<Keyframe> keys_yIT = new List<Keyframe>();
+                            List<Keyframe> keys_zIT = new List<Keyframe>();
+                            List<Keyframe> keys_wIT = new List<Keyframe>();
+
+                            List<Keyframe> keys_xOT = new List<Keyframe>();
+                            List<Keyframe> keys_yOT = new List<Keyframe>();
+                            List<Keyframe> keys_zOT = new List<Keyframe>();
+                            List<Keyframe> keys_wOT = new List<Keyframe>();
+
                             ta.transformType = localType;
                             foreach (JSONNode frameNode in rotArray.Childs)
                             {
@@ -216,7 +227,48 @@ namespace Memoria.Assets
                                     fa.pos.w = keyNode.AsFloat;
                                     keys_w.Add(new Keyframe(time, fa.pos.w));
                                 }
-                                // TODO: read inward/outward tangent (with keys "xInnerTangent", "xOuterTangent", etc.)
+
+                                if (frameClass.Dict.TryGetValue("xInnerTangent", out keyNode))
+                                {
+                                    fa.posInnerTangent.x = keyNode.AsFloat;
+                                    keys_xIT.Add(new Keyframe(time, fa.posInnerTangent.x));
+                                }
+                                if (frameClass.Dict.TryGetValue("yInnerTangent", out keyNode))
+                                {
+                                    fa.posInnerTangent.y = keyNode.AsFloat;
+                                    keys_yIT.Add(new Keyframe(time, fa.posInnerTangent.y));
+                                }
+                                if (frameClass.Dict.TryGetValue("zInnerTangent", out keyNode))
+                                {
+                                    fa.posInnerTangent.z = keyNode.AsFloat;
+                                    keys_zIT.Add(new Keyframe(time, fa.posInnerTangent.z));
+                                }
+                                if (frameClass.Dict.TryGetValue("wInnerTangent", out keyNode))
+                                {
+                                    fa.posInnerTangent.w = keyNode.AsFloat;
+                                    keys_wIT.Add(new Keyframe(time, fa.posInnerTangent.w));
+                                }
+
+                                if (frameClass.Dict.TryGetValue("xOuterTangent", out keyNode))
+                                {
+                                    fa.posOuterTangent.x = keyNode.AsFloat;
+                                    keys_xOT.Add(new Keyframe(time, fa.posOuterTangent.x));
+                                }
+                                if (frameClass.Dict.TryGetValue("yOuterTangent", out keyNode))
+                                {
+                                    fa.posOuterTangent.y = keyNode.AsFloat;
+                                    keys_yOT.Add(new Keyframe(time, fa.posOuterTangent.y));
+                                }
+                                if (frameClass.Dict.TryGetValue("zOuterTangent", out keyNode))
+                                {
+                                    fa.posOuterTangent.z = keyNode.AsFloat;
+                                    keys_zOT.Add(new Keyframe(time, fa.posOuterTangent.z));
+                                }
+                                if (frameClass.Dict.TryGetValue("wOuterTangent", out keyNode))
+                                {
+                                    fa.posOuterTangent.w = keyNode.AsFloat;
+                                    keys_wOT.Add(new Keyframe(time, fa.posOuterTangent.w));
+                                }
                             }
                             if (!keys_x.IsNullOrEmpty())
                             {
@@ -238,6 +290,49 @@ namespace Memoria.Assets
                                 animCurve = new AnimationCurve(keys_w.ToArray());
                                 clip.SetCurve(boneName, typeof(Transform), localType + ".w", animCurve);
                             }
+
+                            if (!keys_xIT.IsNullOrEmpty())
+                            {
+                                animCurve = new AnimationCurve(keys_xIT.ToArray());
+                                clip.SetCurve(boneName, typeof(Transform), localType + ".xInnerTangent", animCurve);
+                            }
+                            if (!keys_yIT.IsNullOrEmpty())
+                            {
+                                animCurve = new AnimationCurve(keys_yIT.ToArray());
+                                clip.SetCurve(boneName, typeof(Transform), localType + ".yInnerTangent", animCurve);
+                            }
+                            if (!keys_zIT.IsNullOrEmpty())
+                            {
+                                animCurve = new AnimationCurve(keys_zIT.ToArray());
+                                clip.SetCurve(boneName, typeof(Transform), localType + ".zInnerTangent", animCurve);
+                            }
+                            if (!keys_wIT.IsNullOrEmpty())
+                            {
+                                animCurve = new AnimationCurve(keys_wIT.ToArray());
+                                clip.SetCurve(boneName, typeof(Transform), localType + ".wInnerTangent", animCurve);
+                            }
+
+                            if (!keys_xOT.IsNullOrEmpty())
+                            {
+                                animCurve = new AnimationCurve(keys_xOT.ToArray());
+                                clip.SetCurve(boneName, typeof(Transform), localType + ".xOuterTangent", animCurve);
+                            }
+                            if (!keys_yOT.IsNullOrEmpty())
+                            {
+                                animCurve = new AnimationCurve(keys_yOT.ToArray());
+                                clip.SetCurve(boneName, typeof(Transform), localType + ".yOuterTangent", animCurve);
+                            }
+                            if (!keys_zOT.IsNullOrEmpty())
+                            {
+                                animCurve = new AnimationCurve(keys_zOT.ToArray());
+                                clip.SetCurve(boneName, typeof(Transform), localType + ".zOuterTangent", animCurve);
+                            }
+                            if (!keys_wOT.IsNullOrEmpty())
+                            {
+                                animCurve = new AnimationCurve(keys_wOT.ToArray());
+                                clip.SetCurve(boneName, typeof(Transform), localType + ".wOuterTangent", animCurve);
+                            }
+
                             ta.frameAnimList.AddRange(faDict.Values);
                             ba.transformAnimList.Add(ta);
                         }

--- a/Assembly-CSharp/Memoria/Assets/3DModel/FbxBinary.cs
+++ b/Assembly-CSharp/Memoria/Assets/3DModel/FbxBinary.cs
@@ -77,7 +77,8 @@ namespace Memoria.Assets
 
         const string timePath1 = "FBXHeaderExtension";
         const string timePath2 = "CreationTimeStamp";
-        static readonly Stack<string> timePath = new Stack<string>([timePath1, timePath2]);
+        static string[] timePaths = [ timePath1, timePath2 ];
+        static readonly Stack<string> timePath = new Stack<string>(timePaths);
 
         // Gets a single timestamp component
         static int GetTimestampVar(FbxNode timestamp, string element)


### PR DESCRIPTION
Going to re-post information from the PR Draft https://github.com/Albeoris/Memoria/pull/1180
--
At the request of @WarpedEdge I have begun working on adding some new functionality to the model viewer so that animations can be edited/added/saved in a format compatible with the game. This will include:

- the ability to pause and iterate over all of the animations key frames
- editing model bone position/rotation/scale
- saving new animations
- adding new keyframes to these custom animations

This is still a work in progress at the moment but the first 3 bullet points above are currently working.
The .anim files must first be exported from Hades Workshop and placed in the `StreamingAssets\Assets\Resources\Animations\` folder, then in the Model Viewer, first press `E` to generate an export file and `E` again to export the existing animation. Then press `L` to load that animation as a custom clip. Once the custom clip is loaded, you can press `Space` to pause the animation and use `Z` and `X` to decrement/increment the current paused keyframe. From here, you can select and bone and modify it and then press `Space` again to view the modified animation. Pressing `E` twice again to export will save this custom animation into a new .anim file (from the export configuration file).


https://github.com/user-attachments/assets/42f514b7-b532-4c73-8499-6b1f1c44ff56


https://github.com/user-attachments/assets/b9179c5d-a3e3-4245-91e6-7cb3be3c430d

