### PR TITLE
CI: Cache dependencies and allow PR jobs to make use of them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,15 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Restore dependency cache
+      id: dependency-cache
+      uses: actions/cache/restore@v6
+      with:
+        path: References
+        key: windows-dependencies-${{ hashFiles('References/Dependencies.7z') }}
+
     - name: Decrypt and extract dependencies
+      if: steps.dependency-cache.outputs.cache-hit != 'true'
       env:
         ARCHIVE_PASSWORD: ${{ secrets.DEPENDENCIES_PASSWORD }}
       shell: pwsh

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,55 @@
+name: Cache Dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 */6 * *"
+
+env:
+  GIT_REDIRECT_STDERR: 2>&1
+
+jobs:
+  cache-dependencies:
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+    - name: Set Git Config
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.filemode false
+        git config --global core.longpaths true
+    - name: Checkout
+      uses: actions/checkout@v4.1.0
+    - name: Restore dependency cache
+      id: dependency-cache
+      uses: actions/cache/restore@v6
+      with:
+        path: References
+        key: windows-dependencies-${{ hashFiles('References/Dependencies.7z') }}
+    - name: Extract game dependencies
+      if: steps.dependency-cache.outputs.cache-hit != 'true'
+      shell: pwsh
+      env:
+        ARCHIVE_PASSWORD: ${{ secrets.DEPENDENCIES_PASSWORD }}
+      run: |
+        if ([string]::IsNullOrWhiteSpace($env:ARCHIVE_PASSWORD)) {
+          throw "DEPENDENCIES_PASSWORD is required to prime dependency cache."
+        }
+
+        New-Item -ItemType Directory -Path References -Force | Out-Null
+        7z x .\References\Dependencies.7z -p"$($env:ARCHIVE_PASSWORD)" -oReferences -y
+    - name: Save dependency cache
+      if: steps.dependency-cache.outputs.cache-hit != 'true' && success()
+      uses: actions/cache/save@v6
+      with:
+        path: References
+        key: windows-dependencies-${{ hashFiles('References/Dependencies.7z') }}
+    - name: Cache summary
+      shell: pwsh
+      run: |
+        if ("${{ steps.dependency-cache.outputs.cache-hit }}" -eq "true") {
+          Write-Output "Dependency cache already exists for this archive hash."
+        }
+        else {
+          Write-Output "Dependency cache has been created."
+        }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,15 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Restore dependency cache
+      id: dependency-cache
+      uses: actions/cache/restore@v6
+      with:
+        path: References
+        key: windows-dependencies-${{ hashFiles('References/Dependencies.7z') }}
+
     - name: Decrypt and extract dependencies
+      if: steps.dependency-cache.outputs.cache-hit != 'true'
       env:
         ARCHIVE_PASSWORD: ${{ secrets.DEPENDENCIES_PASSWORD }}
       shell: pwsh


### PR DESCRIPTION
This PR will enable finally to build Memoria on each PR ( the process will be enabled on a separate PR, after this one is merged ).

**How it works:**
- A new `cache.yml` job will cache the `Dependencies.7z` content as a cache item in the CI for this single repository. The job can either be run manually or it will be run scheduled every 6 days, ensuring the cache item is always there if expired.
- Jobs making use of the archive ( `build.yml` or `release.yml` ) will attempt to use the cache if found. If not, they'll continue unpacking the archive as they did today. This is on purpose to not block releases if jobs are triggered rightfully from the owner ( or maintainers ) of this repo.

**Benefits of this approach:**
- The secret remains still safe in the repo and not shared on every PR
- Cached objects CAN NOT be downloaded and remains stored safely in Github and they can be reused safely across job runs, allowing PR jobs to use it.

**Why this change:**
- It will finally provide confidence that the PR is good at least code wise ( Memoria can build ) and nothing critical was added ( which will likely be discovered later after merge )
- It will provide a testable artifact right while we iterate on the PR, without having to merge to canary to have something ( from both implementer and reviewer side )