### PR TITLE
Launcher: Allow to filter in the mods tab

### DIFF
--- a/Memoria.Launcher/Languages/de.xml
+++ b/Memoria.Launcher/Languages/de.xml
@@ -46,7 +46,7 @@ DeletePresetCaption = "Vorgabe löschen?"
 OK = "OK"
 Cancel = "Abbrechen"
 Auto = "Auto"
-SearchModsPlaceholder = "NACH NAME SUCHEN"
+SearchModsPlaceholder = "SUCHE NACH NAMEN"
 />
 
 <Settings

--- a/Memoria.Launcher/Languages/de.xml
+++ b/Memoria.Launcher/Languages/de.xml
@@ -46,6 +46,7 @@ DeletePresetCaption = "Vorgabe löschen?"
 OK = "OK"
 Cancel = "Abbrechen"
 Auto = "Auto"
+SearchModsPlaceholder = "NACH NAME SUCHEN"
 />
 
 <Settings

--- a/Memoria.Launcher/Languages/en.xml
+++ b/Memoria.Launcher/Languages/en.xml
@@ -46,6 +46,7 @@ DeletePresetCaption = "Delete preset?"
 OK = "OK"
 Cancel = "Cancel"
 Auto = "Auto"
+SearchModsPlaceholder = "SEARCH BY NAME"
 />
 
 <Settings

--- a/Memoria.Launcher/Languages/es.xml
+++ b/Memoria.Launcher/Languages/es.xml
@@ -46,6 +46,7 @@ DeletePresetCaption = "¿Eliminar ajuste preestablecido?"
 OK = "OK"
 Cancel = "Cancelar"
 Auto = "Auto"
+SearchModsPlaceholder = "BUSCAR POR NOMBRE"
 />
 
 <Settings

--- a/Memoria.Launcher/Languages/fr.xml
+++ b/Memoria.Launcher/Languages/fr.xml
@@ -46,6 +46,7 @@ DeletePresetCaption = "Supprimer le préréglage ?"
 OK = "OK"
 Cancel = "Annuler"
 Auto = "Auto"
+SearchModsPlaceholder = "RECHERCHER PAR NOM"
 />
 
 <Settings

--- a/Memoria.Launcher/Languages/it.xml
+++ b/Memoria.Launcher/Languages/it.xml
@@ -46,6 +46,7 @@ DeletePresetCaption = "Eliminare la preimpostazione?"
 OK = "OK"
 Cancel = "Annulla"
 Auto = "Auto"
+SearchModsPlaceholder = "CERCA PER NOME"
 />
 
 <Settings

--- a/Memoria.Launcher/Languages/jp.xml
+++ b/Memoria.Launcher/Languages/jp.xml
@@ -46,6 +46,7 @@ DeletePresetCaption = "プリセットを削除しますか?"
 OK = "OK"
 Cancel = "キャンセル"
 Auto = "自動"
+SearchModsPlaceholder = "名前で検索"
 />
 
 <Settings

--- a/Memoria.Launcher/Languages/pt-BR.xml
+++ b/Memoria.Launcher/Languages/pt-BR.xml
@@ -46,6 +46,7 @@ DeletePresetCaption = "Apagar pré-definição?"
 OK = "OK"
 Cancel = "Cancelar"
 Auto = "Auto"
+SearchModsPlaceholder = "PROCURAR POR NOME"
 />
 
 <Settings

--- a/Memoria.Launcher/Languages/ru.xml
+++ b/Memoria.Launcher/Languages/ru.xml
@@ -46,6 +46,7 @@ DeletePresetCaption = "Удалить предустановку?"
 OK = "OK"
 Cancel = "Отмена"
 Auto = "Авто"
+SearchModsPlaceholder = "ПОИСК ПО НАЗВАНИЮ"
 />
 
 <Settings

--- a/Memoria.Launcher/Languages/tr.xml
+++ b/Memoria.Launcher/Languages/tr.xml
@@ -46,7 +46,7 @@ DeletePresetCaption = "Ön ayar silinsin mi?"
 OK = "TAMAM"
 Cancel = "İptal"
 Auto = "Otomatik"
-SearchModsPlaceholder = "ADA GÖRE ARA"
+SearchModsPlaceholder = "ISIM GÖRE ARAMA"
 />
 
 <Settings

--- a/Memoria.Launcher/Languages/tr.xml
+++ b/Memoria.Launcher/Languages/tr.xml
@@ -46,7 +46,7 @@ DeletePresetCaption = "Ön ayar silinsin mi?"
 OK = "TAMAM"
 Cancel = "İptal"
 Auto = "Otomatik"
-SearchModsPlaceholder = "ISIM GÖRE ARAMA"
+SearchModsPlaceholder = "İSİM GÖRE ARAMA"
 />
 
 <Settings

--- a/Memoria.Launcher/Languages/tr.xml
+++ b/Memoria.Launcher/Languages/tr.xml
@@ -46,6 +46,7 @@ DeletePresetCaption = "Ön ayar silinsin mi?"
 OK = "TAMAM"
 Cancel = "İptal"
 Auto = "Otomatik"
+SearchModsPlaceholder = "ADA GÖRE ARA"
 />
 
 <Settings

--- a/Memoria.Launcher/Languages/uk.xml
+++ b/Memoria.Launcher/Languages/uk.xml
@@ -46,6 +46,7 @@ DeletePresetCaption = "Видалити стиль?"
 OK = "ОК"
 Cancel = "Скасувати"
 Auto = "Авто"
+SearchModsPlaceholder = "ПОШУК ЗА НАЗВОЮ"
 />
 
 <Settings

--- a/Memoria.Launcher/Languages/zh-CN.xml
+++ b/Memoria.Launcher/Languages/zh-CN.xml
@@ -46,6 +46,7 @@ DeletePresetCaption = "删除预设？"
 OK = "确定"
 Cancel = "取消"
 Auto = "自动"
+SearchModsPlaceholder = "按名称搜索"
 />
 
 <Settings

--- a/Memoria.Launcher/Languages/zh-TW.xml
+++ b/Memoria.Launcher/Languages/zh-TW.xml
@@ -46,6 +46,7 @@ DeletePresetCaption = "刪除預設？"
 OK = "確定"
 Cancel = "取消"
 Auto = "自動"
+SearchModsPlaceholder = "按名稱搜尋"
 />
 
 <Settings

--- a/Memoria.Launcher/MainWindow.cs
+++ b/Memoria.Launcher/MainWindow.cs
@@ -84,8 +84,8 @@ namespace Memoria.Launcher
             LoadModSettings();
             CheckForValidModFolder();
             UpdateModListInstalled();
-            lstCatalogMods.ItemsSource = ModListCatalog;
-            lstMods.ItemsSource = ModListInstalled;
+            InitializeModsListView();
+            InitializeCatalogListView();
             lstDownloads.ItemsSource = DownloadList;
             UpdateCatalogInstallationState();
 

--- a/Memoria.Launcher/MainWindow.xaml
+++ b/Memoria.Launcher/MainWindow.xaml
@@ -279,8 +279,8 @@
                                         <Border Background="{StaticResource LightGreyUI}" Margin="2,2,8,0" Padding="6" CornerRadius="6">
                                             <Grid>
                                                 <Grid.RowDefinitions>
-                                                    <RowDefinition Height="*" />
                                                     <RowDefinition Height="auto" />
+                                                    <RowDefinition Height="*" />
                                                 </Grid.RowDefinitions>
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="auto" />
@@ -288,9 +288,11 @@
                                                 </Grid.ColumnDefinitions>
                                                 <StackPanel
                                                     x:Name="stackButtons"
+                                                    Grid.Row="0"
+                                                    Grid.RowSpan="2"
                                                     Grid.Column="0"
                                                     HorizontalAlignment="Left"
-                                                    VerticalAlignment="Stretch">
+                                                    VerticalAlignment="Top">
                                                     <Button x:Name="btnReorganize"
                                                         Style="{StaticResource ToolButtonStyle}"
                                                         Margin="0,0,0,3"
@@ -329,10 +331,24 @@
                                                         <Image Source="/images/btnUninstallimg.png"/>
                                                     </Button>
                                                 </StackPanel>
+                                                <TextBox
+                                                    x:Name="txtSearchMods"
+                                                    Grid.Row="0"
+                                                    Grid.Column="1"
+                                                    Margin="6,0,0,6"
+                                                    TextChanged="TxtSearchMods_TextChanged"
+                                                    launcher:TextBoxHelper.Placeholder="Launcher.SearchModsPlaceholder"
+                                                    Padding="8,6,8,6"
+                                                    FontSize="14"
+                                                    Foreground="#ccc"
+                                                    Background="#222"
+                                                    BorderBrush="#444"
+                                                    BorderThickness="1"
+                                                    CaretBrush="#ccc" />
                                                 <ListView x:Name="lstMods"
                                                     Margin="6,0,0,0"
+                                                    Grid.Row="1"
                                                     Grid.Column="1"
-                                                    ItemsSource="{Binding ModListInstalled}"
                                                     ScrollViewer.CanContentScroll="False"
                                                     ScrollViewer.HorizontalScrollBarVisibility="Auto"
                                                     PreviewMouseLeftButtonDown="ListView_PreviewMouseLeftButtonDown"
@@ -460,6 +476,7 @@
                                         <Border Background="{StaticResource LightGreyUI}" Margin="2,2,8,0" Padding="6" CornerRadius="6">
                                             <Grid>
                                                 <Grid.RowDefinitions>
+                                                    <RowDefinition Height="auto" />
                                                     <RowDefinition Height="*" />
                                                     <RowDefinition Height="auto" />
                                                 </Grid.RowDefinitions>
@@ -468,6 +485,8 @@
                                                     <ColumnDefinition Width="*" />
                                                 </Grid.ColumnDefinitions>
                                                 <StackPanel
+                                                    Grid.Row="0"
+                                                    Grid.RowSpan="3"
                                                     Grid.Column="0"
                                                     HorizontalAlignment="Left"
                                                     VerticalAlignment="Top">
@@ -491,10 +510,24 @@
                                                         Opacity="0" >
                                                     </Button>
                                                 </StackPanel>
+                                                <TextBox
+                                                    x:Name="txtSearchCatalog"
+                                                    Grid.Row="0"
+                                                    Grid.Column="1"
+                                                    Margin="6,0,0,6"
+                                                    TextChanged="TxtSearchCatalog_TextChanged"
+                                                    launcher:TextBoxHelper.Placeholder="Launcher.SearchModsPlaceholder"
+                                                    Padding="8,6,8,6"
+                                                    FontSize="14"
+                                                    Foreground="#ccc"
+                                                    Background="#222"
+                                                    BorderBrush="#444"
+                                                    BorderThickness="1"
+                                                    CaretBrush="#ccc" />
                                                 <ListView x:Name="lstCatalogMods"
                                                     Margin="6,0,0,0"
+                                                    Grid.Row="1"
                                                     Grid.Column="1"
-                                                    ItemsSource="{Binding ModListCatalog}"
                                                     ScrollViewer.CanContentScroll="False"
                                                     ScrollViewer.HorizontalScrollBarVisibility="Auto"
                                                     PreviewMouseLeftButtonDown="ListView_PreviewMouseLeftButtonDown"
@@ -567,11 +600,11 @@
                                                 </ListView>
                                                 <StackPanel x:Name="btnCancelStackpanel"
                                                     Height="0"
-                                                    Grid.Row="1"
+                                                    Grid.Row="2"
                                                     Grid.Column="0"
                                                     Margin="0,0,0,0"
                                                     HorizontalAlignment="Right"
-                                                    VerticalAlignment="Stretch">
+                                                    VerticalAlignment="Top">
                                                     <Button x:Name="btnCancel"
                                                         Style="{StaticResource ToolButtonStyle}"
                                                         Click="OnClickCancelAll"
@@ -585,7 +618,7 @@
                                                 </StackPanel>
                                                 <ListView x:Name="lstDownloads"
                                                     Margin="6,0,0,0"
-                                                    Grid.Row="1"
+                                                    Grid.Row="2"
                                                     Grid.Column="1"
                                                     MinHeight="0"
                                                     MaxHeight="100"

--- a/Memoria.Launcher/MainWindow_ModManager.cs
+++ b/Memoria.Launcher/MainWindow_ModManager.cs
@@ -57,6 +57,44 @@ namespace Memoria.Launcher
 
         private CancellationTokenSource ExtractionCancellationToken = new CancellationTokenSource();
 
+        private ICollectionView _modListInstalledView;
+        private string _searchText = "";
+
+        private ICollectionView _modListCatalogView;
+        private string _searchCatalogText = "";
+
+        public string SearchModsText
+        {
+            get { return _searchText; }
+            set
+            {
+                if (_searchText != value)
+                {
+                    _searchText = value;
+                    if (_modListInstalledView != null)
+                    {
+                        _modListInstalledView.Refresh();
+                    }
+                }
+            }
+        }
+
+        public string SearchCatalogText
+        {
+            get { return _searchCatalogText; }
+            set
+            {
+                if (_searchCatalogText != value)
+                {
+                    _searchCatalogText = value;
+                    if (_modListCatalogView != null)
+                    {
+                        _modListCatalogView.Refresh();
+                    }
+                }
+            }
+        }
+
 
         private void ModManagerWindow_KeyUp(Object sender, System.Windows.Input.KeyEventArgs e)
         {
@@ -72,6 +110,9 @@ namespace Memoria.Launcher
                 AnimateMargin(LogoImage, new Thickness(20, -53, 0, 0), new Thickness(20, -20, 0, 0), TimeSpan.FromMilliseconds(500));
                 AnimateHeight(LogoImage, 250, 125, TimeSpan.FromMilliseconds(500));
                 previousTabWasMod = true;
+
+                // Refresh placeholders when Mods tab is selected
+                RefreshModsPlaceholders();
             }
             else if (previousTabWasMod && !ModManagerTab.IsSelected)
             {
@@ -80,7 +121,93 @@ namespace Memoria.Launcher
                 AnimateHeight(LogoImage, 125, 250, TimeSpan.FromMilliseconds(500));
                 previousTabWasMod = false;
             }
+
+            // Also refresh placeholders when inner tabs change
+            if (tabCtrlMain != null)
+            {
+                RefreshModsPlaceholders();
+            }
         }
+
+        public void RefreshModsPlaceholders()
+        {
+            // Refresh BOTH placeholders when language changes
+            if (txtSearchMods != null)
+            {
+                TextBoxHelper.RefreshPlaceholder(txtSearchMods);
+            }
+            if (txtSearchCatalog != null)
+            {
+                TextBoxHelper.RefreshPlaceholder(txtSearchCatalog);
+            }
+        }
+
+        public void InitializeModsListView()
+        {
+            // Create a CollectionViewSource for the ModListInstalled
+            _modListInstalledView = CollectionViewSource.GetDefaultView(ModListInstalled);
+
+            // Set up the filter
+            _modListInstalledView.Filter = ModFilter;
+
+            // Bind the view to the ListView
+            lstMods.ItemsSource = _modListInstalledView;
+        }
+
+        private bool ModFilter(object obj)
+        {
+            if (string.IsNullOrEmpty(_searchText))
+                return true;
+
+            Mod mod = obj as Mod;
+            if (mod == null || mod.Name == null)
+                return true;
+
+            // Case-insensitive search in mod name
+            return mod.Name.IndexOf(_searchText, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        private void TxtSearchMods_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (sender is TextBox textBox)
+            {
+                SearchModsText = textBox.Text ?? "";
+            }
+        }
+
+        public void InitializeCatalogListView()
+        {
+            // Create a CollectionViewSource for the ModListCatalog
+            _modListCatalogView = CollectionViewSource.GetDefaultView(ModListCatalog);
+
+            // Set up the filter
+            _modListCatalogView.Filter = CatalogModFilter;
+
+            // Bind the view to the ListView
+            lstCatalogMods.ItemsSource = _modListCatalogView;
+        }
+
+        private bool CatalogModFilter(object obj)
+        {
+            if (string.IsNullOrEmpty(_searchCatalogText))
+                return true;
+
+            Mod mod = obj as Mod;
+            if (mod == null || mod.Name == null)
+                return true;
+
+            // Case-insensitive search in mod name
+            return mod.Name.IndexOf(_searchCatalogText, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        private void TxtSearchCatalog_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (sender is TextBox textBox)
+            {
+                SearchCatalogText = textBox.Text ?? "";
+            }
+        }
+
         private void AnimateHeight(FrameworkElement element, double from, double to, TimeSpan duration)
         {
             DoubleAnimation heightAnimation = new DoubleAnimation
@@ -1171,7 +1298,7 @@ namespace Memoria.Launcher
                     .ThenBy(mod => mod.Name)
                     .ThenByDescending(mod => mod.ReleaseDate == null)
                     .ThenByDescending(mod => mod.ReleaseDate));
-                lstCatalogMods.ItemsSource = ModListCatalog;
+                InitializeCatalogListView();
                 ascendingSortedColumn = null;
                 AutoSizeCatalogColumns();
             }
@@ -1660,7 +1787,7 @@ namespace Memoria.Launcher
                 return ascending ? ac.CompareTo(bc) : -ac.CompareTo(bc);
             });
             ModListCatalog = new ObservableCollection<Mod>(catalogList);
-            lstCatalogMods.ItemsSource = ModListCatalog;
+            InitializeCatalogListView();
         }
 
         public void LoadModSettings()

--- a/Memoria.Launcher/Memoria.Launcher.csproj
+++ b/Memoria.Launcher/Memoria.Launcher.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Launcher\Window_ChangeLog.xaml.cs">
       <DependentUpon>Window_ChangeLog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="TextBoxHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="App.xaml">

--- a/Memoria.Launcher/TextBoxHelper.cs
+++ b/Memoria.Launcher/TextBoxHelper.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Media;
+
+namespace Memoria.Launcher
+{
+    public static class TextBoxHelper
+    {
+        public static string GetPlaceholder(DependencyObject obj) =>
+            (string)obj.GetValue(PlaceholderProperty);
+
+        public static void SetPlaceholder(DependencyObject obj, string value) =>
+            obj.SetValue(PlaceholderProperty, value);
+
+        public static readonly DependencyProperty PlaceholderProperty =
+            DependencyProperty.RegisterAttached(
+                "Placeholder",
+                typeof(string),
+                typeof(TextBoxHelper),
+                new FrameworkPropertyMetadata(
+                    defaultValue: null,
+                    propertyChangedCallback: OnPlaceholderChanged)
+                );
+
+        private static void OnPlaceholderChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is TextBox textBoxControl)
+            {
+                if (!textBoxControl.IsLoaded)
+                {
+                    // Ensure that the events are not added multiple times
+                    textBoxControl.Loaded -= TextBoxControl_Loaded;
+                    textBoxControl.Loaded += TextBoxControl_Loaded;
+                }
+
+                textBoxControl.TextChanged -= TextBoxControl_TextChanged;
+                textBoxControl.TextChanged += TextBoxControl_TextChanged;
+
+                // If the adorner exists, invalidate it to draw the current text
+                if (GetOrCreateAdorner(textBoxControl, out PlaceholderAdorner adorner))
+                    adorner.InvalidateVisual();
+            }
+        }
+
+        private static void TextBoxControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (sender is TextBox textBoxControl)
+            {
+                textBoxControl.Loaded -= TextBoxControl_Loaded;
+                GetOrCreateAdorner(textBoxControl, out _);
+            }
+        }
+
+        private static void TextBoxControl_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (sender is TextBox textBoxControl
+                && GetOrCreateAdorner(textBoxControl, out PlaceholderAdorner adorner))
+            {
+                // Control has text. Hide the adorner.
+                if (textBoxControl.Text.Length > 0)
+                    adorner.Visibility = Visibility.Hidden;
+
+                // Control has no text. Show the adorner.
+                else
+                    adorner.Visibility = Visibility.Visible;
+            }
+        }
+
+        private static bool GetOrCreateAdorner(TextBox textBoxControl, out PlaceholderAdorner adorner)
+        {
+            // Get the adorner layer
+            AdornerLayer layer = AdornerLayer.GetAdornerLayer(textBoxControl);
+
+            // If null, it doesn't exist or the control's template isn't loaded
+            if (layer == null)
+            {
+                adorner = null;
+                return false;
+            }
+
+            // Layer exists, try to find the adorner
+            adorner = layer.GetAdorners(textBoxControl)?.OfType<PlaceholderAdorner>().FirstOrDefault();
+
+            // Adorner never added to control, so add it
+            if (adorner == null)
+            {
+                adorner = new PlaceholderAdorner(textBoxControl);
+                layer.Add(adorner);
+            }
+
+            return true;
+        }
+
+        public static void RefreshPlaceholder(TextBox textBoxControl)
+        {
+            if (textBoxControl != null && GetOrCreateAdorner(textBoxControl, out PlaceholderAdorner adorner))
+            {
+                // Update visibility based on whether textbox has content
+                if (textBoxControl.Text.Length > 0)
+                    adorner.Visibility = Visibility.Hidden;
+                else
+                    adorner.Visibility = Visibility.Visible;
+
+                adorner.InvalidateVisual();
+            }
+        }
+
+        private static string ResolveResourceValue(string key)
+        {
+            try
+            {
+                // Try to get from Lang.Res first (which is Application.Current.Resources)
+                if (Lang.Res.Contains(key))
+                {
+                    var value = Lang.Res[key];
+                    if (value != null)
+                        return value.ToString();
+                }
+
+                // Fallback: Try Application.Current.Resources directly
+                if (Application.Current?.Resources != null && Application.Current.Resources.Contains(key))
+                {
+                    var value = Application.Current.Resources[key];
+                    if (value != null)
+                        return value.ToString();
+                }
+            }
+            catch { }
+
+            // If not found, return empty string so the original string displays as fallback
+            return string.Empty;
+        }
+
+        public class PlaceholderAdorner : Adorner
+        {
+            public PlaceholderAdorner(TextBox textBox) : base(textBox) { }
+
+            protected override void OnRender(DrawingContext drawingContext)
+            {
+                TextBox textBoxControl = (TextBox)AdornedElement;
+
+                string placeholderValue = TextBoxHelper.GetPlaceholder(textBoxControl);
+
+                if (string.IsNullOrEmpty(placeholderValue))
+                    return;
+
+                // Always try to resolve from language resources first
+                string resolvedValue = ResolveResourceValue(placeholderValue);
+                if (!string.IsNullOrEmpty(resolvedValue))
+                {
+                    // Use resolved value from resources
+                    placeholderValue = resolvedValue;
+                }
+                // else keep the original placeholderValue (it might be a literal string or unresolved key)
+
+                if (string.IsNullOrEmpty(placeholderValue))
+                    return;
+
+                // Create the formatted text object
+                FormattedText text = new FormattedText(
+                                            placeholderValue,
+                                            CultureInfo.CurrentCulture,
+                                            textBoxControl.FlowDirection,
+                                            new Typeface(textBoxControl.FontFamily,
+                                                         textBoxControl.FontStyle,
+                                                         textBoxControl.FontWeight,
+                                                         textBoxControl.FontStretch),
+                                            textBoxControl.FontSize,
+                                            SystemColors.InactiveCaptionBrush,
+                                            VisualTreeHelper.GetDpi(textBoxControl).PixelsPerDip);
+
+                text.MaxTextWidth = Math.Max(textBoxControl.ActualWidth - textBoxControl.Padding.Left - textBoxControl.Padding.Right, 10);
+                text.MaxTextHeight = Math.Max(textBoxControl.ActualHeight, 10);
+
+                // Render based on padding of the control, to try and match where the textbox places text
+                Point renderingOffset = new Point(textBoxControl.Padding.Left, textBoxControl.Padding.Top);
+
+                // Template contains the content part; adjust sizes to try and align the text
+                if (textBoxControl.Template.FindName("PART_ContentHost", textBoxControl) is FrameworkElement part)
+                {
+                    Point partPosition = part.TransformToAncestor(textBoxControl).Transform(new Point(0, 0));
+                    renderingOffset.X += partPosition.X;
+                    renderingOffset.Y += partPosition.Y;
+
+                    text.MaxTextWidth = Math.Max(part.ActualWidth - renderingOffset.X, 10);
+                    text.MaxTextHeight = Math.Max(part.ActualHeight, 10);
+                }
+
+                // Draw the text
+                drawingContext.DrawText(text, renderingOffset);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a search box in both Mod Catalog and My Mods tabs, allowing users to filter on top of the list, based on the order criteria they picked ( either default or the one they clicked in the list ). The search box supports a placeholder named `Adjorner` and this is given via the `TextBoxHelper` class which is losely based on [the official guide](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/how-to-add-a-watermark-to-a-textbox). I opted for making it generic enough for every future TextBox control that might need it.

The placeholder text will support all languages, and again I want to be honest and transparent I used AI to translate strings, as I don't own all the knowledge of all languages here, but everyone is welcome to PR on top if something was translated wrong, everything is best effort.

Visually after this patch, the Launcher will look like this:
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/840eeb95-c7d7-43ab-9412-c8e25e5769a4" />
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/303a905c-f5e7-431f-b624-5f44d9a34f40" />
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/fcb509b2-598e-46dc-832c-ee4826bc331b" />
<img width="1000" height="700" alt="immagine" src="https://github.com/user-attachments/assets/fb7e180f-ba46-451b-a9d4-fd0349bc1974" />

Credits to @faospark for the design idea.

Any question feel free to ask :)