### PR TITLE
Window_ChangeLog: Replace FlowDocumentScrollViewer with ScrollViewer+RichTextBox

### DIFF
--- a/Memoria.Launcher/Launcher/Window_ChangeLog.xaml
+++ b/Memoria.Launcher/Launcher/Window_ChangeLog.xaml
@@ -60,21 +60,27 @@
                     Padding="0"
                     Height="28"
                     Margin="-5,-10,0,0"/>
-                    <FlowDocumentScrollViewer
+                    <ScrollViewer
                         Width="700"
                         Height="400"
                         Padding="0"
                         Margin="-15,6"
                         VerticalScrollBarVisibility="Auto"
                         PreviewMouseWheel="DocumentScrollViewer_PreviewMouseWheel">
-                        <FlowDocument
+                        <RichTextBox
                             x:Name="Document"
-                            PagePadding="15,0"
+                            Padding="15,0"
                             Foreground="{StaticResource WhiteUI}"
-                            FontFamily="Segoe UI"
-                            FontSize="16">
-                        </FlowDocument>
-                    </FlowDocumentScrollViewer>
+                            FontFamily="Tahoma"
+                            FontSize="16"
+                            Background="Transparent"
+                            BorderThickness="0"
+                            IsReadOnly="True"
+                            IsDocumentEnabled="True"
+                            UseLayoutRounding="True"
+                            TextOptions.TextFormattingMode="Display">
+                        </RichTextBox>
+                    </ScrollViewer>
                     <Button
                         x:Name="Ok"
                         Content="{DynamicResource Launcher.OK}"

--- a/Memoria.Launcher/Launcher/Window_ChangeLog.xaml.cs
+++ b/Memoria.Launcher/Launcher/Window_ChangeLog.xaml.cs
@@ -30,13 +30,13 @@ namespace Memoria.Launcher
 
         private async void LoadRemoteChangelog()
         {
-            Document.Blocks.Clear();
+            Document.Document.Blocks.Clear();
             Paragraph loading = new Paragraph(new Run($"Loading changelog..."))
             {
                 Margin = new Thickness(0, 20, 0, 20),
                 Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#aeee"))
             };
-            Document.Blocks.Add(loading);
+            Document.Document.Blocks.Add(loading);
             try
             {
                 // Load the release page from github and parse it into a changelog
@@ -54,19 +54,19 @@ namespace Memoria.Launcher
             }
             catch
             {
-                Document.Blocks.Clear();
+                Document.Document.Blocks.Clear();
                 Paragraph p = new Paragraph(new Run($"Couldn't load the changelog."))
                 {
                     Margin = new Thickness(0, 20, 0, 20),
                     Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#aeee"))
                 };
-                Document.Blocks.Add(p);
+                Document.Document.Blocks.Add(p);
             }
         }
 
         private void ParseChangeLogHtml()
         {
-            Document.Blocks.Clear();
+            Document.Document.Blocks.Clear();
 
             try
             {
@@ -106,7 +106,7 @@ namespace Memoria.Launcher
                             p.Inlines.Add(new LineBreak());
                             p.Inlines.Add(link);
                         }
-                        Document.Blocks.Add(p);
+                        Document.Document.Blocks.Add(p);
                     }
 
                     // Parse content
@@ -126,7 +126,7 @@ namespace Memoria.Launcher
                                 Margin = new Thickness(0, 20, 0, 10),
                                 FontSize = 20
                             };
-                            Document.Blocks.Add(p);
+                            Document.Document.Blocks.Add(p);
                             continue;
                         }
                         if (trimmed.StartsWith("<ul>"))
@@ -146,7 +146,7 @@ namespace Memoria.Launcher
                             {
                                 list = new List();
                                 list.Padding = new Thickness(0, 0, 0, 0);
-                                Document.Blocks.Add(list);
+                                Document.Document.Blocks.Add(list);
                             }
                             list.ListItems.Add(item);
                             continue;
@@ -165,7 +165,7 @@ namespace Memoria.Launcher
                                 Margin = new Thickness(0, 10, 0, 10),
                                 Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#aeee"))
                             };
-                            Document.Blocks.Add(p);
+                            Document.Document.Blocks.Add(p);
                             continue;
                         }
                     }
@@ -173,13 +173,13 @@ namespace Memoria.Launcher
             }
             catch
             {
-                Document.Blocks.Clear();
+                Document.Document.Blocks.Clear();
                 Paragraph p = new Paragraph(new Run($"Couldn't parse the changelog."))
                 {
                     Margin = new Thickness(0, 20, 0, 20),
                     Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#aeee"))
                 };
-                Document.Blocks.Add(p);
+                Document.Document.Blocks.Add(p);
             }
         }
 
@@ -208,13 +208,9 @@ namespace Memoria.Launcher
 
         private void DocumentScrollViewer_PreviewMouseWheel(Object sender, MouseWheelEventArgs e)
         {
-            FlowDocumentScrollViewer o = (FlowDocumentScrollViewer)sender;
-            ScrollViewer scrollViewer = o.Template?.FindName("PART_ContentHost", o) as ScrollViewer;
-            if (scrollViewer is not null)
-            {
-                double offset = scrollViewer.VerticalOffset - (e.Delta / 3f);
-                scrollViewer.ScrollToVerticalOffset(offset < 0 ? 0 : offset > scrollViewer.ExtentHeight ? scrollViewer.ExtentHeight : offset);
-            }
+            ScrollViewer scrollViewer = (ScrollViewer)sender;
+            double offset = scrollViewer.VerticalOffset - (e.Delta / 3f);
+            scrollViewer.ScrollToVerticalOffset(offset < 0 ? 0 : offset > scrollViewer.ExtentHeight ? scrollViewer.ExtentHeight : offset);
         }
     }
 }


### PR DESCRIPTION
This PR fixes the black changelog window under Linux Wine/Proton.

Here how it renders now under Windows:
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/d56fffc4-0e4d-49fc-93d4-bdfb40b37ad8" />

And here it is under Linux:
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/e571e05d-b58e-48c9-9073-f0364124980f" />

Tested on both Steam and GOG editions.