### PR TITLE
Launcher: Fix vertical spacing for remote text

### DIFF
--- a/Memoria.Launcher/Launcher/Window_ChangeLog.xaml.cs
+++ b/Memoria.Launcher/Launcher/Window_ChangeLog.xaml.cs
@@ -57,7 +57,7 @@ namespace Memoria.Launcher
                 Document.Document.Blocks.Clear();
                 Paragraph p = new Paragraph(new Run($"Couldn't load the changelog."))
                 {
-                    Margin = new Thickness(0, 20, 0, 20),
+                    Padding = new Thickness(0, 0, 0, 10),
                     Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#aeee"))
                 };
                 Document.Document.Blocks.Add(p);
@@ -89,7 +89,8 @@ namespace Memoria.Launcher
                     {
                         Paragraph p = new Paragraph(new Run($"Version {version}"))
                         {
-                            Margin = new Thickness(0, 20, 0, 20),
+                            Margin = new Thickness(),
+                            Padding = new Thickness(0, 10, 0, 10),
                             FontSize = 26
                         };
 
@@ -123,7 +124,8 @@ namespace Memoria.Launcher
                         {
                             Paragraph p = new Paragraph(new Run(plainText))
                             {
-                                Margin = new Thickness(0, 20, 0, 10),
+                                Margin = new Thickness(),
+                                Padding = new Thickness(0, 20, 0, 10),
                                 FontSize = 20
                             };
                             Document.Document.Blocks.Add(p);
@@ -136,16 +138,19 @@ namespace Memoria.Launcher
                         }
                         if (trimmed.StartsWith("<li>"))
                         {
-                            Paragraph p = new Paragraph(new Run(plainText));
+                            Paragraph p = new Paragraph(new Run("• " + plainText));
                             ListItem item = new ListItem(p)
                             {
                                 Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#aeee"))
                             };
-                            item.Margin = new Thickness(20 + indent * 20, 0, 0, 0);
+                            item.Margin = new Thickness();
+                            item.Padding = new Thickness(indent * 10, 0, 0, 5);
                             if (list == null)
                             {
                                 list = new List();
-                                list.Padding = new Thickness(0, 0, 0, 0);
+                                list.MarkerStyle = TextMarkerStyle.None;
+                                list.Margin = new Thickness();
+                                list.Padding = new Thickness();
                                 Document.Document.Blocks.Add(list);
                             }
                             list.ListItems.Add(item);
@@ -162,7 +167,8 @@ namespace Memoria.Launcher
                         {
                             Paragraph p = new Paragraph(new Run(plainText))
                             {
-                                Margin = new Thickness(0, 10, 0, 10),
+                                Margin = new Thickness(),
+                                Padding = new Thickness(0, 10, 0, 10),
                                 Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#aeee"))
                             };
                             Document.Document.Blocks.Add(p);
@@ -176,7 +182,7 @@ namespace Memoria.Launcher
                 Document.Document.Blocks.Clear();
                 Paragraph p = new Paragraph(new Run($"Couldn't parse the changelog."))
                 {
-                    Margin = new Thickness(0, 20, 0, 20),
+                    Padding = new Thickness(0, 0, 0, 10),
                     Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#aeee"))
                 };
                 Document.Document.Blocks.Add(p);

--- a/Memoria.Launcher/Launcher/Window_ModDescription.xaml.cs
+++ b/Memoria.Launcher/Launcher/Window_ModDescription.xaml.cs
@@ -37,18 +37,22 @@ namespace Memoria.Launcher
                     {
                         Paragraph p = new Paragraph(new Run(paragraph.Trim()))
                         {
-                            Margin = new Thickness(0, 10, 0, 10),
+                            Margin = new Thickness(),
+                            Padding = new Thickness(0, 0, 0, 10),
                             Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#aeee"))
                         };
                         Document.Document.Blocks.Add(p);
                         paragraph = "";
                     }
-                    ListItem item = new ListItem(new Paragraph(new Run(line.TrimStart(['-', ' ']))));
-                    item.Margin = new Thickness(20, 0, 0, 0);
+                    ListItem item = new ListItem(new Paragraph(new Run("• " + line.TrimStart(['-', ' ']))));
+                    item.Margin = new Thickness();
+                    item.Padding = new Thickness(20, 0, 0, 5);
                     if (list == null)
                     {
                         list = new List();
-                        list.Padding = new Thickness(0, 0, 0, 0);
+                        list.MarkerStyle = TextMarkerStyle.None;
+                        list.Margin = new Thickness();
+                        list.Padding = new Thickness(0, 10, 0, 10);
                         list.Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#aeee"));
                         Document.Document.Blocks.Add(list);
                     }
@@ -60,7 +64,8 @@ namespace Memoria.Launcher
                     {
                         Paragraph p1 = new Paragraph(new Run(paragraph.Trim()))
                         {
-                            Margin = new Thickness(0, 10, 0, 10),
+                            Margin = new Thickness(),
+                            Padding = new Thickness(0, 0, 0, 10),
                             Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#aeee"))
                         };
                         Document.Document.Blocks.Add(p1);
@@ -69,7 +74,8 @@ namespace Memoria.Launcher
                     list = null;
                     Paragraph p = new Paragraph(new Run(line.TrimStart('#')))
                     {
-                        Margin = new Thickness(0, 20, 0, 10),
+                        Margin = new Thickness(),
+                        Padding = new Thickness(0, 0, 0, 10),
                         FontSize = 20
                     };
                     Document.Document.Blocks.Add(p);
@@ -85,7 +91,8 @@ namespace Memoria.Launcher
             {
                 Paragraph p = new Paragraph(new Run(paragraph.Trim()))
                 {
-                    Margin = new Thickness(0, 10, 0, 10),
+                    Margin = new Thickness(),
+                    Padding = new Thickness(0, 0, 0, 10),
                     Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#aeee"))
                 };
                 Document.Document.Blocks.Add(p);
@@ -98,7 +105,7 @@ namespace Memoria.Launcher
                 link.TextDecorations = TextDecorations.Underline;
                 link.Cursor = Cursors.Hand;
                 link.Click += OnHyperlinkClick;
-                Document.Document.Blocks.Add(new Paragraph(link) { Margin = new Thickness(0, 10, 0, 10), });
+                Document.Document.Blocks.Add(new Paragraph(link) { Margin = new Thickness(), Padding = new Thickness(0, 0, 0, 10), });
             }
         }
 


### PR DESCRIPTION
This PR is a continuation of #1437 which aims to fix the vertical spacing for text in the Changelog window and Mod description.

In order to make it look as close as possible between platforms, I had to "cheat" a bit as Disc bullet list styles apparently do not render wll under Proton/Wine ( or Wine Mono ), and because of it I had to force a display none of the style and use instead a fixed glyph `•`.

Other than that I had to change a bit the logic of `Margin` and `Padding` as also they do not apply well cross-platform, but combining them this way provided an almost identical layout ( still not 100% similar, but I'd say a solid 90% ).

Here how it will look like after the PR:

**Windows:**
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/5782840b-d901-4e4e-9d9b-218bccbc3bb8" />
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/06e202d0-0462-4bed-ae9b-e6778fda7990" />

**Linux (Proton/Wine):**
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/3dfff4d5-eaac-482e-9ecf-79e3c4359769" />
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/8e9bd8cf-da72-4350-9fd3-5ef56b8e8677" />

Any question feel free to ask