### PR TITLE
Improve voice acting dialog timing options

### DIFF
--- a/Assembly-CSharp/Memoria/Configuration/Access/VoiceActing.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Access/VoiceActing.cs
@@ -12,6 +12,7 @@ namespace Memoria
             public static Boolean LogVoiceActing => Instance._voiceActing.LogVoiceActing;
             public static Boolean StopVoiceWhenDialogDismissed = Instance._voiceActing.StopVoiceWhenDialogDismissed;
             public static Boolean AutoDismissDialogAfterCompletion = Instance._voiceActing.AutoDismissDialogAfterCompletion;
+            public static Boolean HoldScriptClosedDialogsUntilVoiceEnds = Instance._voiceActing.HoldScriptClosedDialogsUntilVoiceEnds;
             public static Int32 ForceMessageSpeed = Mathf.Clamp(Instance._voiceActing.ForceMessageSpeed.Value, -1, 6);
             public static Int32 ForceLanguage = (Instance._voiceActing.ForceLanguage.Value > 6 || Instance._voiceActing.ForceLanguage.Value < 0) ? -1 : Instance._voiceActing.ForceLanguage.Value;
             public static Int32 Volume = Instance._voiceActing.Volume.Value;

--- a/Assembly-CSharp/Memoria/Configuration/Memoria.ini
+++ b/Assembly-CSharp/Memoria/Configuration/Memoria.ini
@@ -386,12 +386,14 @@ Field = 0
 	; LogVoiceActing: writes debugging messages in the log
 	; StopVoiceWhenDialogDismissed: When this option is enabled, most of voice sounds get stopped when the related dialog box is skipped by the player
 	; AutoDismissDialogAfterCompletion: Automatically closes the dialog box when the audio file has been played
+	; HoldScriptClosedDialogsUntilVoiceEnds: Waits for voice playback before closing dialogs that are normally closed by event scripts
 	; ForceMessageSpeed (default -1) -1: Uses the user controlled setting (save dependent), 0-6: Enforce the field message speed instead of using the user controlled setting
 	; ForceLanguage (default -1) -1: Use in-game setting, 0: English(US), 1: English(UK), 2: Japanese, 3: German, 4: French, 5: Itallien, 6: Spanish
 Enabled = 0
 LogVoiceActing = 1
 StopVoiceWhenDialogDismissed = 1
 AutoDismissDialogAfterCompletion = 1
+HoldScriptClosedDialogsUntilVoiceEnds = 0
 ForceMessageSpeed = -1
 ForceLanguage = -1
 Volume = 100

--- a/Assembly-CSharp/Memoria/Configuration/Structure/VoiceActingSection.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Structure/VoiceActingSection.cs
@@ -10,6 +10,7 @@ namespace Memoria
             public readonly IniValue<Boolean> LogVoiceActing;
             public readonly IniValue<Boolean> StopVoiceWhenDialogDismissed;
             public readonly IniValue<Boolean> AutoDismissDialogAfterCompletion;
+            public readonly IniValue<Boolean> HoldScriptClosedDialogsUntilVoiceEnds;
             public readonly IniValue<Int32> ForceMessageSpeed;
             public readonly IniValue<Int32> ForceLanguage;
             public readonly IniValue<Int32> Volume;
@@ -19,6 +20,7 @@ namespace Memoria
                 LogVoiceActing = BindBoolean(nameof(LogVoiceActing), false);
                 StopVoiceWhenDialogDismissed = BindBoolean(nameof(StopVoiceWhenDialogDismissed), false);
                 AutoDismissDialogAfterCompletion = BindBoolean(nameof(AutoDismissDialogAfterCompletion), false);
+                HoldScriptClosedDialogsUntilVoiceEnds = BindBoolean(nameof(HoldScriptClosedDialogsUntilVoiceEnds), false);
                 ForceMessageSpeed = BindInt32(nameof(ForceMessageSpeed), -1);
                 ForceLanguage = BindInt32(nameof(ForceLanguage), -1);
                 Volume = BindInt32(nameof(Volume), 100);

--- a/Assembly-CSharp/Memoria/VoiceActing/VoicePlayer.cs
+++ b/Assembly-CSharp/Memoria/VoiceActing/VoicePlayer.cs
@@ -149,10 +149,11 @@ public class VoicePlayer : SoundPlayer
             msgString.Contains("\n“") || // English
             msgString.Contains("\n「") || // Japanese
             msgString.Contains(":\n") || // German, French
+            msgString.Contains("\uFF1A\n") || // Chinese
             msgString.Contains("\n─") // Italian, Spanish
             ))
         {
-            String name = msgString.Split('\n')[0].Replace(":", "").Trim();
+            String name = msgString.Split('\n')[0].Replace(":", "").Replace("\uFF1A", "").Trim();
             candidates.Add($"Voices/{lang}/{FieldZoneId}/va_{messageNumber}_{name}{pageIndex}");
         }
 
@@ -483,6 +484,8 @@ public class VoicePlayer : SoundPlayer
 
     public static Boolean HoldDialogUntilSoundEnds(Int32 zoneId, Int32 universalTextId, Int32 mapNo)
     {
+        if (Configuration.VoiceActing.HoldScriptClosedDialogsUntilVoiceEnds)
+            return true;
         if (zoneId == 2 && mapNo >= 59 && mapNo <= 67) // 'I want to be your canary' stage (early game)
             return true;
         if (zoneId == 187) // Ending scene (Vivi monologue and stage afterwards)

--- a/Memoria.Launcher/Ini/Memoria.ini
+++ b/Memoria.Launcher/Ini/Memoria.ini
@@ -386,12 +386,14 @@ Field = 0
 	; LogVoiceActing: writes debugging messages in the log
 	; StopVoiceWhenDialogDismissed: When this option is enabled, most of voice sounds get stopped when the related dialog box is skipped by the player
 	; AutoDismissDialogAfterCompletion: Automatically closes the dialog box when the audio file has been played
+	; HoldScriptClosedDialogsUntilVoiceEnds: Waits for voice playback before closing dialogs that are normally closed by event scripts
 	; ForceMessageSpeed (default -1) -1: Uses the user controlled setting (save dependent), 0-6: Enforce the field message speed instead of using the user controlled setting
 	; ForceLanguage (default -1) -1: Use in-game setting, 0: English(US), 1: English(UK), 2: Japanese, 3: German, 4: French, 5: Itallien, 6: Spanish
 Enabled = 0
 LogVoiceActing = 1
 StopVoiceWhenDialogDismissed = 1
 AutoDismissDialogAfterCompletion = 1
+HoldScriptClosedDialogsUntilVoiceEnds = 0
 ForceMessageSpeed = -1
 ForceLanguage = -1
 Volume = 100


### PR DESCRIPTION
This adds an optional voice acting setting for dialogs that are closed by field scripts, while keeping the current hardcoded behavior as the default.

Summary:
- add `VoiceActing.HoldScriptClosedDialogsUntilVoiceEnds`, defaulting to false
- let voice mods opt into waiting for voice playback before script-closed dialogs are dismissed
- recognize full-width colon speaker headers when building voice path candidates

Testing:
- `git diff --check`
- `dotnet build` was not completed locally because this checkout does not have the FF9 game references, VC++ targets, or .NET Framework reference assemblies required by the solution.