### PR TITLE
Common: Bump dependencies

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -1477,7 +1477,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Memoria.Client/Memoria.Client.csproj
+++ b/Memoria.Client/Memoria.Client.csproj
@@ -198,7 +198,7 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.6.1" />
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="5.0.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Memoria.Launcher/Launcher/Utils.cs
+++ b/Memoria.Launcher/Launcher/Utils.cs
@@ -831,7 +831,7 @@ namespace Memoria.Launcher
             {
                 return;
             }
-            using (var archive = ArchiveFactory.Open(archivePath))
+            using (var archive = ArchiveFactory.OpenArchive(archivePath))
             {
                 int total = 0;
                 foreach (var entry in archive.Entries)

--- a/Memoria.Launcher/MainWindow_ModManager.cs
+++ b/Memoria.Launcher/MainWindow_ModManager.cs
@@ -828,7 +828,7 @@ namespace Memoria.Launcher
         private String FindModRoot(String archivePath, String preferedRootName = null)
         {
             String[] lookUpFiles = [Mod.DESCRIPTION_FILE, "Memoria.ini", "DictionaryPatch.txt", "FF9_Data", "StreamingAssets"];
-            using (IArchive archive = ArchiveFactory.Open(archivePath))
+            using (IArchive archive = ArchiveFactory.OpenArchive(archivePath))
             {
                 foreach (var entry in archive.Entries)
                 {

--- a/Memoria.Launcher/Memoria.Launcher.csproj
+++ b/Memoria.Launcher/Memoria.Launcher.csproj
@@ -278,7 +278,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NLog" Version="6.1.3" />
-    <PackageReference Include="SharpCompress" Version="0.40.0" />
+    <PackageReference Include="SharpCompress" Version="0.48.1" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="Memoria.Launcher.targets" />


### PR DESCRIPTION
This PR bumpes the following dependencies:

- Newtonsoft.Json: 13.0.3 -> 13.0.4
- Extended.Wpf.Toolkit: 4.6.1 -> 5.0.0
- SharpCompress: 0.40.0 -> 0.48.1 ( fixes https://github.com/advisories/GHSA-6c8g-7p36-r338 )