### PR TITLE
Added white background to model viewer scene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 .idea/
 .vs/
+.vscode/
 bin/
 obj/
 /packages/
@@ -24,3 +25,4 @@ obj/
 /Memoria.Injection/Debug/
 /Memoria.Injection/Release/
 /Memoria.Injection/x64/
+/.devcontainer/

--- a/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
+++ b/Assembly-CSharp/Memoria/Assets/ModelViewer/ModelViewerScene.cs
@@ -1318,6 +1318,7 @@ namespace Memoria.Assets
                         if (camera.backgroundColor == Color.black) camera.backgroundColor = Color.grey;
                         else if (camera.backgroundColor == Color.grey) camera.backgroundColor = Color.green;
                         else if (camera.backgroundColor == Color.green) camera.backgroundColor = Color.blue;
+                        else if (camera.backgroundColor == Color.blue) camera.backgroundColor = Color.white;
                         else camera.backgroundColor = Color.black;
                     }
                 }


### PR DESCRIPTION
This is a little adjustment that adds an additional background color `White` to the model viewer when cycling with `C`. 

I also added a couple of other ignored to the `.gitignore` when using devcontainers and vscode.