### PR TITLE
Fix FieldCreatorScene export writing overlay PNGs to the game root instead of the field folder

### DIFF
--- a/Assembly-CSharp/Global/BGSCENE_DEF.cs
+++ b/Assembly-CSharp/Global/BGSCENE_DEF.cs
@@ -516,7 +516,10 @@ public class BGSCENE_DEF
         foreach (BGOVERLAY_DEF bgOverlay in this.overlayList)
         {
             bgsStr += $"OVERLAY\n";
-            bgsStr += ExportMemoriaBGXOverlay(bgOverlay, fileName);
+            // Write overlay PNGs NEXT TO the .bgx, not the process CWD (the game root).
+            // ExportMemoriaBGXOverlay derives the .bgx "Image:" ref with Path.GetFileName(),
+            // so it stays bare/relative while the file lands in the field folder.
+            bgsStr += ExportMemoriaBGXOverlay(bgOverlay, folder + fileName);
         }
         foreach (BGANIM_DEF bgAnim in this.animList)
         {


### PR DESCRIPTION
## Problem

`BGSCENE_DEF.ExportMemoriaBGX` computes the output `folder`, but passes the bare `fileName` (no directory) to `ExportMemoriaBGXOverlay`. That helper writes each overlay via `WriteTextureToFile(texture, "{base}_{n}.png")` — a relative path — so the PNGs land in the process working directory (the game root), while the emitted `.bgx` `Image:` line (correctly a bare filename via `Path.GetFileName`) is loaded from the field's own folder.

Net result: the in-editor (FieldCreatorScene) export produces a `.bgx` whose overlay PNGs are **missing from the field folder**, so the field black-screens when loaded — the editor can't save a usable custom field.

## Fix

Pass `folder + fileName` as the texture base path. `ExportMemoriaBGXOverlay` already derives the `Image:` reference with `Path.GetFileName(...)`, so the reference stays bare/relative while the file is written into the field folder.

One-line change, scoped to the editor export path: `folder` already ends in `/`, and this is the only call site of `ExportMemoriaBGXOverlay`, so nothing else is affected.
