### PR TITLE
Launcher: Fix Linux rendering for middle columns

### DIFF
--- a/Memoria.Launcher/Launcher/UiGrid.cs
+++ b/Memoria.Launcher/Launcher/UiGrid.cs
@@ -20,7 +20,7 @@ namespace Memoria.Launcher
         public UiGrid()
         {
             SetCols(100);
-            Width = 293;
+            Width = 290;
             Margin = new Thickness(0);
         }
 


### PR DESCRIPTION
This PR fixes another minor layout inconsistency between Windows and Linux, related to the middle column rendering in all grids ( Settings, Cheats, Advanced ).

### Before

**Linux:**
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/f32e4e56-e0f4-4993-aee2-9eee77a9d973" />

### After

**Linux:**
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/3acb4588-c31b-4763-8971-fc7e99f9071b" />

**Windows:** ( for comparison )
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/33c8f953-c1e5-45a2-b0bc-1d39130c8a6c" />
