### PR TITLE
Patcher: Fix missing SaXAudio x86 binaries

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -1479,5 +1479,9 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
+  <Target Name="AssemblyCSharpBuildSaXAudio" BeforeTargets="Build" Condition="'$(DesignTimeBuild)' != 'true'">
+    <MSBuild Projects="..\SaXAudio\SaXAudio.vcxproj" Properties="Configuration=$(Configuration);Platform=Win32" RunEachTargetSeparately="true" />
+    <MSBuild Projects="..\SaXAudio\SaXAudio.vcxproj" Properties="Configuration=$(Configuration);Platform=x64" RunEachTargetSeparately="true" />
+  </Target>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Memoria.Patcher/Memoria.Patcher.csproj
+++ b/Memoria.Patcher/Memoria.Patcher.csproj
@@ -3794,8 +3794,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <Target Name="MemoriaPatcherBeforeBuild" BeforeTargets="Build" Condition="'$(DesignTimeBuild)' != 'true'">
+    <MSBuild Projects="..\Assembly-CSharp\Assembly-CSharp.csproj" Properties="Configuration=$(Configuration);Platform=AnyCPU" RunEachTargetSeparately="true" />
+  </Target>
   <Target Name="MemoriaPatcherBeforePublish" BeforeTargets="Publish" Condition="'$(PublishSingleFile)' == 'true'">
-    <MSBuild Projects="..\Assembly-CSharp\Assembly-CSharp.csproj" Properties="Platform=AnyCPU" RunEachTargetSeparately="true" />
+    <MSBuild Projects="..\Assembly-CSharp\Assembly-CSharp.csproj" Properties="Configuration=$(Configuration);Platform=AnyCPU" RunEachTargetSeparately="true" />
   </Target>
   <Target Name="MemoriaPatcherAfterPublish" AfterTargets="Publish" Condition="'$(PublishSingleFile)' == 'true'">
     <PropertyGroup>


### PR DESCRIPTION
This PR will solve missing x86 SaXAudio.dll files that are required if someone wants to run the x86 binary. This fixes the game freezing while trying to use the new Audio engine.

To prove it, feel free to open this action job https://github.com/julianxhokaxhiu/Memoria/actions/runs/26684184813/job/78649512654 and search for `x86\SaXAudio.dll`. If you can find a match it means the file is being build and packed as well.

Before that wasn't the case ( search for the same token in the last job on main and you'll find no match ).