### PR TITLE
Update Melodies of Metal to v1.1.1

### DIFF
--- a/MemoriaCatalog.xml
+++ b/MemoriaCatalog.xml
@@ -3377,16 +3377,17 @@ Please notify if you notice problems</PatchNotes>
 
 <Mod>
 	<Name>Melodies of Metal</Name>
-	<Version>1.1</Version>
+	<Version>1.1.1</Version>
 	<InstallationPath>Melodies of Metal</InstallationPath>
-	<ReleaseDate>2026-07-04</ReleaseDate>
+	<ReleaseDate>2026-07-25</ReleaseDate>
 	<ReleaseDateOriginal>2026-06-20</ReleaseDateOriginal>
 	<Author>josias7c5</Author>
 	<Description>Melodies of Metal is an unofficial fan-made soundtrack tribute mod for Final Fantasy IX.
-
 It includes 99 in-game soundtrack replacement files based on 97 unique Heavy Metal cover arrangements created by The Melody Arcade, used with permission, and carefully converted and configured to work in-game.
 
-This Memoria version uses OGG audio files and can be enabled or disabled directly through the Memoria Mod Manager.
+This Memoria version uses OGG audio files and can be installed, enabled, disabled, and managed directly through the Memoria Mod Manager.
+
+Version 1.1.1 automatically includes the audio backend configuration validated for Melodies of Metal. Manual editing of the main Final Fantasy IX Memoria.ini file should normally not be required.
 
 Manual Hades Workshop import is no longer required for this version.
 
@@ -3394,24 +3395,31 @@ This project was created as a tribute to the legendary Nobuo Uematsu and to the 
 
 Some legends deserve to be remembered.
 Others deserve to be played louder.</Description>
+	<PatchNotes>Version 1.1.1 is the Audio Backend Compatibility Hotfix and definitive Memoria build.
 
-	<PatchNotes>Version 1.1 adds native Memoria Mod Manager support.
+The mod-specific Memoria.ini now includes:
 
-The mod can now be installed, enabled, disabled, and managed directly through the Memoria launcher.
+[Audio]
+PriorityToOGG = 1
+Backend = 2
+Enabled = 1
 
-This version uses OGG audio files with Memoria's PriorityToOGG option enabled.
+This configuration improves compatibility with boss, field, and cutscene soundtrack playback and resolves cases where music may remain silent when Backend = 1 is active.
 
-Manual Hades Workshop import is no longer required when using this Memoria version.
+Under normal circumstances, users no longer need to modify the main Final Fantasy IX Memoria.ini manually.
 
-The package includes the same 99 in-game soundtrack replacements from Version 1.0, based on 97 unique Heavy Metal cover arrangements created by The Melody Arcade and used with permission.
+The installation guide, technical notes, changelog, credits, license, version information, and troubleshooting documentation were updated.
 
-This version also includes updated documentation for Memoria installation, technical notes, song replacement list, changelog, credits, license, and version information.</PatchNotes>
+The Song Replacement List entry for 24) Sweet Dreams was corrected:
+Related Code: se000022
+Note: Original preserved.
 
+All 99 soundtrack replacement files, the 97 unique Heavy Metal cover arrangements, and all existing LoopStart and LoopEnd metadata remain unchanged.</PatchNotes>
 	<Category>Music</Category>
 	<Website>https://www.nexusmods.com/finalfantasy9/mods/134</Website>
 	<PreviewFile>Artwork/Melodies of Metal.png</PreviewFile>
 	<DownloadFormat>Zip</DownloadFormat>
-	<DownloadUrl>https://github.com/josias7c5/Melodies-of-Metal/releases/download/v1.1/Melodies_of_Metal_Memoria_v1.1.zip</DownloadUrl>
+	<DownloadUrl>https://github.com/josias7c5/Melodies-of-Metal/releases/download/v1.1.1/Melodies_of_Metal_Memoria_v1.1.1.zip</DownloadUrl>
 	<PreviewFileUrl>https://staticdelivery.nexusmods.com/mods/1948/images/134/134-1781966932-2123509564.png</PreviewFileUrl>
 	<IncompatibleWith>Gaia Bless the Soundtrack, Songs of Memories, Moguri Alt Soundtrack</IncompatibleWith>
 </Mod>


### PR DESCRIPTION
## Summary

Updates **Melodies of Metal** from Version 1.1 to Version 1.1.1 in the Memoria Mod Manager catalog.

## Changes

- Updated the version from `1.1` to `1.1.1`
- Updated the release date to `2026-07-25`
- Updated the GitHub release download URL
- Added the `Backend = 2` audio compatibility fix to the patch notes
- Clarified that manual audio configuration should normally not be required
- Updated the installation and troubleshooting information
- Documented the correction to the Song Replacement List entry for `24) Sweet Dreams`
- Preserved the existing installation path, category, preview image, website, and incompatible soundtrack mod list

## Audio Compatibility

The mod-specific `Memoria.ini` now includes:

    [Audio]
    PriorityToOGG = 1
    Backend = 2
    Enabled = 1

Controlled playback tests produced the following results:

| Main Memoria.ini | Mod Memoria.ini | Result |
|---|---|---|
| Backend 1 | Backend 1 | Failed |
| Backend 1 | Backend 2 | Passed |
| Backend 2 | Backend 1 | Passed |
| Backend 2 | Backend 2 | Passed |

Under normal circumstances, users should no longer need to modify the main Final Fantasy IX `Memoria.ini` manually.

## Package

The updated package is available from the GitHub `v1.1.1` release:

`Melodies_of_Metal_Memoria_v1.1.1.zip`

## Documentation

The Song Replacement List entry for `24) Sweet Dreams` was corrected to:

- Related Code: `se000022`
- Note: `Original preserved.`

No soundtrack replacements, OGG files, or existing loop points were changed.

## Compatibility

Known incompatible soundtrack mods remain unchanged:

- Gaia Bless the Soundtrack
- Songs of Memories
- Moguri Alt Soundtrack