### PR TITLE
Some fixes for SaXAudio

### DIFF
--- a/Assembly-CSharp/NCalc/Evaluant.Calculator/Expression.cs
+++ b/Assembly-CSharp/NCalc/Evaluant.Calculator/Expression.cs
@@ -1,9 +1,9 @@
 ﻿using Antlr.Runtime;
 using NCalc.Domain;
+using Memoria.Prime;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 
@@ -79,7 +79,7 @@ namespace NCalc
                 foreach (string key in keysToRemove)
                 {
                     compiledExpressions.Remove(key);
-                    Trace.TraceInformation("Cache entry released: " + key);
+                    Log.Trace("[NCalc::Expression] Cache entry released: " + key);
                 }
             }
             finally
@@ -102,7 +102,7 @@ namespace NCalc
 
                     if (compiledExpressions.ContainsKey(expression))
                     {
-                        Trace.TraceInformation("Expression retrieved from cache: " + expression);
+                        Log.Trace("[NCalc::Expression] Expression retrieved from cache: " + expression);
                         var wr = compiledExpressions[expression];
                         logicalExpression = wr.Target as LogicalExpression;
 
@@ -144,7 +144,7 @@ namespace NCalc
 
                     CleanCache();
 
-                    Trace.TraceInformation("Expression added to cache: " + expression);
+                    Log.Trace("[NCalc::Expression] Expression added to cache: " + expression);
                 }
             }
 

--- a/Memoria.Prime/Log.cs
+++ b/Memoria.Prime/Log.cs
@@ -55,6 +55,20 @@ namespace Memoria.Prime
             Instance.Write('E', 0, FormatException(ex, format, args));
         }
 
+        public static void Trace(String format, params Object[] args)
+        {
+#if DEBUG
+            Instance.Write('T', 1, format, args);
+#endif
+        }
+
+        public static void Trace(Exception ex, String format = null, params Object[] args)
+        {
+#if DEBUG
+            Instance.Write('T', 1, FormatException(ex, format, args));
+#endif
+        }
+
         private static String FormatException(Exception ex, String format, params Object[] args)
         {
             StringBuilder sb = new StringBuilder(256);

--- a/SaXAudio/AudioVoice.cpp
+++ b/SaXAudio/AudioVoice.cpp
@@ -620,6 +620,10 @@ namespace SaXAudio
         }
         Log(BankID, VoiceID, "[OnBufferEnd] Voice finished playing");
 
-        SaXAudio::Instance.RemoveVoice(VoiceID);
+        INT32 voiceID = VoiceID;
+        thread cleanupThread([voiceID]() {
+            SaXAudio::Instance.RemoveVoice(voiceID);
+            });
+        cleanupThread.detach();
     }
 }


### PR DESCRIPTION
With @julianxhokaxhiu, we find two issues with SaXAudio :

### 1) Critical issue on AudioVoice::OnBufferEnd

From the debug with VS, i get this crash :

```
>    XAudio2_9.dll!OAPIPELINE::ResampleLinearFromFl32MonoSafe(struct OAPIPELINE::SSRCParameters *)    Unknown
     XAudio2_9.dll!LEAPFX::CAudioSRC::Process(unsigned int,struct XAPO_PROCESS_BUFFER_PARAMETERS const *,unsigned int,struct XAPO_PROCESS_BUFFER_PARAMETERS *,int)    Unknown
     XAudio2_9.dll!LEAPCORE::CSWVoice::Process(unsigned int)    Unknown
     XAudio2_9.dll!LEAPCORE::CGraphManager::GraphThreadProc(unsigned __int64)    Unknown
     XAudio2_9.dll!CThreadBase::StaticGraphThreadProc(void *)    Unknown
     kernel32.dll!00007ffcd414e957()    Unknown
     ntdll.dll!00007ffcd63a7c1c()    Unknown
```

I just discovered that you can load some `.pdb` files, from specific files used by Microsoft.... like `XAudio2_9.dll` ! :)
It seems that it's not recommended to delete a voice directly using this feature, because XAudio might try to play it at the moment it's being deleted... and then, oops.
So, by moving it to a thread, the process becomes much safer.

### 2) Trace.TraceInformation is too "chatty"

This was something I had noticed in the older version of SaXAudio that I had proposed... and it seems that @julianxhokaxhiu has encountered the same issue: the "log" generated by `NCalc` are extremely frequent/heavy in `Expression.cs` via the `Trace.Information` functions.

> Mono’s System.Diagnostics.Trace is executing a configured TraceListener (or Trace/Debug infrastructure) that’s failing badly (e.g., a bad custom listener, a missing dependency, or an incompatibility in Mono’s tracing implementation).
> 
> You can customize the tracing output's target by adding TraceListener instances to or removing instances from the Listeners collection. The Listeners collection is shared by both the Debug and the Trace classes; adding a trace listener to either class adds the listener to both. By default, trace output is emitted using the DefaultTraceListener class.
> https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.trace?view=net-10.0

The idea behind TrueOdin is therefore simply to move these logs to `Memoria.Prime.Log.Trace`.
These functions will be called only if the build was built in `Debug` mode.

After completing two intensive playthroughs (starting from the beginning of the game and playing at a constant **5x speed**, using Echo-S).
=> During my first playthrough, I crashed in the Gargan Roo of Treno (Disc 2).
=> During the second one, I managed to get further... but I had to stop my test due to lack of time :(

In any case, I think these two fixes help stabilize SaXAudio (though crashes are still possible, seems rarely).
If this PR is accepted, we’ll be able to share the `Canary` or `Pre-Release` version with players for testing.