### PR TITLE
New option : ATBSpeedFactor

### DIFF
--- a/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
+++ b/Assembly-CSharp/Global/Honolulu/HonoluluBattleMain.cs
@@ -455,7 +455,7 @@ public class HonoluluBattleMain : PersistenSingleton<MonoBehaviour>
 
                     changed = true;
                     if (advanceAtb)
-                        current.at += (Int16)(current.at_coef * 4);
+                        current.at += (Int16)(current.at_coef * Configuration.Battle.ATBSpeedFactor);
                     else
                         needContinue = false;
                 }

--- a/Assembly-CSharp/Memoria/Configuration/Access/Battle.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Access/Battle.cs
@@ -14,7 +14,7 @@ namespace Memoria
                 get => Instance._battle.Speed;
                 set => Instance._battle.Speed.Value = value;
             }
-            public static Int32 ATBSpeedFactor => Math.Max(1, Instance._battle.ATBSpeedFactor);
+            public static Single ATBSpeedFactor => GetBattleSpeedATB();
 
             public static Boolean NoAutoTrance => Instance._battle.NoAutoTrance;
             public static Int32 EncounterInterval => Instance._battle.EncounterInterval;
@@ -63,6 +63,13 @@ namespace Memoria
                 Instance._battle.Enabled.Value = true;
                 SaveValue(Instance._battle.Name, Instance._battle.Enabled);
                 SaveValue(Instance._battle.Name, Instance._battle.Speed);
+            }
+            private static Single GetBattleSpeedATB()
+            {
+                if (Single.TryParse(Instance._battle.ATBSpeedFactor, out Single value))
+                    return value < 1.0f ? 1.0f : value; // [DV] 1.0f is already very slow imo.
+
+                return 4.0f;
             }
             public static Boolean IsMenuEnabledInBattle(MainMenuUI.SubMenu subMenu)
             {

--- a/Assembly-CSharp/Memoria/Configuration/Access/Battle.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Access/Battle.cs
@@ -1,4 +1,3 @@
-using Newtonsoft.Json.Linq;
 using System;
 using System.Linq;
 

--- a/Assembly-CSharp/Memoria/Configuration/Access/Battle.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Access/Battle.cs
@@ -14,6 +14,8 @@ namespace Memoria
                 get => Instance._battle.Speed;
                 set => Instance._battle.Speed.Value = value;
             }
+            public static Int32 ATBSpeedFactor => Math.Max(1, Instance._battle.ATBSpeedFactor);
+
             public static Boolean NoAutoTrance => Instance._battle.NoAutoTrance;
             public static Int32 EncounterInterval => Instance._battle.EncounterInterval;
             public static Int32 EncounterInitial => Instance._battle.EncounterInitial;

--- a/Assembly-CSharp/Memoria/Configuration/Access/Battle.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Access/Battle.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json.Linq;
 using System;
 using System.Linq;
 
@@ -14,8 +15,7 @@ namespace Memoria
                 get => Instance._battle.Speed;
                 set => Instance._battle.Speed.Value = value;
             }
-            public static Single ATBSpeedFactor => GetBattleSpeedATB();
-
+            public static Single ATBSpeedFactor => Instance._battle.ATBSpeedFactor < 1.0f ? 1.0f : Instance._battle.ATBSpeedFactor; // [DV] 1.0f is already very slow imo.
             public static Boolean NoAutoTrance => Instance._battle.NoAutoTrance;
             public static Int32 EncounterInterval => Instance._battle.EncounterInterval;
             public static Int32 EncounterInitial => Instance._battle.EncounterInitial;
@@ -64,13 +64,7 @@ namespace Memoria
                 SaveValue(Instance._battle.Name, Instance._battle.Enabled);
                 SaveValue(Instance._battle.Name, Instance._battle.Speed);
             }
-            private static Single GetBattleSpeedATB()
-            {
-                if (Single.TryParse(Instance._battle.ATBSpeedFactor, out Single value))
-                    return value < 1.0f ? 1.0f : value; // [DV] 1.0f is already very slow imo.
 
-                return 4.0f;
-            }
             public static Boolean IsMenuEnabledInBattle(MainMenuUI.SubMenu subMenu)
             {
                 return AccessMenus > 0 && (AvailableMenus.Length == 0 || AvailableMenus.Contains(subMenu.ToString()));

--- a/Assembly-CSharp/Memoria/Configuration/Memoria.ini
+++ b/Assembly-CSharp/Memoria/Configuration/Memoria.ini
@@ -142,7 +142,7 @@ InvertedFlightY = 1
 [Battle]
 	; SFXRework (default 1) Use the reworked system of battle SFX (required for Speed types 3 and above)
 	; Speed (default 0) 0 = Default / 1 = Fast / 2 = Turn-based / 3 = Simultaneous, targets can't attack, turn-order respected / 4 = Simultaneous, targets can't attack / 5 = Simultaneous
-	; ATBSpeedFactor (default 4) The speed of the ATB gauge filling (1 is the slowest, 4 by default)
+	; ATBSpeedFactor (default 4.0) The speed of the ATB gauge filling (1.0 is the slowest, 4.0 by default)
 	; NoAutoTrance (default 0) Disable automatic trance
 	; EncounterInterval (default 960) The distance to travel between random encounter checks
 	; EncounterInitial (default -1440) -1440 = Default / Negative numbers give some walk time with no encounter check when entering a field
@@ -171,7 +171,7 @@ InvertedFlightY = 1
 Enabled = 0
 SFXRework = 1
 Speed = 0
-ATBSpeedFactor = 4
+ATBSpeedFactor = 4.0
 NoAutoTrance = 0
 EncounterInterval = 960
 EncounterInitial = -1440
@@ -238,7 +238,7 @@ LvMax = 0
 GilMax = 0
 
 [Hacks]
-	### MEMORIA CHEATS ###
+	; ### MEMORIA CHEATS ###
 	; AllCharactersAvailable (default 0) 1 = All characters are available / 2 = All characters are available and characters are not removed or swapped because of the scenario. Be careful: the option 2 soft-locks the game in some situations.
 	; RopeJumpingIncrement (default 1) Number of points per jump
 	; SwordplayAssistance (default 1) Ease the sword fight mini-game against Blank: 0 = difficulty of the PSX version / 1 = +30% scoring (default of the Steam version) / 2 = remove the reaction time limit

--- a/Assembly-CSharp/Memoria/Configuration/Memoria.ini
+++ b/Assembly-CSharp/Memoria/Configuration/Memoria.ini
@@ -167,6 +167,7 @@ InvertedFlightY = 1
 	; SpiritStatFormula (default: Min(50, SpiritBase + Level * 3 / 20 + (SpiritBonus / 32))) Formula for the level progression of player character spirit
 	; MagicStoneStockFormula (default: Min(99, MagicStoneBase + Level * 4 / 10 + (MagicStoneBonus / 32))) Formula for the level progression of player character magic stones
 	; TranceDecreaseFormula (default: (300 - Level) / Spirit * 10) Formula for the trance decrease after each turn spent in trance (the full gauge corresponds to 255)
+	; KeepRestTimeInBattle (default 1) 0 = After finishing an action, the ATB will always start to zero / 1 = When the ATB bar reaches its maximum, the existing “ATB excess” is carried over to the next round (often around 1% or less).
 Enabled = 0
 SFXRework = 1
 Speed = 0

--- a/Assembly-CSharp/Memoria/Configuration/Memoria.ini
+++ b/Assembly-CSharp/Memoria/Configuration/Memoria.ini
@@ -142,6 +142,7 @@ InvertedFlightY = 1
 [Battle]
 	; SFXRework (default 1) Use the reworked system of battle SFX (required for Speed types 3 and above)
 	; Speed (default 0) 0 = Default / 1 = Fast / 2 = Turn-based / 3 = Simultaneous, targets can't attack, turn-order respected / 4 = Simultaneous, targets can't attack / 5 = Simultaneous
+	; ATBSpeedFactor (default 4) The speed of the ATB gauge filling (1 is the slowest, 4 by default)
 	; NoAutoTrance (default 0) Disable automatic trance
 	; EncounterInterval (default 960) The distance to travel between random encounter checks
 	; EncounterInitial (default -1440) -1440 = Default / Negative numbers give some walk time with no encounter check when entering a field
@@ -169,6 +170,7 @@ InvertedFlightY = 1
 Enabled = 0
 SFXRework = 1
 Speed = 0
+ATBSpeedFactor = 4
 NoAutoTrance = 0
 EncounterInterval = 960
 EncounterInitial = -1440
@@ -235,7 +237,7 @@ LvMax = 0
 GilMax = 0
 
 [Hacks]
-	; Memoria cheats
+	### MEMORIA CHEATS ###
 	; AllCharactersAvailable (default 0) 1 = All characters are available / 2 = All characters are available and characters are not removed or swapped because of the scenario. Be careful: the option 2 soft-locks the game in some situations.
 	; RopeJumpingIncrement (default 1) Number of points per jump
 	; SwordplayAssistance (default 1) Ease the sword fight mini-game against Blank: 0 = difficulty of the PSX version / 1 = +30% scoring (default of the Steam version) / 2 = remove the reaction time limit

--- a/Assembly-CSharp/Memoria/Configuration/Structure/BattleSection.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Structure/BattleSection.cs
@@ -9,7 +9,7 @@ namespace Memoria
         {
             public readonly IniValue<Boolean> SFXRework;
             public readonly IniValue<Int32> Speed;
-            public readonly IniValue<Int32> ATBSpeedFactor;
+            public readonly IniValue<String> ATBSpeedFactor;
             public readonly IniValue<Boolean> NoAutoTrance;
             public readonly IniValue<Int32> EncounterInterval;
             public readonly IniValue<Int32> EncounterInitial;
@@ -61,7 +61,7 @@ namespace Memoria
             {
                 SFXRework = BindBoolean(nameof(SFXRework), true);
                 Speed = BindInt32(nameof(Speed), 0);
-                ATBSpeedFactor = BindInt32(nameof(ATBSpeedFactor), 4);
+                ATBSpeedFactor = BindString(nameof(ATBSpeedFactor), "4.0");
                 NoAutoTrance = BindBoolean(nameof(NoAutoTrance), false);
                 EncounterInterval = BindInt32(nameof(EncounterInterval), 960);
                 EncounterInitial = BindInt32(nameof(EncounterInitial), -1440);

--- a/Assembly-CSharp/Memoria/Configuration/Structure/BattleSection.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Structure/BattleSection.cs
@@ -9,7 +9,7 @@ namespace Memoria
         {
             public readonly IniValue<Boolean> SFXRework;
             public readonly IniValue<Int32> Speed;
-            public readonly IniValue<String> ATBSpeedFactor;
+            public readonly IniValue<Single> ATBSpeedFactor;
             public readonly IniValue<Boolean> NoAutoTrance;
             public readonly IniValue<Int32> EncounterInterval;
             public readonly IniValue<Int32> EncounterInitial;
@@ -61,7 +61,7 @@ namespace Memoria
             {
                 SFXRework = BindBoolean(nameof(SFXRework), true);
                 Speed = BindInt32(nameof(Speed), 0);
-                ATBSpeedFactor = BindString(nameof(ATBSpeedFactor), "4.0");
+                ATBSpeedFactor = BindSingle(nameof(ATBSpeedFactor), 4.0f);
                 NoAutoTrance = BindBoolean(nameof(NoAutoTrance), false);
                 EncounterInterval = BindInt32(nameof(EncounterInterval), 960);
                 EncounterInitial = BindInt32(nameof(EncounterInitial), -1440);

--- a/Assembly-CSharp/Memoria/Configuration/Structure/BattleSection.cs
+++ b/Assembly-CSharp/Memoria/Configuration/Structure/BattleSection.cs
@@ -9,6 +9,7 @@ namespace Memoria
         {
             public readonly IniValue<Boolean> SFXRework;
             public readonly IniValue<Int32> Speed;
+            public readonly IniValue<Int32> ATBSpeedFactor;
             public readonly IniValue<Boolean> NoAutoTrance;
             public readonly IniValue<Int32> EncounterInterval;
             public readonly IniValue<Int32> EncounterInitial;
@@ -60,6 +61,7 @@ namespace Memoria
             {
                 SFXRework = BindBoolean(nameof(SFXRework), true);
                 Speed = BindInt32(nameof(Speed), 0);
+                ATBSpeedFactor = BindInt32(nameof(ATBSpeedFactor), 4);
                 NoAutoTrance = BindBoolean(nameof(NoAutoTrance), false);
                 EncounterInterval = BindInt32(nameof(EncounterInterval), 960);
                 EncounterInitial = BindInt32(nameof(EncounterInitial), -1440);

--- a/Memoria.Launcher/Ini/Memoria.ini
+++ b/Memoria.Launcher/Ini/Memoria.ini
@@ -142,7 +142,7 @@ InvertedFlightY = 1
 [Battle]
 	; SFXRework (default 1) Use the reworked system of battle SFX (required for Speed types 3 and above)
 	; Speed (default 0) 0 = Default / 1 = Fast / 2 = Turn-based / 3 = Simultaneous, targets can't attack, turn-order respected / 4 = Simultaneous, targets can't attack / 5 = Simultaneous
-	; ATBSpeedFactor (default 4) The speed of the ATB gauge filling (1 is the slowest, 4 by default)
+	; ATBSpeedFactor (default 4.0) The speed of the ATB gauge filling (1.0 is the slowest, 4.0 by default)
 	; NoAutoTrance (default 0) Disable automatic trance
 	; EncounterInterval (default 960) The distance to travel between random encounter checks
 	; EncounterInitial (default -1440) -1440 = Default / Negative numbers give some walk time with no encounter check when entering a field
@@ -171,7 +171,7 @@ InvertedFlightY = 1
 Enabled = 0
 SFXRework = 1
 Speed = 0
-ATBSpeedFactor = 4
+ATBSpeedFactor = 4.0
 NoAutoTrance = 0
 EncounterInterval = 960
 EncounterInitial = -1440
@@ -238,7 +238,7 @@ LvMax = 0
 GilMax = 0
 
 [Hacks]
-	### MEMORIA CHEATS ###
+	; ### MEMORIA CHEATS ###
 	; AllCharactersAvailable (default 0) 1 = All characters are available / 2 = All characters are available and characters are not removed or swapped because of the scenario. Be careful: the option 2 soft-locks the game in some situations.
 	; RopeJumpingIncrement (default 1) Number of points per jump
 	; SwordplayAssistance (default 1) Ease the sword fight mini-game against Blank: 0 = difficulty of the PSX version / 1 = +30% scoring (default of the Steam version) / 2 = remove the reaction time limit

--- a/Memoria.Launcher/Ini/Memoria.ini
+++ b/Memoria.Launcher/Ini/Memoria.ini
@@ -167,6 +167,7 @@ InvertedFlightY = 1
 	; SpiritStatFormula (default: Min(50, SpiritBase + Level * 3 / 20 + (SpiritBonus / 32))) Formula for the level progression of player character spirit
 	; MagicStoneStockFormula (default: Min(99, MagicStoneBase + Level * 4 / 10 + (MagicStoneBonus / 32))) Formula for the level progression of player character magic stones
 	; TranceDecreaseFormula (default: (300 - Level) / Spirit * 10) Formula for the trance decrease after each turn spent in trance (the full gauge corresponds to 255)
+	; KeepRestTimeInBattle (default 1) 0 = After finishing an action, the ATB will always start to zero / 1 = When the ATB bar reaches its maximum, the existing “ATB excess” is carried over to the next round (often around 1% or less).
 Enabled = 0
 SFXRework = 1
 Speed = 0

--- a/Memoria.Launcher/Ini/Memoria.ini
+++ b/Memoria.Launcher/Ini/Memoria.ini
@@ -142,6 +142,7 @@ InvertedFlightY = 1
 [Battle]
 	; SFXRework (default 1) Use the reworked system of battle SFX (required for Speed types 3 and above)
 	; Speed (default 0) 0 = Default / 1 = Fast / 2 = Turn-based / 3 = Simultaneous, targets can't attack, turn-order respected / 4 = Simultaneous, targets can't attack / 5 = Simultaneous
+	; ATBSpeedFactor (default 4) The speed of the ATB gauge filling (1 is the slowest, 4 by default)
 	; NoAutoTrance (default 0) Disable automatic trance
 	; EncounterInterval (default 960) The distance to travel between random encounter checks
 	; EncounterInitial (default -1440) -1440 = Default / Negative numbers give some walk time with no encounter check when entering a field
@@ -169,6 +170,7 @@ InvertedFlightY = 1
 Enabled = 0
 SFXRework = 1
 Speed = 0
+ATBSpeedFactor = 4
 NoAutoTrance = 0
 EncounterInterval = 960
 EncounterInitial = -1440
@@ -235,7 +237,7 @@ LvMax = 0
 GilMax = 0
 
 [Hacks]
-	; Memoria cheats
+	### MEMORIA CHEATS ###
 	; AllCharactersAvailable (default 0) 1 = All characters are available / 2 = All characters are available and characters are not removed or swapped because of the scenario. Be careful: the option 2 soft-locks the game in some situations.
 	; RopeJumpingIncrement (default 1) Number of points per jump
 	; SwordplayAssistance (default 1) Ease the sword fight mini-game against Blank: 0 = difficulty of the PSX version / 1 = +30% scoring (default of the Steam version) / 2 = remove the reaction time limit

--- a/Memoria.Prime/Ini/IniSection.cs
+++ b/Memoria.Prime/Ini/IniSection.cs
@@ -43,6 +43,14 @@ namespace Memoria.Prime.Ini
             return handler;
         }
 
+        protected IniValue<Single> BindSingle(String name, Single defaultValue)
+        {
+            IniValue<Single> handler = IniValue.Single(name);
+            handler.Value = defaultValue;
+            _bindings.Add(new ValueBinding<Single>(handler));
+            return handler;
+        }
+
         protected IniValue<String> BindPath(String name, String defaultValue)
         {
             if (IniValue.TryParsePath(defaultValue, out var path))

--- a/Memoria.Prime/Ini/IniValue.cs
+++ b/Memoria.Prime/Ini/IniValue.cs
@@ -58,6 +58,11 @@ namespace Memoria.Prime.Ini
             return new IniSet<Int32>(name, TryParseInt32, FormatInt32);
         }
 
+        public static IniValue<Single> Single(String name)
+        {
+            return new IniValue<Single>(name, TryParseSingle, FormatSingle);
+        }
+
         public static IniArray<String> StringArray(String name)
         {
             return new IniArray<String>(name, TryParseString, FormatString);
@@ -116,6 +121,16 @@ namespace Memoria.Prime.Ini
         }
 
         private static String FormatInt32(Int32 value)
+        {
+            return value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        private static Boolean TryParseSingle(String rawstring, out Single value)
+        {
+            return System.Single.TryParse(rawstring, NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+        }
+
+        private static String FormatSingle(Single value)
         {
             return value.ToString(CultureInfo.InvariantCulture);
         }


### PR DESCRIPTION
A tiny PR to add a new option for Memoria : `ATBSpeedFactor`.

Simply editing the ATB Formula in HonoluluBattleMain : 
`current.at += (Int16)(current.at_coef * 4);`
by
`current.at += (Int16)(current.at_coef * Configuration.Battle.ATBSpeedFactor);`

In that's way, we can slow or speed up the ATB bar (the minimum value is `1` of course)

Linked to https://github.com/Albeoris/Memoria/issues/1432

Also, i discovered the `Configuration.Battle.IsKeepRestTimeInBattle` => From what i seen... i don't think it's still usefull ? 🤔 
Especially given the current code:

https://github.com/Albeoris/Memoria/blob/e3db540bc58895054dad74dbc4d0823160e2b06c/Assembly-CSharp/Global/btl_cmd.cs#L1409-L1417

Here, `(Int16)Math.Max(0, unit.CurrentAtb - unit.MaximumAtb)` will be always 0 so.... and since this option is extremely old (since the birth of Memoria ?), I'm not sure if that's really relevant.

EDIT => Seen with Tir, `Configuration.Battle.IsKeepRestTimeInBattle` working as expected so no problem.