### PR TITLE
Fix OverwriteFile bak rotation and dll/exe upgrade pathway

### DIFF
--- a/Memoria.Patcher/Program.cs
+++ b/Memoria.Patcher/Program.cs
@@ -412,8 +412,10 @@ namespace Memoria.Patcher
                 else if (_filesForBackup.Contains(extension))
                 {
                     String backupPath = Path.ChangeExtension(outputPath, ".bak");
-                    if (!File.Exists(backupPath))
-                        File.Move(outputPath, backupPath);
+
+                    if (File.Exists(backupPath)) File.Delete(backupPath);
+
+                    File.Move(outputPath, backupPath);
                 }
                 else if (_iniFileName.Contains(outputName))
                 {


### PR DESCRIPTION
This PR addresses an issue me and @DV666 found while testing the patcher on top of an existing FF9 installation.

What we found out is that for `dll` and `exe` files, if they have already existing `.bak` counterpart, the codepath will literally do nothing and will attempt to copy the new `dll` or `exe` over the existing path, crashing while trying to run the `File.Create` routine.

<img width="1293" height="607" alt="immagine" src="https://github.com/user-attachments/assets/8c0b11eb-c3ec-45f5-b9c2-de6ab05c0cc3" />

This patch should resolve that issue, by assuming that any previous `bak` file is no more needed, and only the current existing `dll` or `exe` has to be backup again, before writing the new file in the disk ( from Memoria.Patcher ).