### PR TITLE
CI: Enable vcpkg binary caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
     - main
   workflow_dispatch:
 
+env:
+  # VCPKG: Enable Binary Caching
+  VCPKG_BINARY_SOURCES: clear;nuget,github,readwrite
+
 jobs:
   build:
     runs-on: windows-latest
@@ -32,6 +36,15 @@ jobs:
         key: nuget-${{ runner.os }}-${{ hashFiles('**/packages.config', '**/*.csproj') }}
         restore-keys: |
           nuget-${{ runner.os }}-
+
+    - name: Setup Github Package Registry
+      shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+            nuget sources add -Name github -Source "https://nuget.pkg.github.com/${env:GITHUB_REPOSITORY_OWNER}/index.json" -Username ${env:GITHUB_REPOSITORY_OWNER} -Password ${env:GITHUB_TOKEN} -StorePasswordInClearText
+            nuget setApiKey ${env:GITHUB_TOKEN} -Source "https://nuget.pkg.github.com/${env:GITHUB_REPOSITORY_OWNER}/index.json"
+            nuget sources list
 
     - name: NuGet restore
       run: nuget restore Memoria.sln

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+env:
+  # VCPKG: Enable Binary Caching
+  VCPKG_BINARY_SOURCES: clear;nuget,github,readwrite
+
 jobs:
   release:
     runs-on: windows-latest
@@ -31,6 +35,15 @@ jobs:
         key: nuget-${{ runner.os }}-${{ hashFiles('**/packages.config', '**/*.csproj') }}
         restore-keys: |
           nuget-${{ runner.os }}-
+
+    - name: Setup Github Package Registry
+      shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+            nuget sources add -Name github -Source "https://nuget.pkg.github.com/${env:GITHUB_REPOSITORY_OWNER}/index.json" -Username ${env:GITHUB_REPOSITORY_OWNER} -Password ${env:GITHUB_TOKEN} -StorePasswordInClearText
+            nuget setApiKey ${env:GITHUB_TOKEN} -Source "https://nuget.pkg.github.com/${env:GITHUB_REPOSITORY_OWNER}/index.json"
+            nuget sources list
 
     - name: NuGet restore
       run: nuget restore Memoria.sln

--- a/Memoria.Injection/vcpkg.json
+++ b/Memoria.Injection/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "memoria-injection",
   "version": "1.0.0",
-  "builtin-baseline": "120deac3062162151622ca4860575a33844ba10b",
+  "builtin-baseline": "c3867e714dd3a51c272826eea77267876517ed99",
   "dependencies": [
     "detours"
   ],


### PR DESCRIPTION
This PR is a minor boost for CI/CD that would enable VCPKG [binary caching](https://learn.microsoft.com/en-us/vcpkg/users/binarycaching) improving therefore build times ( as vcpkg dependencies would be built once per stack upgrade, instead of everytime we run a job on the CI/CD ).

I additionally bumped the vcpkg baseline, but basically it doesn't impact anything, it just makes sure we use the latest stable tag when pulling dependencies, if any new one may be required.