### PR TITLE
Fix crash when launcher UI fonts are installed system-wide

### DIFF
--- a/Memoria.Launcher/Languages/Lang.cs
+++ b/Memoria.Launcher/Languages/Lang.cs
@@ -9,7 +9,7 @@ namespace Memoria.Launcher
     public sealed partial class Lang
     {
         public static String LangName = "en";
-        public static ResourceDictionary Res => Application.Current.Resources;
+        public static ResourceDictionary Res { get; } = new ResourceDictionary();
 
         public static String[] LauncherLanguageList = { "en", "de", "es", "fr", "it", "jp", "pt-BR", "ru", "tr", "uk", "zh-CN", "zh-TW" };
 
@@ -71,7 +71,14 @@ namespace Memoria.Launcher
             {
                 foreach (XmlAttribute at in node.Attributes)
                 {
-                    Application.Current.Resources[$"{node.Name}.{at.Name}"] = at.Value;
+                    string key = $"{node.Name}.{at.Name}";
+                    string value = at.Value;
+
+                    // Add to Application.Resources for XAML bindings to work
+                    Application.Current.Resources[key] = value;
+
+                    // Also add to our language-only dictionary
+                    Res[key] = value;
                 }
             }
         }


### PR DESCRIPTION
Issue: https://github.com/Albeoris/Memoria/issues/1327

If a user has any of the fonts that are shipped with the launcher installed, it will crash from the second time it is ran onwards. 

https://github.com/Albeoris/Memoria/blob/cf5697dc2a48c413e06b77b8a27d71ffc4028161/Memoria.Launcher/Resources/Fonts.xaml#L1-L6

If you are trying to recreate this issue, you don't need to install these fonts. You can manually add the name of any of the above fonts to the `FontList` file.

The first time the launcher is ran the `FontList` file of installed fonts doesn't exist and so the crash doesn't happen.

If a user has one of the fonts installed, the next time it is ran this code at line 517 will cause the crash:

https://github.com/Albeoris/Memoria/blob/cf5697dc2a48c413e06b77b8a27d71ffc4028161/Memoria.Launcher/Launcher/UiGrid.cs#L514-L520

The above code looks to see if there is a specific language string for the combo box values. The crash happens because `Lang.Res` contains the `FontFamily` objects of the above 4 fonts. It returns a match and then crashes when cast to a string.

The same problem exists in `RefereshComboBoxes` although it currently crashes before that can ever throw an error.

I'm not sure what the best way to fix this is but this is my attempt. I created a separate `ResourceDictionary` just for all the language strings. This way, whenever you lookup a key in `Lang.Res` you can guarantee it's a string from one of the language files and not another type of resource. 


