### PR TITLE
UpdateTitle function

### DIFF
--- a/Assembly-CSharp/Global/Field/Map/FieldMap.cs
+++ b/Assembly-CSharp/Global/Field/Map/FieldMap.cs
@@ -302,6 +302,7 @@ public class FieldMap : HonoBehavior
         {
             currentCounterNumber = PersistenSingleton<EventEngine>.Instance.eBin.getVarManually(EBin.SC_COUNTER_SVR);
             Log.Message("Map: " + FF9StateSystem.Common.FF9.fldMapNo + " | Scenario counter: " + PersistenSingleton<EventEngine>.Instance.eBin.getVarManually(EBin.SC_COUNTER_SVR));
+            PlayerWindow.UpdateTitle();
         }
     }
 
@@ -411,8 +412,7 @@ public class FieldMap : HonoBehavior
         this.walkMesh.UpdateActiveCameraWalkmesh();
         SmoothCamDelay = 4;
         SmoothCamActive = (!SmoothCamExcludeMaps.Contains(FF9StateSystem.Common.FF9.fldMapNo));
-        String camIdxIfCam = this.scene.cameraList.Count > 1 ? "-" + this.camIdx : "";
-        PlayerWindow.Instance.SetTitle($"Map: {FF9StateSystem.Common.FF9.fldMapNo}{camIdxIfCam} ({FF9StateSystem.Common.FF9.mapNameStr}) | Index/Counter: {PersistenSingleton<EventEngine>.Instance.eBin.getVarManually(EBin.MAP_INDEX_SVR)}/{PersistenSingleton<EventEngine>.Instance.eBin.getVarManually(EBin.SC_COUNTER_SVR)} | Loc: {FF9StateSystem.Common.FF9.fldLocNo}");
+        PlayerWindow.UpdateTitle();
         if (dbug) Log.Message(" |_ SetCurrentCameraIndex | ShaderMulX: " + ShaderMulX + " | bgCamera.depthOffset: " + bgCamera.depthOffset + " | bgCamera.vrpMaxX " + bgCamera.vrpMaxX + " | bgCamera.depthOffset: " + bgCamera.depthOffset + " | this.scene.maxX: " + this.scene.maxX);
     }
 

--- a/Assembly-CSharp/Global/Honolulu/HonoluluFieldMain.cs
+++ b/Assembly-CSharp/Global/Honolulu/HonoluluFieldMain.cs
@@ -156,8 +156,7 @@ public class HonoluluFieldMain : HonoBehavior
         Int32 camNumber = PersistenSingleton<EventEngine>.Instance?.fieldmap?.camIdx ?? -1;
         String camNumberStr = "-" + camNumber;
         if (camNumber == -1) { camNumberStr = ""; };
-        String camIdxIfCam = (PersistenSingleton<EventEngine>.Instance?.fieldmap?.scene?.cameraList.Count > 1 && PersistenSingleton<EventEngine>.Instance?.fieldmap?.camIdx != -1) ? "-" + PersistenSingleton<EventEngine>.Instance.fieldmap.camIdx : "";
-        PlayerWindow.Instance.SetTitle($"Map: {FF9StateSystem.Common.FF9.fldMapNo}{camIdxIfCam} ({FF9StateSystem.Common.FF9.mapNameStr}) | Index/Counter: {PersistenSingleton<EventEngine>.Instance.eBin.getVarManually(EBin.MAP_INDEX_SVR)}/{PersistenSingleton<EventEngine>.Instance.eBin.getVarManually(EBin.SC_COUNTER_SVR)} | Loc: {FF9StateSystem.Common.FF9.fldLocNo}");
+        PlayerWindow.UpdateTitle();
         FPSManager.DelayMainLoop(Time.realtimeSinceStartup - loadStartTime);
 
         // We use a coroutine here otherwise the game crashes frequently during the autosave for some reason

--- a/Assembly-CSharp/Global/MBG.cs
+++ b/Assembly-CSharp/Global/MBG.cs
@@ -305,7 +305,7 @@ public class MBG : HonoBehavior
         SceneDirector.ToggleFadeAll(true);
         FPSManager.SetTargetFPS(this.tempTargetFrameRate);
         //PlayerWindow.Instance.SetTitle(String.Empty);
-        PlayerWindow.Instance.SetTitle($"Map: {FF9StateSystem.Common.FF9.fldMapNo} ({FF9StateSystem.Common.FF9.mapNameStr}) | Index/Counter: {PersistenSingleton<EventEngine>.Instance.eBin.getVarManually(EBin.MAP_INDEX_SVR)}/{PersistenSingleton<EventEngine>.Instance.eBin.getVarManually(EBin.SC_COUNTER_SVR)} | Loc: {FF9StateSystem.Common.FF9.fldLocNo}");
+        PlayerWindow.UpdateTitle();
 
         vib.VIB_actuatorReset(0);
         this.movieMaterial.Transparency = 0f;

--- a/Assembly-CSharp/Global/battle/battle.cs
+++ b/Assembly-CSharp/Global/battle/battle.cs
@@ -77,6 +77,7 @@ public static class battle
         battle.isSpecialTutorialWindow = false;
 
         AudioEffectManager.ApplyBattleEffects(FF9StateSystem.Battle.battleMapIndex, battlebg.nf_BbgNumber);
+        PlayerWindow.UpdateTitle(true);
     }
 
     public static UInt32 BattleMain()

--- a/Assembly-CSharp/Global/ff9/ff9.cs
+++ b/Assembly-CSharp/Global/ff9/ff9.cs
@@ -3734,11 +3734,7 @@ public static class ff9
     {
         if ((ff9.w_framePhase == 0 || ff9.w_framePhase == 2) && (ff9.w_framePhase == 0 || ff9.w_framePhase == 2))
             ff9.w_frameResult = ff9.ServiceEvents();
-        String wldLocName = ff9.w_worldLocationName();
-        if (String.IsNullOrEmpty(wldLocName))
-            PlayerWindow.Instance.SetTitle($"World Map: {FF9StateSystem.Common.FF9.wldMapNo}");
-        else
-            PlayerWindow.Instance.SetTitle($"World Map: {FF9StateSystem.Common.FF9.wldMapNo}, {wldLocName}");
+        PlayerWindow.UpdateTitle();
     }
 
     public static String w_worldLocationName()

--- a/Assembly-CSharp/Memoria/Application/PlayerWindow.cs
+++ b/Assembly-CSharp/Memoria/Application/PlayerWindow.cs
@@ -1,4 +1,5 @@
-﻿using Memoria.Prime;
+﻿using Assets.Scripts.Common;
+using Memoria.Prime;
 using Memoria.Prime.WinAPI;
 using System;
 using System.ComponentModel;
@@ -11,6 +12,7 @@ namespace Memoria
     {
         private static readonly Object _lock = new Object();
         private static volatile PlayerWindow _instance;
+        private static string _currentwindowtitle;
 
         public static PlayerWindow Instance
         {
@@ -50,6 +52,36 @@ namespace Memoria
         {
             if (_windowHandle != IntPtr.Zero)
                 User32.SetWindowText(_windowHandle, OriginalTitle + " - " + message);
+        }
+
+        public static void UpdateTitle(Boolean InBattle = false) // Maybe something to handle FMV too ?
+        {
+            string TextTile = "";
+            if (InBattle)
+            {
+                TextTile = _currentwindowtitle;
+                TextTile += $" | Battle/Group: {FF9StateSystem.Common.FF9.btlMapNo}/{FF9StateSystem.Battle?.FF9Battle?.btl_scene?.PatNum}";
+            }
+            else
+            {
+                if (SceneDirector.IsFieldScene())
+                {
+                    String camIdxIfCam = (PersistenSingleton<EventEngine>.Instance?.fieldmap?.scene?.cameraList.Count > 1 && PersistenSingleton<EventEngine>.Instance?.fieldmap?.camIdx != -1) ? "-" + PersistenSingleton<EventEngine>.Instance.fieldmap.camIdx : "";
+                    TextTile = $"Map: {FF9StateSystem.Common.FF9.fldMapNo}{camIdxIfCam} ({FF9StateSystem.Common.FF9.mapNameStr}) | Index/Counter: {PersistenSingleton<EventEngine>.Instance.eBin.getVarManually(EBin.MAP_INDEX_SVR)}/{PersistenSingleton<EventEngine>.Instance.eBin.getVarManually(EBin.SC_COUNTER_SVR)} | Loc: {FF9StateSystem.Common.FF9.fldLocNo}";
+                }
+                else if (SceneDirector.IsWorldScene())
+                {
+                    String wldLocName = ff9.w_worldLocationName();
+                    if (String.IsNullOrEmpty(wldLocName))
+                        TextTile = $"World Map: {FF9StateSystem.Common.FF9.wldMapNo}";
+                    else
+                        TextTile = $"World Map: {FF9StateSystem.Common.FF9.wldMapNo}, {wldLocName}";
+                }
+                _currentwindowtitle = TextTile;
+            }
+
+
+            Instance.SetTitle(TextTile);
         }
     }
 }


### PR DESCRIPTION
Just a tiny PR to regroup all the `SetTitle` to `UpdateTitle`

I add a little argument to add text when entering a battle or not (to not lose the previous field), showing now the `BattleId` and `BattleGroupId`.

Also, it's refresh correctly the `ScenarioCounter` in `FieldMap.cs‎` (when this value changes during a scene, like when Garnet/Steiner/Marcus arrive to Treno at Disc 2).