### PR TITLE
Update 2K/4K Video Pack version and Auto-Organizer priority (Memoria Catalog)

### DIFF
--- a/MemoriaCatalog.xml
+++ b/MemoriaCatalog.xml
@@ -46,27 +46,27 @@ Snouz - syncronization</Description>
 
 <Mod>
 	<Name>2K Video Pack</Name>
-	<Version>1.0.3</Version>
-	<Priority>-32</Priority>
+	<Version>1.0.4</Version>
+	<Priority>-20</Priority>
 	<InstallationPath>2K Video Pack - Ultimate Remaster</InstallationPath>
 	<Author>Ultimate Remaster</Author>
 	<Category>Visual</Category>
 	<ReleaseDateOriginal>2025-08-27</ReleaseDateOriginal>
-	<ReleaseDate>2025-09-08</ReleaseDate>
+	<ReleaseDate>2026-06-23</ReleaseDate>
 	<Description>This remaster transforms every FMV into true 2k high definition (1920x1440p 4:3) — restoring details lost over time to heavy compression, pixelation, noise, and blur, all while faithfully preserving the original artistic style with professional care, patience, hard work and a lot of time leveraging AI and handmade adjustments, to bring back the timeless beauty of a game that defined a generation, and that, to this day, lives in the hearts of thousands of people.
     
     - This lighter version is highly recommended for PCs/Laptops with 2K or lower screens.
 
-    EACH SCENE HAS BEEN METICULOUSLY RESTORED TO:
+    EACH SCENE HAS BEEN CAREFULLY RESTORED TO:
 
     1) Remove compression artifacts and visual noise, resulting in a cleaner, more polished image.
     2) Sharpen and restore fine details in textures, architecture, and character models.
     3) Improve overall clarity and color balance, giving each scene richer tones without oversaturation.
     4) Optimize motion playback through encoding refinements, adjusting frame timing and keyframe placement to enhance smoothness.
 
-    I HOPE YOU ALL ENJOY IT!
-
-    Check out and subscribe to my YouTube channel to find more high-definition mods and video demonstrations — link on the Website button ;)
+    For more information, visual comparisons, and other mods I’ve developed, click the Website button ;)
+	
+	I HOPE YOU ALL ENJOY IT!
 
     Best regards,
     Ultimate Remaster
@@ -81,27 +81,27 @@ Snouz - syncronization</Description>
 
 <Mod>
 	<Name>4K Video Pack</Name>
-	<Version>1.0.3</Version>
-	<Priority>-31</Priority>
+	<Version>1.0.4</Version>
+	<Priority>-21</Priority>
 	<InstallationPath>4K Video Pack - Ultimate Remaster</InstallationPath>
 	<Author>Ultimate Remaster</Author>
 	<Category>Visual</Category>
 	<ReleaseDateOriginal>2025-08-27</ReleaseDateOriginal>
-	<ReleaseDate>2025-09-08</ReleaseDate>
+	<ReleaseDate>2026-06-23</ReleaseDate>
 	<Description>This remaster transforms every FMV into true 4k high definition (2880x2160p 4:3) — restoring details lost over time to heavy compression, pixelation, noise, and blur, all while faithfully preserving the original artistic style with professional care, patience, hard work and a lot of time leveraging AI and handmade adjustments, to bring back the timeless beauty of a game that defined a generation, and that, to this day, lives in the hearts of thousands of people.
 
     - This 4K Version is recommended for mid-range and high-end PCs/Laptops with 4K or higher screens.
 
-    EACH SCENE HAS BEEN METICULOUSLY RESTORED TO:
+    EACH SCENE HAS BEEN CAREFULLY RESTORED TO:
 
     1) Remove compression artifacts and visual noise, resulting in a cleaner, more polished image.
     2) Sharpen and restore fine details in textures, architecture, and character models.
     3) Improve overall clarity and color balance, giving each scene richer tones without oversaturation.
     4) Optimize motion playback through encoding refinements, adjusting frame timing and keyframe placement to enhance smoothness.
 
-    I HOPE YOU ALL ENJOY IT!
-
-    Check out and subscribe to my YouTube channel to find more high-definition mods and video demonstrations — link on the Website button ;)
+    For more information, visual comparisons, and other mods I’ve developed, click the Website button ;)
+	
+	I HOPE YOU ALL ENJOY IT!
 
     Best regards,
     Ultimate Remaster


### PR DESCRIPTION
Hi Tirlititi and team! How are you?

This week, I updated the mods to fix FMV023, which was cutting off the first 10 seconds during in-game video playback. I have already replaced the download file on Dropbox, and I am opening this pull request to update the version and the mod description in the catalog.

I am also changing the priority values to try to adjust the mod’s order in the Auto-Organizer, because it has been placed below Moguri Mod when users use the Auto-Organizer. Ideally, it should be placed above Moguri Mod so that the game’s motion backgrounds are also displayed according to the active 2K/4K version of the mod, instead of Moguri’s motion backgrounds.
