### PR TITLE
Allow voice mods to hold selected scripted dialogs

### DIFF
--- a/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
+++ b/Assembly-CSharp/Global/Event/Engine/EventEngine.DoEventCode.cs
@@ -544,7 +544,7 @@ public partial class EventEngine
                         //   WindowAsync( winId, uiFlags, textId )
                         //   Wait( 30 )
                         //   CloseWindow( winId )
-                        if (VoicePlayer.HoldDialogUntilSoundEnds(FF9TextTool.FieldZoneId, UniversalTextId.GetUniversalTextId(Localization.CurrentSymbol, FF9TextTool.FieldZoneId, dialog.TextId), mapNo))
+                        if (VoicePlayer.HoldDialogUntilSoundEnds(FF9TextTool.FieldZoneId, dialog.TextId, UniversalTextId.GetUniversalTextId(Localization.CurrentSymbol, FF9TextTool.FieldZoneId, dialog.TextId), mapNo))
                         {
                             // Block the script and wait for the voice acting sound to complete
                             this.stay();

--- a/Assembly-CSharp/Memoria/Configuration/DataPatchers.cs
+++ b/Assembly-CSharp/Memoria/Configuration/DataPatchers.cs
@@ -37,6 +37,7 @@ namespace Memoria
             // Apply patches; the default folder (out of any mod folder) is ignored
             try
             {
+                global::VoicePlayer.ClearModdedHoldDialogRules();
                 foreach (AssetManager.AssetFolder folder in AssetManager.FolderLowToHigh)
                 {
                     if (String.IsNullOrEmpty(folder.FolderPath))
@@ -368,6 +369,38 @@ namespace Memoria
                                 EventEngine.moogleFldMap.Remove(fldid);
                         }
                     }
+                }
+                else if (String.Equals(entry[0], "VoiceActingHoldDialog"))
+                {
+                    // eg.: VoiceActingHoldDialog Add 4 126
+                    // eg.: VoiceActingHoldDialog Add 4 126 100
+                    // eg.: VoiceActingHoldDialog Add 4 120-130 100-105
+                    // Format: [Add|Remove|Set] FieldZoneId TextId [MapNo], where TextId matches the voice file number va_<TextId>
+                    Int32 valueIndex = 1;
+                    Boolean add = true;
+                    Boolean set = false;
+                    if (String.Equals(entry[valueIndex], "Set"))
+                    {
+                        set = true;
+                        valueIndex++;
+                    }
+                    else if (String.Equals(entry[valueIndex], "Add"))
+                    {
+                        add = true;
+                        valueIndex++;
+                    }
+                    else if (String.Equals(entry[valueIndex], "Remove"))
+                    {
+                        add = false;
+                        valueIndex++;
+                    }
+                    if (entry.Length < valueIndex + 2)
+                        continue;
+                    if (set)
+                        global::VoicePlayer.ClearModdedHoldDialogRules();
+                    String mapNo = entry.Length > valueIndex + 2 ? entry[valueIndex + 2] : null;
+                    if (!global::VoicePlayer.PatchHoldDialogRule(add, entry[valueIndex], entry[valueIndex + 1], mapNo))
+                        Log.Message("[DataPatchers] Invalid VoiceActingHoldDialog entry: " + s);
                 }
                 else if (String.Equals(entry[0], "BattleMapModel"))
                 {

--- a/Assembly-CSharp/Memoria/VoiceActing/VoicePlayer.cs
+++ b/Assembly-CSharp/Memoria/VoiceActing/VoicePlayer.cs
@@ -15,6 +15,7 @@ public class VoicePlayer : SoundPlayer
     private static Dialog specialDialog;
     private static Int32 specialLastPlayed;
     private static Int32 specialCount = 0;
+    private static readonly List<HoldDialogRule> moddedHoldDialogRules = new List<HoldDialogRule>();
 
     public static Boolean closeDialogOnFinish = false;
 
@@ -149,10 +150,11 @@ public class VoicePlayer : SoundPlayer
             msgString.Contains("\n“") || // English
             msgString.Contains("\n「") || // Japanese
             msgString.Contains(":\n") || // German, French
+            msgString.Contains("\uFF1A\n") || // Chinese
             msgString.Contains("\n─") // Italian, Spanish
             ))
         {
-            String name = msgString.Split('\n')[0].Replace(":", "").Trim();
+            String name = msgString.Split('\n')[0].Replace(":", "").Replace("\uFF1A", "").Trim();
             candidates.Add($"Voices/{lang}/{FieldZoneId}/va_{messageNumber}_{name}{pageIndex}");
         }
 
@@ -481,7 +483,7 @@ public class VoicePlayer : SoundPlayer
         }
     }
 
-    public static Boolean HoldDialogUntilSoundEnds(Int32 zoneId, Int32 universalTextId, Int32 mapNo)
+    public static Boolean HoldDialogUntilSoundEnds(Int32 zoneId, Int32 textId, Int32 universalTextId, Int32 mapNo)
     {
         if (zoneId == 2 && mapNo >= 59 && mapNo <= 67) // 'I want to be your canary' stage (early game)
             return true;
@@ -493,7 +495,149 @@ public class VoicePlayer : SoundPlayer
             return true;
         if (zoneId == 484 && universalTextId == 165) // Mount Gulug: Kuja meets the party after Eiko defeated Zorn & Thorn ("How can that-")
             return true;
+        foreach (HoldDialogRule rule in moddedHoldDialogRules)
+            if (rule.Matches(zoneId, textId, mapNo))
+                return true;
         return false;
+    }
+
+    public static Boolean PatchHoldDialogRule(Boolean add, String zoneId, String textId, String mapNo = null)
+    {
+        if (!HoldDialogRule.TryParse(zoneId, textId, mapNo, out HoldDialogRule rule))
+            return false;
+        if (add)
+        {
+            if (!moddedHoldDialogRules.Contains(rule))
+                moddedHoldDialogRules.Add(rule);
+        }
+        else
+        {
+            moddedHoldDialogRules.RemoveAll(registeredRule => registeredRule.Equals(rule));
+        }
+        return true;
+    }
+
+    public static void ClearModdedHoldDialogRules()
+    {
+        moddedHoldDialogRules.Clear();
+    }
+
+    private struct HoldDialogRule : IEquatable<HoldDialogRule>
+    {
+        public readonly HoldDialogRange ZoneId;
+        public readonly HoldDialogRange TextId;
+        public readonly HoldDialogRange MapNo;
+
+        public HoldDialogRule(HoldDialogRange zoneId, HoldDialogRange textId, HoldDialogRange mapNo)
+        {
+            ZoneId = zoneId;
+            TextId = textId;
+            MapNo = mapNo;
+        }
+
+        public Boolean Matches(Int32 zoneId, Int32 textId, Int32 mapNo)
+        {
+            return ZoneId.Matches(zoneId) && TextId.Matches(textId) && MapNo.Matches(mapNo);
+        }
+
+        public static Boolean TryParse(String zoneId, String textId, String mapNo, out HoldDialogRule rule)
+        {
+            rule = default;
+            if (!HoldDialogRange.TryParse(zoneId, false, out HoldDialogRange zoneRange))
+                return false;
+            if (!HoldDialogRange.TryParse(textId, false, out HoldDialogRange textRange))
+                return false;
+            if (!HoldDialogRange.TryParse(mapNo, true, out HoldDialogRange mapRange))
+                return false;
+            rule = new HoldDialogRule(zoneRange, textRange, mapRange);
+            return true;
+        }
+
+        public Boolean Equals(HoldDialogRule other)
+        {
+            return ZoneId.Equals(other.ZoneId) && TextId.Equals(other.TextId) && MapNo.Equals(other.MapNo);
+        }
+
+        public override Boolean Equals(System.Object obj)
+        {
+            return obj is HoldDialogRule other && Equals(other);
+        }
+
+        public override Int32 GetHashCode()
+        {
+            unchecked
+            {
+                Int32 hash = ZoneId.GetHashCode();
+                hash = (hash * 397) ^ TextId.GetHashCode();
+                hash = (hash * 397) ^ MapNo.GetHashCode();
+                return hash;
+            }
+        }
+    }
+
+    private struct HoldDialogRange : IEquatable<HoldDialogRange>
+    {
+        private readonly Int32 min;
+        private readonly Int32 max;
+
+        private HoldDialogRange(Int32 min, Int32 max)
+        {
+            this.min = min;
+            this.max = max;
+        }
+
+        public Boolean Matches(Int32 value)
+        {
+            return value >= min && value <= max;
+        }
+
+        public static Boolean TryParse(String token, Boolean allowEmpty, out HoldDialogRange range)
+        {
+            range = new HoldDialogRange(Int32.MinValue, Int32.MaxValue);
+            if (String.IsNullOrEmpty(token) || token.Trim().Length == 0)
+                return allowEmpty;
+            token = token.Trim();
+            if (String.Equals(token, "*", StringComparison.OrdinalIgnoreCase) || String.Equals(token, "Any", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            Int32 separatorIndex = token.IndexOf('-', 1);
+            if (separatorIndex >= 0)
+            {
+                if (!Int32.TryParse(token.Substring(0, separatorIndex), out Int32 minValue) || !Int32.TryParse(token.Substring(separatorIndex + 1), out Int32 maxValue))
+                    return false;
+                if (minValue > maxValue)
+                {
+                    Int32 swap = minValue;
+                    minValue = maxValue;
+                    maxValue = swap;
+                }
+                range = new HoldDialogRange(minValue, maxValue);
+                return true;
+            }
+
+            if (!Int32.TryParse(token, out Int32 value))
+                return false;
+            range = new HoldDialogRange(value, value);
+            return true;
+        }
+
+        public Boolean Equals(HoldDialogRange other)
+        {
+            return min == other.min && max == other.max;
+        }
+
+        public override Boolean Equals(System.Object obj)
+        {
+            return obj is HoldDialogRange other && Equals(other);
+        }
+
+        public override Int32 GetHashCode()
+        {
+            unchecked
+            {
+                return (min * 397) ^ max;
+            }
+        }
     }
 
     public void PauseAllSounds()


### PR DESCRIPTION
Some voiced field dialogs are closed by event scripts before localized voice lines can finish. The existing hardcoded hold list covers known cases, but a global setting can also delay timing-sensitive cutscenes.

This keeps the current default behavior and lets voice acting mods extend the hold list from `DictionaryPatch.txt` instead:

```txt
VoiceActingHoldDialog Add <FieldZoneId> <TextId> [MapNo]
VoiceActingHoldDialog Remove <FieldZoneId> <TextId> [MapNo]
VoiceActingHoldDialog Set <FieldZoneId> <TextId> [MapNo]
```

`TextId` matches the voice file number in `va_<TextId>`. Ranges are accepted, and `*`/`Any` can be used as wildcards. `Set` clears previously added custom rules before adding the replacement rule.

Summary:
- add mod-defined voice dialog hold rules loaded from `DictionaryPatch.txt`
- keep the current hardcoded hold list and default behavior unchanged
- pass the field `TextId` into the hold check so mods can target voice file numbers directly
- recognize full-width colon speaker headers when building voice path candidates

Build:
- `Assembly-CSharp` Release build with VS MSBuild (`/p:CI=true`)