### PR TITLE
Launcher: Migrate to HttpClient and log error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -621,3 +621,6 @@ cmake-build*/
 
 # vcpkg
 vcpkg_installed/
+
+# VS Code C# Dev Kit
+*.lscache

--- a/Memoria.Launcher/App.xaml.cs
+++ b/Memoria.Launcher/App.xaml.cs
@@ -10,6 +10,8 @@ namespace Memoria.Launcher
 {
     public partial class App : Application
     {
+        private static readonly NLog.Logger _log = AppLogger.GetLogger();
+
         protected override void OnStartup(StartupEventArgs e)
         {
             SubscribeUnhandledExceptions();
@@ -52,6 +54,7 @@ namespace Memoria.Launcher
 
         private void HandleException(Exception ex)
         {
+            _log.Fatal(ex, "Unhandled exception");
             var message = "A critical error occurred during the operation of the program." + Environment.NewLine +
                           "Further work of the program may lead to data corruption. The application will be closed." + Environment.NewLine +
                           "Please press Ctrl+C to copy the exception details, and contact the author to fix the problem." + Environment.NewLine +

--- a/Memoria.Launcher/Launcher/AppLogger.cs
+++ b/Memoria.Launcher/Launcher/AppLogger.cs
@@ -1,0 +1,49 @@
+using NLog;
+using NLog.Config;
+using NLog.Targets;
+using System;
+using System.IO;
+using System.Text;
+
+namespace Memoria.Launcher
+{
+    /// <summary>
+    /// Central logging accessor for Memoria.Launcher.
+    /// Configures NLog programmatically so logging always works regardless of
+    /// whether NLog.config is present. NLog.config is still loaded when found
+    /// and takes precedence, allowing users to customise behaviour.
+    /// Any class in the project can obtain a named logger with:
+    ///   private static readonly Logger Log = AppLogger.GetLogger();
+    /// </summary>
+    public static class AppLogger
+    {
+        static AppLogger()
+        {
+            // If NLog.config was found and loaded automatically, respect it.
+            // Otherwise fall back to a hardcoded file target so logging always works.
+            if (LogManager.Configuration == null || LogManager.Configuration.AllTargets.Count == 0)
+            {
+                var config = new LoggingConfiguration();
+
+                var fileTarget = new FileTarget("file")
+                {
+                    FileName = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "MemoriaLauncher.log"),
+                    Layout = "${longdate} [${level:uppercase=true}] ${logger} - ${message}${onexception:inner=${newline}${exception:format=tostring}}",
+                    KeepFileOpen = true,
+                    Encoding = Encoding.UTF8,
+                    DeleteOldFileOnStartup = true,
+                };
+
+                config.AddTarget(fileTarget);
+                config.AddRule(LogLevel.Info, LogLevel.Fatal, fileTarget);
+                LogManager.Configuration = config;
+            }
+        }
+
+        /// <summary>Returns a logger named after the calling class.</summary>
+        public static Logger GetLogger() => LogManager.GetCurrentClassLogger();
+
+        /// <summary>Returns a logger with the specified name.</summary>
+        public static Logger GetLogger(string name) => LogManager.GetLogger(name);
+    }
+}

--- a/Memoria.Launcher/Launcher/UiLauncherPlayButton.cs
+++ b/Memoria.Launcher/Launcher/UiLauncherPlayButton.cs
@@ -367,16 +367,17 @@ namespace Memoria.Launcher
         public String TargetName;
         public String TargetPath;
 
-        public void ReadFromResponse(string url, WebResponse response)
+        public void ReadFromResponse(string url, HttpResponseMessage response)
         {
             Url = url;
-            ContentLength = response.ContentLength;
-            LastModified = ((HttpWebResponse)response).LastModified;
+            ContentLength = response.Content.Headers.ContentLength ?? -1;
+            LastModified = response.Content.Headers.LastModified?.UtcDateTime ?? DateTime.MinValue;
         }
     }
 
     public sealed class Downloader
     {
+        private static readonly HttpClient _httpClient = new HttpClient();
         private readonly ManualResetEvent _cancelEvent;
 
         public event Action<long> DownloadProgress;
@@ -393,11 +394,10 @@ namespace Memoria.Launcher
             if (_cancelEvent.WaitOne(0))
                 return result;
 
-            WebRequest request = WebRequest.Create(url);
-            request.Method = "HEAD";
-
-            using (WebResponse resp = await request.GetResponseAsync())
+            using (HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Head, url))
+            using (HttpResponseMessage resp = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false))
             {
+                resp.EnsureSuccessStatusCode();
                 if (_cancelEvent.WaitOne(0))
                     return result;
 
@@ -420,8 +420,7 @@ namespace Memoria.Launcher
             if (_cancelEvent.WaitOne(0))
                 return;
 
-            using (HttpClient client = new HttpClient())
-            using (Stream input = await client.GetStreamAsync(url))
+            using (Stream input = await _httpClient.GetStreamAsync(url).ConfigureAwait(false))
                 await CopyAsync(input, output, _cancelEvent, DownloadProgress);
         }
 

--- a/Memoria.Launcher/Launcher/Utils.cs
+++ b/Memoria.Launcher/Launcher/Utils.cs
@@ -7,10 +7,12 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
+using System.Net.Http;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Timers;
 using Timer = System.Timers.Timer;
 
@@ -918,28 +920,191 @@ namespace Memoria.Launcher
 
     #region ThrottledWeb
 
-    public class ThrottledWebClient : WebClient
+    public sealed class ThrottledDownloadProgressChangedEventArgs : EventArgs
     {
-        private Timer _timer;
+        public ThrottledDownloadProgressChangedEventArgs(Int64 bytesReceived, Int64 totalBytesToReceive)
+        {
+            BytesReceived = bytesReceived;
+            TotalBytesToReceive = totalBytesToReceive;
+        }
+
+        public Int64 BytesReceived { get; }
+        public Int64 TotalBytesToReceive { get; }
+
+        public Int32 ProgressPercentage
+        {
+            get
+            {
+                if (TotalBytesToReceive <= 0)
+                    return 0;
+
+                Double progress = BytesReceived * 100d / TotalBytesToReceive;
+                return (Int32)Math.Max(0, Math.Min(100, Math.Round(progress)));
+            }
+        }
+    }
+
+    public class ThrottledHttpClient : IDisposable
+    {
+        private static readonly NLog.Logger _log = AppLogger.GetLogger();
+
+        private readonly HttpClient _client;
+        private readonly Timer _timer;
+        private readonly object _stateLock = new object();
+        private CancellationTokenSource _downloadCts;
+        private bool _isBusy;
         private bool _updatePending;
 
-        public ThrottledWebClient()
+        public event EventHandler<ThrottledDownloadProgressChangedEventArgs> DownloadProgressChanged;
+        public event AsyncCompletedEventHandler DownloadFileCompleted;
+
+        public bool IsBusy
         {
+            get
+            {
+                lock (_stateLock)
+                    return _isBusy;
+            }
+        }
+
+        public ThrottledHttpClient()
+        {
+            HttpClientHandler handler = new HttpClientHandler
+            {
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+            };
+
+            _client = new HttpClient(handler, disposeHandler: true);
+            _client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0");
+
             _timer = new Timer(100);
             _timer.Elapsed += OnTimerElapsed;
             _timer.Start();
         }
 
-        protected override void OnDownloadProgressChanged(DownloadProgressChangedEventArgs e)
+        public void CancelAsync()
         {
-            if (!_updatePending)
+            lock (_stateLock)
             {
-                _updatePending = true;
-                base.OnDownloadProgressChanged(e);
+                _downloadCts?.Cancel();
             }
         }
 
-        private void OnTimerElapsed(object sender, ElapsedEventArgs e)
+        public void DownloadFileAsync(Uri address, String fileName)
+        {
+            _log.Info("Requesting {Uri}", address);
+
+            CancellationTokenSource cts;
+            lock (_stateLock)
+            {
+                if (_isBusy)
+                    throw new InvalidOperationException("A download is already in progress.");
+
+                _downloadCts = new CancellationTokenSource();
+                cts = _downloadCts;
+                _isBusy = true;
+            }
+
+            _ = DownloadFileInternalAsync(address, fileName, cts);
+        }
+
+        private async Task DownloadFileInternalAsync(Uri address, String fileName, CancellationTokenSource cts)
+        {
+            Exception error = null;
+            bool cancelled = false;
+
+            try
+            {
+                using (HttpResponseMessage response = await _client.GetAsync(address, HttpCompletionOption.ResponseHeadersRead, cts.Token).ConfigureAwait(false))
+                {
+                    response.EnsureSuccessStatusCode();
+                    LogResponse(response, address);
+
+                    Int64 totalBytes = response.Content.Headers.ContentLength ?? -1;
+                    Int64 bytesReceived = 0;
+
+                    using (Stream input = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                    using (FileStream output = File.Create(fileName))
+                    {
+                        Byte[] buffer = new Byte[32 * 1024];
+                        Int32 read;
+                        while ((read = await input.ReadAsync(buffer, 0, buffer.Length, cts.Token).ConfigureAwait(false)) > 0)
+                        {
+                            await output.WriteAsync(buffer, 0, read, cts.Token).ConfigureAwait(false);
+                            bytesReceived += read;
+                            RaiseDownloadProgressChanged(bytesReceived, totalBytes);
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                cancelled = true;
+                _log.Warn("Download was cancelled for {Uri}.", address);
+            }
+            catch (Exception ex)
+            {
+                error = ex;
+                _log.Error(ex, "Download failed for {Uri}.", address);
+            }
+            finally
+            {
+                lock (_stateLock)
+                {
+                    _isBusy = false;
+                    if (ReferenceEquals(_downloadCts, cts))
+                    {
+                        _downloadCts.Dispose();
+                        _downloadCts = null;
+                    }
+                }
+
+                if (error == null && !cancelled)
+                    _log.Info("Download completed successfully for {Uri}.", address);
+
+                DownloadFileCompleted?.Invoke(this, new AsyncCompletedEventArgs(error, cancelled, null));
+            }
+        }
+
+        private void RaiseDownloadProgressChanged(Int64 bytesReceived, Int64 totalBytesToReceive)
+        {
+            if (_updatePending)
+                return;
+
+            _updatePending = true;
+            DownloadProgressChanged?.Invoke(this, new ThrottledDownloadProgressChangedEventArgs(bytesReceived, totalBytesToReceive));
+        }
+
+        private void LogResponse(HttpResponseMessage response, Uri uri)
+        {
+            Int32 status = (Int32)response.StatusCode;
+            if (status >= 400)
+                _log.Warn("HTTP {StatusCode} ({StatusDescription}) for {Uri}", status, response.ReasonPhrase, uri);
+            else
+                _log.Info("HTTP {StatusCode} for {Uri} - Content-Type: {ContentType}, Content-Length: {ContentLength}",
+                    status,
+                    uri,
+                    response.Content.Headers.ContentType,
+                    response.Content.Headers.ContentLength ?? -1);
+        }
+
+        public void Dispose()
+        {
+            lock (_stateLock)
+            {
+                _downloadCts?.Cancel();
+                _downloadCts?.Dispose();
+                _downloadCts = null;
+                _isBusy = false;
+            }
+
+            _timer.Stop();
+            _timer.Elapsed -= OnTimerElapsed;
+            _timer.Dispose();
+            _client.Dispose();
+        }
+
+        private void OnTimerElapsed(Object sender, ElapsedEventArgs e)
         {
             _updatePending = false;
         }

--- a/Memoria.Launcher/MainWindow.cs
+++ b/Memoria.Launcher/MainWindow.cs
@@ -22,6 +22,8 @@ namespace Memoria.Launcher
 {
     public partial class MainWindow : Window, IComponentConnector
     {
+        private static readonly NLog.Logger _log = AppLogger.GetLogger();
+
         //public ModManagerWindow ModdingWindow;
         public static DateTime MemoriaAssemblyCompileDate;
 
@@ -44,6 +46,8 @@ namespace Memoria.Launcher
                 Directory.SetCurrentDirectory(launcherDirectory);
                 MemoriaAssemblyCompileDate = new DateTime(2000, 1, 1);
             }
+
+            _log.Info("Memoria Launcher started (v{Version})", MainWindow.MemoriaAssemblyCompileDate.ToString("yyyy.MM.dd"));
 
             InitializeComponent();
 

--- a/Memoria.Launcher/MainWindow_ModManager.cs
+++ b/Memoria.Launcher/MainWindow_ModManager.cs
@@ -783,9 +783,9 @@ namespace Memoria.Launcher
                     ext = "zip";
                 }
                 downloadingPath = Mod.INSTALLATION_TMP + "/" + (mod.InstallationPath ?? mod.Name) + "." + ext;
-                downloadClient = new ThrottledWebClient();
-                downloadClient.DownloadProgressChanged += new DownloadProgressChangedEventHandler(DownloadLoop);
-                downloadClient.DownloadFileCompleted += new AsyncCompletedEventHandler(DownloadEnd);
+                downloadClient = new ThrottledHttpClient();
+                downloadClient.DownloadProgressChanged += DownloadLoop;
+                downloadClient.DownloadFileCompleted += DownloadEnd;
                 downloadClient.DownloadFileAsync(new Uri(mod.DownloadUrl), downloadingPath);
             });
             downloadThread.Start();
@@ -793,7 +793,7 @@ namespace Memoria.Launcher
             lstDownloads.Height = 100;
             btnCancelStackpanel.Height = 100;
         }
-        private void DownloadLoop(Object sender, DownloadProgressChangedEventArgs e)
+        private void DownloadLoop(Object sender, ThrottledDownloadProgressChangedEventArgs e)
         {
             Dispatcher.BeginInvoke((MethodInvoker)delegate
             {
@@ -812,7 +812,10 @@ namespace Memoria.Launcher
                     }
 
                     downloadingMod.DownloadSpeed = $"{dlSpeed} {measurement}/{(String)Lang.Res["Measurement.SecondAbbr"]}";
-                    downloadingMod.RemainingTime = $"{TimeSpan.FromSeconds(Math.Round((e.TotalBytesToReceive - e.BytesReceived) * timeSpan / e.BytesReceived)):g}";
+                    if (e.BytesReceived > 0 && e.TotalBytesToReceive > 0)
+                        downloadingMod.RemainingTime = $"{TimeSpan.FromSeconds(Math.Round((e.TotalBytesToReceive - e.BytesReceived) * timeSpan / e.BytesReceived)):g}";
+                    else
+                        downloadingMod.RemainingTime = "";
                 }
                 catch (NullReferenceException) // added to catch a race condition that sometimes occures where Ui tries to update but download has finished
                 {
@@ -1093,8 +1096,8 @@ namespace Memoria.Launcher
             ReadCatalog();
             downloadCatalogThread = new Thread(() =>
             {
-                downloadCatalogClient = new WebClient();
-                downloadCatalogClient.DownloadFileCompleted += new AsyncCompletedEventHandler(DownloadCatalogEnd);
+                downloadCatalogClient = new ThrottledHttpClient();
+                downloadCatalogClient.DownloadFileCompleted += DownloadCatalogEnd;
                 downloadCatalogClient.DownloadFileAsync(new Uri(CATALOG_URL), CATALOG_PATH + ".tmp");
             });
             downloadCatalogThread.Start();
@@ -1797,8 +1800,8 @@ namespace Memoria.Launcher
         private DateTime downloadBytesTime;
         private Thread downloadThread;
         private Thread downloadCatalogThread;
-        private WebClient downloadClient;
-        private WebClient downloadCatalogClient;
+        private ThrottledHttpClient downloadClient;
+        private ThrottledHttpClient downloadCatalogClient;
         private object ascendingSortedColumn = null;
 
         private const String CATALOG_PATH = "./ModCatalog.xml";

--- a/Memoria.Launcher/Memoria.Launcher.csproj
+++ b/Memoria.Launcher/Memoria.Launcher.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Launcher\IniFile.cs" />
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Launcher\SettingsGrid_Vanilla.cs" />
+    <Compile Include="Launcher\AppLogger.cs" />
     <Compile Include="Launcher\Utils.cs" />
     <Compile Include="Launcher\UiLauncherPlayButton.cs" />
     <Compile Include="Launcher\UiLauncherButton.xaml.cs">
@@ -275,6 +276,7 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="NLog" Version="6.1.3" />
     <PackageReference Include="SharpCompress" Version="0.40.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
This PR attempts to tackle two minor paintpoints I've seen recently while trying to support some users who were claiming to have issues downloading mods.

The first part is about migrating from `WebClient` to `HttpClient` which is also future proof in the .NET ecosystem ( see https://learn.microsoft.com/en-us/dotnet/core/compatibility/networking/6.0/webrequest-deprecated ). While doing so I did uniform the client used to download the catalog and the client used to download mods to be only one. This will hopefully solve download issues some users are reporting since the layer is deprecated and not maintained by the dotnet community.

The second part of this PR focuses on the launcher, which will produce a new log file name `MemoriaLauncher.log` which will contain minimal required information to be able to troubleshoot why something failed on the HTTP side, if users report having issues. The log framework used is [Nlog](https://nlog-project.org/) which is the same we use on 7th Heaven and Junction VIII and has been proved to be rock solid. The log layer is also generically available in the entire Launcher project to be used in case we want to log more to enhance troubleshooting ( see `AppLogger.cs` ).

Finally, I added one minor commit about ignoring `lscache` files which are being produced by the VSCode C# extension ( see https://github.com/microsoft/vscode-dotnettools/issues/2961 ), which otherwise would blast the repository side and they are not required ( other than for optimization purposes in case you compile from VSCode, but that's not the case for most of us ).

I personally tested this PR already and I had no issues refreshing the catalog, downloading mods as well as having logs generating what was needed, but feel free to have a test yourself. Feel free as well to use my canary release which contains this very same patch https://github.com/julianxhokaxhiu/Memoria/releases/tag/canary if you don't want to build it yourself.

As always I'm open for feedback, thank you in advance :)

