### PR TITLE
Fix memory leak for Static Sound streams

### DIFF
--- a/Assembly-CSharp/Global/Sound/SoundPlayer.cs
+++ b/Assembly-CSharp/Global/Sound/SoundPlayer.cs
@@ -47,6 +47,8 @@ public abstract class SoundPlayer
 
     public static void StaticCreateSound(SoundProfile soundProfile)
     {
+        if (soundProfile.SoundID > 0) return;
+
         Int32 num = ISdLibAPIProxy.Instance.SdSoundSystem_CreateSound(soundProfile.BankID);
         if (num == 0)
         {


### PR DESCRIPTION
This patch fixes a memory leak happening every time a static sound effect is being played ( for eg. footsteps )

Me and Nenny from the Echo-S 9 team did a test and on both of our machines seems to have fixed the memory leak.

The main reasoning behind this line change is that once a sound slot is being created over SaXAudio, it was cached in `soundProfile.SoundID` but never used before hand to check if the same soundProfile needs to have a slot attached. All this patch does is to check if the current given `soundProfile` has already a valid `SoundID`. If it does not, it will continue creating it and assigning, otherwise it does nothing.

You could potentially nop it also before calling this function but it's cheap anyway and it's cleaner to read the code this way so I proposed the patch this way.

---

**How to repro:**
1. Launch the game
2. Load a save file where you can free roam with Zidane
3. Run around the scene
4. Proof it

**Expected behavior:**
Footsteps are audible and the memory stays constant through time

**Current behavior:**
Footsteps are audible but memory consumption keeps growing without Windows reclaiming it back
