### PR TITLE
Launcher: Fix tooltip size calculation for Linux

### DIFF
--- a/Memoria.Launcher/Launcher/UiGrid.cs
+++ b/Memoria.Launcher/Launcher/UiGrid.cs
@@ -81,6 +81,25 @@ namespace Memoria.Launcher
         }
         private static HashSet<string> ImageResourceNames = GetImageResourceNames();
 
+        private static void ApplyTooltipTextRendering(TextBlock textBlock)
+        {
+            // Force a bundled font so glyph metrics/spacing are consistent across platforms.
+            FontFamily tooltipFont = Application.Current.TryFindResource("Overpass") as FontFamily;
+            if (tooltipFont != null)
+                textBlock.FontFamily = tooltipFont;
+        }
+
+        private static void ApplyTooltipTextWrapLayout(TextBlock textBlock, Double maxWidth)
+        {
+            textBlock.MaxWidth = maxWidth;
+            textBlock.Loaded += (sender, e) =>
+            {
+                textBlock.Measure(new Size(Double.PositiveInfinity, Double.PositiveInfinity));
+                Double desiredWidth = Math.Ceiling(textBlock.DesiredSize.Width);
+                textBlock.Width = Math.Min(Math.Max(desiredWidth, 0), maxWidth);
+            };
+        }
+
         public static void MakeTooltip(FrameworkElement uiElement, String text = "", String imageName = "", String curstorType = "mog", PlacementMode placement = PlacementMode.Bottom)
         {
             if (text != "" || imageName != "")
@@ -90,6 +109,7 @@ namespace Memoria.Launcher
                     Orientation = Orientation.Vertical,
                     Margin = new Thickness(0)
                 };
+                Boolean hasHelpIcon = false;
                 try
                 {
                     Image helpIcon = new Image
@@ -101,6 +121,7 @@ namespace Memoria.Launcher
                         Margin = new Thickness(0, 5, 0, 0)
                     };
                     tooltipStackPanel.Children.Add(helpIcon);
+                    hasHelpIcon = true;
                 }
                 catch { }
 
@@ -118,13 +139,14 @@ namespace Memoria.Launcher
                     tooltipTextBlock = new TextBlock
                     {
                         Opacity = 1,
-                        MaxWidth = 275,
                         FontSize = 14,
                         TextWrapping = TextWrapping.Wrap,
                         HorizontalAlignment = HorizontalAlignment.Left,
                         Effect = dropShadow,
-                        Margin = new Thickness(0)
+                        Margin = hasHelpIcon ? new Thickness(0, 5, 0, 0) : new Thickness(0)
                     };
+                    ApplyTooltipTextRendering(tooltipTextBlock);
+                    ApplyTooltipTextWrapLayout(tooltipTextBlock, 275);
                     if (Lang.Res.Contains(text))
                     {
                         tooltipTextBlock.SetResourceReference(TextBlock.TextProperty, text);
@@ -175,7 +197,10 @@ namespace Memoria.Launcher
                                 }
 
                                 if (tooltipTextBlock != null && tooltipImage.Width > 275)
+                                {
                                     tooltipTextBlock.MaxWidth = tooltipImage.Width;
+                                    tooltipTextBlock.Width = tooltipImage.Width;
+                                }
                             };
                             BitmapImage bitmap = new BitmapImage();
                             bitmap.BeginInit();
@@ -287,12 +312,13 @@ namespace Memoria.Launcher
                 Text = "The quick brown fox jumps over the lazy dog",
                 Opacity = 1,
                 Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#C8C8C8")),
-                MaxWidth = 275,
                 FontSize = 24,
                 TextWrapping = TextWrapping.Wrap,
                 Effect = dropShadow,
                 Margin = new Thickness(0)
             };
+            ApplyTooltipTextRendering(tooltipTextBlock);
+            ApplyTooltipTextWrapLayout(tooltipTextBlock, 275);
             tooltipStackPanel.Children.Add(tooltipTextBlock);
 
             Border bottomrightBorder = new Border


### PR DESCRIPTION
This PR mainly tackles another minor UI layout rendering fix between Windows and Linux (Proton/Wine). The UI tooltip text sometimes was cut off under Linux, while it was rendering fine on Windows.

This is how it looks like today under Linux:
<img width="970" height="687" alt="immagine" src="https://github.com/user-attachments/assets/19e47749-41df-404e-b652-f34008a4947e" />

After this PR, the tooltip will look like this instead:

**Windows:**
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/6b042e5a-35e9-4403-ba9c-379dc3cb0ba3" />

**Linux:**
<img width="999" height="704" alt="immagine" src="https://github.com/user-attachments/assets/359e9c07-444f-4776-8c75-9b7cada29232" />

Main things changed:
- tooltip now uses the embedded `Overpass` font ( provides consistent glyph rendering across platforms )
- tooltip width is now calculated manually instead of using `MaxSize` ( unfortunately this doesn't work well under Wine Mono )
- added 5px margin between `HELP` and text block to improve readability

---

~~Another minor change I did was removing the `MemoriaCatalog.xml` since it's an old one and not used by the project, as the real one exists under https://github.com/Albeoris/Memoria/tree/mod-catalog so I took the freedom to remove it, but if you prefer to not have this patch let me know and I'll be happy to drop it.~~ Dropped, see below.

Thank you in advance and as usual, any feedback is more than welcome