### PR TITLE
Common: Update dependencies

### DIFF
--- a/Memoria.Client/Memoria.Client.csproj
+++ b/Memoria.Client/Memoria.Client.csproj
@@ -198,7 +198,7 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="5.0.0" />
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="5.1.2" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Memoria.Launcher/Memoria.Launcher.csproj
+++ b/Memoria.Launcher/Memoria.Launcher.csproj
@@ -281,8 +281,8 @@
     <PackageReference Include="Ae.Dns.Client">
       <Version>3.1.0</Version>
     </PackageReference>
-    <PackageReference Include="NLog" Version="6.1.3" />
-    <PackageReference Include="SharpCompress" Version="0.48.1" />
+    <PackageReference Include="NLog" Version="6.2.0" />
+    <PackageReference Include="SharpCompress" Version="0.50.4" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="Memoria.Launcher.targets" />


### PR DESCRIPTION
This PR bumps the following dependencies:

- Extended.Wpf.Toolkit: 5.0.0 -> 5.1.2
- NLog: 6.1.3 -> 6.2.0
- SharpCompress: 0.48.1 -> 0.50.4