### PR TITLE
Launcher: Replace Tahoma for Overpass and fix layout

### DIFF
--- a/Memoria.Launcher/Launcher/SettingsGrid_Display.cs
+++ b/Memoria.Launcher/Launcher/SettingsGrid_Display.cs
@@ -61,7 +61,7 @@ namespace Memoria.Launcher
                 }
                 catch { }
             }
-            CreateCombobox("FontChoice", fontNames, 25, "Settings.FontChoice", "Settings.FontChoice_Tooltip", "", true);
+            CreateCombobox("FontChoice", fontNames, 45, "Settings.FontChoice", "Settings.FontChoice_Tooltip", "", true);
 
         }
     }

--- a/Memoria.Launcher/Launcher/UiGrid.cs
+++ b/Memoria.Launcher/Launcher/UiGrid.cs
@@ -452,9 +452,12 @@ namespace Memoria.Launcher
             textbloc.Foreground = TextColor;
             Border border = new Border();
             textbloc.FontSize = FontSizeNormal;
+            textbloc.HorizontalAlignment = HorizontalAlignment.Left;
+            textbloc.TextAlignment = TextAlignment.Left;
             textbloc.VerticalAlignment = VerticalAlignment.Center;
             textbloc.Margin = new Thickness(0);
             textbloc.Padding = new Thickness(0, 4, 0, 6);
+            border.HorizontalAlignment = HorizontalAlignment.Stretch;
             border.VerticalAlignment = VerticalAlignment.Center;
             border.SetValue(RowProperty, Row);
             border.SetValue(ColumnProperty, 0);
@@ -552,6 +555,8 @@ namespace Memoria.Launcher
                 MakeFontPreview(comboBox);
             comboBox.Margin = CommonMargin;
             comboBox.Height = ComboboxHeight;
+            comboBox.HorizontalAlignment = HorizontalAlignment.Right;
+            comboBox.VerticalAlignment = VerticalAlignment.Center;
             if (selectByName)
                 comboBox.SetBinding(Selector.SelectedItemProperty, new Binding(property) { Mode = BindingMode.TwoWay });
             else
@@ -560,6 +565,14 @@ namespace Memoria.Launcher
             comboBox.SetValue(ColumnProperty, firstColumn);
             comboBox.SetValue(RowSpanProperty, 1);
             comboBox.SetValue(ColumnSpanProperty, MaxColumns - firstColumn);
+            comboBox.Loaded += (sender, e) =>
+            {
+                comboBox.Width = Math.Max(0, ActualWidth * (MaxColumns - firstColumn) / MaxColumns);
+            };
+            SizeChanged += (sender, e) =>
+            {
+                comboBox.Width = Math.Max(0, ActualWidth * (MaxColumns - firstColumn) / MaxColumns);
+            };
             comboBox.MouseEnter += (sender, e) =>
             {
                 comboBox.Focus();
@@ -592,9 +605,10 @@ namespace Memoria.Launcher
             slider.IsSnapToTickEnabled = true;
             slider.TickPlacement = TickPlacement.None;
             slider.SetValue(RowProperty, Row);
-            slider.SetValue(ColumnProperty, firstColumn + 6);
+            Int32 sliderFirstColumn = firstColumn + 6;
+            slider.SetValue(ColumnProperty, sliderFirstColumn);
             slider.SetValue(RowSpanProperty, 1);
-            slider.SetValue(ColumnSpanProperty, (MaxColumns - firstColumn));
+            slider.SetValue(ColumnSpanProperty, Math.Max(0, MaxColumns - sliderFirstColumn));
             slider.MouseWheel += (sender, e) =>
             {
                 slider.Value = Math.Max(Math.Min(slider.Value + Math.Sign(e.Delta) * tickFrequency, max), min);

--- a/Memoria.Launcher/Launcher/Window_ChangeLog.xaml
+++ b/Memoria.Launcher/Launcher/Window_ChangeLog.xaml
@@ -71,7 +71,7 @@
                             x:Name="Document"
                             Padding="15,0"
                             Foreground="{StaticResource WhiteUI}"
-                            FontFamily="Tahoma"
+                            FontFamily="{StaticResource Overpass}"
                             FontSize="16"
                             Background="Transparent"
                             BorderThickness="0"

--- a/Memoria.Launcher/Launcher/Window_ModDescription.xaml
+++ b/Memoria.Launcher/Launcher/Window_ModDescription.xaml
@@ -71,7 +71,7 @@
                             x:Name="Document"
                             Padding="15,0"
                             Foreground="{StaticResource WhiteUI}"
-                            FontFamily="Tahoma"
+                            FontFamily="{StaticResource Overpass}"
                             FontSize="16"
                             Background="Transparent"
                             BorderThickness="0"

--- a/Memoria.Launcher/MainWindow.xaml
+++ b/Memoria.Launcher/MainWindow.xaml
@@ -860,7 +860,7 @@
                                                                VerticalAlignment="Center"
                                                                Margin="28,0,0,0"/>
                                                         <Label x:Name="ModOptionsHeaderArrow"
-                                                               FontFamily="Tahoma"
+                                                               FontFamily="{StaticResource Overpass}"
                                                                Foreground="{StaticResource WhiteUI}"
                                                                FontSize="16"
                                                                VerticalAlignment="Center"

--- a/Memoria.Launcher/Resources/ButtonsStyle.xaml
+++ b/Memoria.Launcher/Resources/ButtonsStyle.xaml
@@ -2,7 +2,7 @@
 
     <Style x:Key="ButtonStyle" TargetType="{x:Type Button}">
         <Setter Property="Foreground" Value="{DynamicResource WhiteUI}"/>
-        <Setter Property="FontFamily" Value="Tahoma"/>
+        <Setter Property="FontFamily" Value="{StaticResource Overpass}"/>
         <Setter Property="FontWeight" Value="Medium"/>
         <Setter Property="FontSize" Value="13"/>
         <Setter Property="Template">
@@ -49,7 +49,7 @@
 
     <Style x:Key="ButtonStyleRed" TargetType="{x:Type Button}">
         <Setter Property="Foreground" Value="{DynamicResource WhiteUI}"/>
-        <Setter Property="FontFamily" Value="Tahoma"/>
+        <Setter Property="FontFamily" Value="{StaticResource Overpass}"/>
         <Setter Property="FontWeight" Value="Medium"/>
         <Setter Property="FontSize" Value="13"/>
         <Setter Property="Template">

--- a/Memoria.Launcher/Resources/CheckBoxStyle.xaml
+++ b/Memoria.Launcher/Resources/CheckBoxStyle.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Style x:Key="CheckBoxStyle" TargetType="{x:Type CheckBox}">
         <Setter Property="Foreground" Value="{DynamicResource WhiteUI}"/>
-        <Setter Property="FontFamily" Value="Tahoma"/>
+        <Setter Property="FontFamily" Value="{StaticResource Overpass}"/>
         <Setter Property="FontSize" Value="14"/>
         <Setter Property="Template">
             <Setter.Value>

--- a/Memoria.Launcher/Resources/ComboBoxStyle.xaml
+++ b/Memoria.Launcher/Resources/ComboBoxStyle.xaml
@@ -175,7 +175,7 @@
         <Setter Property="Background" Value="{DynamicResource BrushLightColorFaded}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BrushLightColorNormal}"/>
         <Setter Property="Foreground" Value="{DynamicResource BrushDarkTextColor}"/>
-        <Setter Property="FontFamily" Value="Tahoma"/>
+        <Setter Property="FontFamily" Value="{StaticResource Overpass}"/>
         <Setter Property="FontWeight" Value="Medium"/>
         <Setter Property="FontSize" Value="13"/>
         <Setter Property="BorderThickness" Value="1"/>

--- a/Memoria.Launcher/Resources/ComboBoxStyle.xaml
+++ b/Memoria.Launcher/Resources/ComboBoxStyle.xaml
@@ -178,6 +178,7 @@
         <Setter Property="FontFamily" Value="{StaticResource Overpass}"/>
         <Setter Property="FontWeight" Value="Medium"/>
         <Setter Property="FontSize" Value="13"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
@@ -208,7 +209,7 @@
                     <Grid>
                         <Border Name="HighLight" CornerRadius="3" Background="{DynamicResource BrushAccentColorHover}" Opacity="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" SnapsToDevicePixels="true"/>
                         <Border Name="Border" CornerRadius="3" Padding="8,5,8,5" SnapsToDevicePixels="true">
-                            <ContentPresenter />
+                            <ContentPresenter VerticalAlignment="Center"/>
                         </Border>
                     </Grid>
                     <ControlTemplate.Triggers>

--- a/Memoria.Launcher/Resources/ToggleStyle.xaml
+++ b/Memoria.Launcher/Resources/ToggleStyle.xaml
@@ -4,7 +4,7 @@
         <Setter Property="BorderBrush" Value="{StaticResource BrushLightColorNormal}"/>
         <Setter Property="Foreground" Value="{StaticResource {x:Static SystemColors.ControlTextBrushKey}}"/>
         <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="FontFamily" Value="Tahoma"/>
+        <Setter Property="FontFamily" Value="{StaticResource Overpass}"/>
         <Setter Property="FontSize" Value="14"/>
         <Setter Property="Foreground" Value="{StaticResource BrushLightColorNormal}"/>
         <Setter Property="Template">

--- a/Settings.ini
+++ b/Settings.ini
@@ -1,0 +1,4 @@
+[Settings]
+ActiveMonitor = 0
+WindowMode = 0
+ScreenResolution = 1920x1080

--- a/Settings.ini
+++ b/Settings.ini
@@ -1,4 +1,0 @@
-[Settings]
-ActiveMonitor = 0
-WindowMode = 0
-ScreenResolution = 1920x1080


### PR DESCRIPTION
This PR targets some visual coherence between all platforms we support ( Windows, macOS, Linux ). The main idea is that instead of allowing each environment to guess the glyphs to use when we ask for `Tahoma` we instead embed our own Font and we use it universally. This provides hopefully some visual coherence, including alignments, width, fonts, etc.

The code changes include as well minor layout fixes to rows in each column, ensuring they render within the column boundary, labels are aligned to the left, controls to the right, they are respectively vertically aligned in the middle, and text inside dropdowns are aligned to the middle as well.

After the PR this is how Memoria Launcher will look like:

**Windows:**
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/9e345ff3-0701-4d93-a146-52d779995a33" />
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/ca5272d4-990f-4977-8d56-1a38fdc3f703" />
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/efe11b7e-fea2-47f9-a2fb-d35650e0fab5" />
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/ae2e31ab-c77c-4725-b3fa-d72746988865" />

**Linux (Proton/Wine):**
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/6a9433fa-3552-4ee3-8d20-29927fcdd65e" />
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/ab43d559-856c-4da5-86f5-a1d6efbc502d" />
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/e940c6c3-0faa-4977-9d0b-dcbadb84a3f1" />
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/4e832dd3-57fd-4ed8-a439-63ea93cad235" />

**macOS:**
I don't have one at hand to test it, but should look similar to Linux.

---

Please note that there still might be minor vertical spacing in the text ( see for eg. changelog screenshot or mod description ) but I will address them in a separate PR.

Any question, feel free to ask.