### PR TITLE
Launcher: Allow to sort by Updated date in the Mod Catalog view

### DIFF
--- a/Memoria.Launcher/MainWindow.xaml
+++ b/Memoria.Launcher/MainWindow.xaml
@@ -501,7 +501,8 @@
                                                     PreviewMouseMove="ListView_PreviewMouseMove"
                                                     MouseMove="ListView_MouseMove"
                                                     PreviewMouseLeftButtonUp="ListView_PreviewMouseLeftButtonUp"
-                                                    MouseLeave="ListView_MouseLeave">
+                                                    MouseLeave="ListView_MouseLeave"
+                                                    SizeChanged="LstCatalogMods_SizeChanged">
                                                     <ListView.ItemContainerStyle>
                                                         <Style TargetType="ListViewItem" BasedOn="{StaticResource {x:Type ListViewItem}}">
                                                             <EventSetter Event="MouseDoubleClick" Handler="OnCatalogListDoubleClick"/>

--- a/Memoria.Launcher/MainWindow.xaml
+++ b/Memoria.Launcher/MainWindow.xaml
@@ -551,6 +551,16 @@
                                                                     </Style>
                                                                 </GridViewColumn.HeaderContainerStyle>
                                                             </GridViewColumn>
+                                                            <GridViewColumn
+                                                                x:Name="colCatalogReleaseDate"
+                                                                DisplayMemberBinding="{Binding ReleaseDate}"
+                                                                Header="Release Date">
+                                                                <GridViewColumn.HeaderContainerStyle>
+                                                                    <Style TargetType="{x:Type GridViewColumnHeader}" BasedOn="{StaticResource {x:Type GridViewColumnHeader}}">
+                                                                        <Setter Property="HorizontalContentAlignment" Value="Left" />
+                                                                    </Style>
+                                                                </GridViewColumn.HeaderContainerStyle>
+                                                            </GridViewColumn>
                                                         </GridView>
                                                     </ListView.View>
                                                 </ListView>

--- a/Memoria.Launcher/MainWindow_ModManager.cs
+++ b/Memoria.Launcher/MainWindow_ModManager.cs
@@ -730,6 +730,8 @@ namespace Memoria.Launcher
                 accessors = typeof(Mod).GetProperty("Author")?.GetAccessors();
             else if (sender == colCatalogCategory.Header)
                 accessors = typeof(Mod).GetProperty("Category")?.GetAccessors();
+            else if (sender == colCatalogReleaseDate.Header)
+                accessors = typeof(Mod).GetProperty("ReleaseDate")?.GetAccessors();
             else if (sender == colCatalogInstalled.Header)
                 accessors = typeof(Mod).GetProperty("Installed")?.GetAccessors();
             if (accessors != null)
@@ -1114,6 +1116,8 @@ namespace Memoria.Launcher
                 using (StreamReader reader = new StreamReader(input))
                     Mod.LoadModDescriptions(reader, ModListCatalog);
                 UpdateCatalogInstallationState();
+                SortCatalog(typeof(Mod).GetProperty("ReleaseDate")?.GetGetMethod(), false);
+                ascendingSortedColumn = null;
             }
             catch (Exception err)
             {
@@ -1784,6 +1788,11 @@ namespace Memoria.Launcher
             header.SetResourceReference(ContentProperty, "ModEditor.Category");
             header.Click += OnClickCatalogHeader;
             colCatalogCategory.Header = header;
+
+            header = new GridViewColumnHeader();
+            header.SetResourceReference(ContentProperty, "ModEditor.Release");
+            header.Click += OnClickCatalogHeader;
+            colCatalogReleaseDate.Header = header;
 
             header = new GridViewColumnHeader() { Content = "" };
             header.Click += OnClickCatalogHeader;

--- a/Memoria.Launcher/MainWindow_ModManager.cs
+++ b/Memoria.Launcher/MainWindow_ModManager.cs
@@ -1164,7 +1164,14 @@ namespace Memoria.Launcher
                 using (StreamReader reader = new StreamReader(input))
                     Mod.LoadModDescriptions(reader, ModListCatalog);
                 UpdateCatalogInstallationState();
-                SortCatalog(typeof(Mod).GetProperty("ReleaseDate")?.GetGetMethod(), false);
+                ModListCatalog = new ObservableCollection<Mod>(ModListCatalog
+                    .OrderBy(mod => mod.Category == null)
+                    .ThenBy(mod => mod.Category)
+                    .ThenBy(mod => mod.Name == null)
+                    .ThenBy(mod => mod.Name)
+                    .ThenByDescending(mod => mod.ReleaseDate == null)
+                    .ThenByDescending(mod => mod.ReleaseDate));
+                lstCatalogMods.ItemsSource = ModListCatalog;
                 ascendingSortedColumn = null;
                 AutoSizeCatalogColumns();
             }

--- a/Memoria.Launcher/MainWindow_ModManager.cs
+++ b/Memoria.Launcher/MainWindow_ModManager.cs
@@ -606,6 +606,53 @@ namespace Memoria.Launcher
 
         private GridViewColumn priorityColumn = null;
 
+        private void LstCatalogMods_SizeChanged(Object sender, SizeChangedEventArgs e)
+        {
+            AutoSizeCatalogColumns();
+        }
+
+        private void AutoSizeCatalogColumns()
+        {
+            if (!(lstCatalogMods.View is GridView))
+                return;
+
+            Double viewportWidth = lstCatalogMods.ActualWidth - SystemParameters.VerticalScrollBarWidth - 18;
+            if (viewportWidth <= 0)
+                return;
+
+            Double installedWidth = 34;
+            Double priorityWidth = priorityColumn != null ? priorityColumn.Width : 0;
+            Double availableWidth = viewportWidth - installedWidth - priorityWidth;
+            if (availableWidth <= 0)
+                return;
+
+            Double minName = 140;
+            Double minCategory = 110;
+            Double minAuthor = 130;
+            Double minReleaseDate = 120;
+            Double minTotal = minName + minCategory + minAuthor + minReleaseDate;
+
+            if (availableWidth <= minTotal)
+            {
+                Double scale = availableWidth / minTotal;
+                colCatalogName.Width = minName * scale;
+                colCatalogCategory.Width = minCategory * scale;
+                colCatalogAuthor.Width = minAuthor * scale;
+                colCatalogReleaseDate.Width = minReleaseDate * scale;
+            }
+            else
+            {
+                Double extra = availableWidth - minTotal;
+                Double totalWeight = 12;
+                colCatalogName.Width = minName + extra * 4 / totalWeight;
+                colCatalogCategory.Width = minCategory + extra * 2.5 / totalWeight;
+                colCatalogAuthor.Width = minAuthor + extra * 3 / totalWeight;
+                colCatalogReleaseDate.Width = minReleaseDate + extra * 2.5 / totalWeight;
+            }
+
+            colCatalogInstalled.Width = installedWidth;
+        }
+
         private void OnClickPriority(Object sender, RoutedEventArgs e)
         {
             if (priorityColumn != null) return;
@@ -636,6 +683,7 @@ namespace Memoria.Launcher
                 }
             }
             UpdateCatalogPriorities();
+            AutoSizeCatalogColumns();
         }
 
         private void UpdateCatalogPriorities()
@@ -1118,6 +1166,7 @@ namespace Memoria.Launcher
                 UpdateCatalogInstallationState();
                 SortCatalog(typeof(Mod).GetProperty("ReleaseDate")?.GetGetMethod(), false);
                 ascendingSortedColumn = null;
+                AutoSizeCatalogColumns();
             }
             catch (Exception err)
             {


### PR DESCRIPTION
This PR is essentially a community request to add an Updated column to the mod view, allowing users to sort mods by date. By default the view will start always with Updated DESC. The Updated information is the same used in the mod detail ( `RelaseDate` XML node ) and will show in ISO format of `YYYY-MM-DD` for every language.

The final result will look like this once this PR is merged:
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/a7f359e9-2866-401b-acbb-a64dfaeea1ae" />

Finally in order to fit all the columns automatically in the view I added some mods to automatically calculate their size and make them fit. If you don't like this behavior I've made it on purpose as a separate commit so I can remove it anytime.

Any question feel free to ask.