### PR TITLE
UDIM Texture Feature for Custom Models

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -380,6 +380,7 @@
     <Compile Include="Memoria\Assets\3DModel\FbxSkeleton.cs" />
     <Compile Include="Memoria\Assets\3DModel\FbxUdimBlink.cs" />
     <Compile Include="Memoria\Assets\3DModel\FbxUdimTexture.cs" />
+    <Compile Include="Memoria\Assets\3DModel\UdimTextureAtlas.cs" />
     <Compile Include="Memoria\Assets\3DModel\FbxVersion.cs" />
     <Compile Include="Memoria\Assets\3DModel\ModelImporter.cs" />
     <Compile Include="Memoria\Assets\Export\TranslationExporter.cs" />

--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -378,6 +378,7 @@
     <Compile Include="Memoria\Assets\3DModel\FbxNode.cs" />
     <Compile Include="Memoria\Assets\3DModel\FbxNodeList.cs" />
     <Compile Include="Memoria\Assets\3DModel\FbxSkeleton.cs" />
+    <Compile Include="Memoria\Assets\3DModel\FbxUdimBlink.cs" />
     <Compile Include="Memoria\Assets\3DModel\FbxUdimTexture.cs" />
     <Compile Include="Memoria\Assets\3DModel\FbxVersion.cs" />
     <Compile Include="Memoria\Assets\3DModel\ModelImporter.cs" />

--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -378,6 +378,7 @@
     <Compile Include="Memoria\Assets\3DModel\FbxNode.cs" />
     <Compile Include="Memoria\Assets\3DModel\FbxNodeList.cs" />
     <Compile Include="Memoria\Assets\3DModel\FbxSkeleton.cs" />
+    <Compile Include="Memoria\Assets\3DModel\FbxUdimTexture.cs" />
     <Compile Include="Memoria\Assets\3DModel\FbxVersion.cs" />
     <Compile Include="Memoria\Assets\3DModel\ModelImporter.cs" />
     <Compile Include="Memoria\Assets\Export\TranslationExporter.cs" />

--- a/Assembly-CSharp/FF9/btl_mot.cs
+++ b/Assembly-CSharp/FF9/btl_mot.cs
@@ -443,6 +443,7 @@ namespace FF9
                 GeoTexAnim.geoTexAnimStop(btl.tranceTexanimptr, 2);
                 GeoTexAnim.geoTexAnimPlayOnce(btl.tranceTexanimptr, 0);
             }
+            FbxUdimBlink.SetBattleEyesClosed(btl, true);
             Boolean cancelDeath = false;
             foreach (BattleStatusId statusId in btl.stat.cur.ToStatusList())
                 if (btl.stat.effects.TryGetValue(statusId, out StatusScriptBase effect))
@@ -450,6 +451,7 @@ namespace FF9
                         cancelDeath = true;
             if (cancelDeath)
             {
+                FbxUdimBlink.SetBattleEyesClosed(btl, false);
                 FF9StateSystem.Settings.SetHPFull();
                 if (!cancelMonsterTransform)
                     btl_mot.SetDefaultIdle(btl);

--- a/Assembly-CSharp/Global/Geo/GeoTexAnim.cs
+++ b/Assembly-CSharp/Global/Geo/GeoTexAnim.cs
@@ -1,4 +1,5 @@
 using Assets.Scripts.Common;
+using Memoria.Assets;
 using System;
 using System.Collections;
 using System.Linq;
@@ -55,6 +56,7 @@ public class GeoTexAnim : HonoBehavior
         this.TextureAnim.geotex[anum].lastframe = 4096;
         if (anum == 0)
             this.TextureAnim.geotex[2].flags &= unchecked((Byte)~3);
+        FbxUdimBlink.SynchronizeTextureAnimation(gameObject, this.TextureAnim);
     }
 
     public static void geoTexAnimPlay(GEOTEXHEADER tab, Int32 anum)
@@ -73,6 +75,7 @@ public class GeoTexAnim : HonoBehavior
         this.TextureAnim.geotex[anum].flags |= 3;
         this.TextureAnim.geotex[anum].frame = 0;
         this.TextureAnim.geotex[anum].lastframe = 4096;
+        FbxUdimBlink.SynchronizeTextureAnimation(gameObject, this.TextureAnim);
     }
 
     public static void geoTexAnimPlayOnce(GEOTEXHEADER tab, Int32 anum)
@@ -89,6 +92,7 @@ public class GeoTexAnim : HonoBehavior
         if (!this._isLoaded)
             return;
         this.TextureAnim.geotex[anum].flags &= unchecked((Byte)~3);
+        FbxUdimBlink.SynchronizeTextureAnimation(gameObject, this.TextureAnim);
     }
 
     public static void geoTexAnimStop(GEOTEXHEADER tab, Int32 anum)

--- a/Assembly-CSharp/Global/battle/BattlePlayerCharacter.cs
+++ b/Assembly-CSharp/Global/battle/BattlePlayerCharacter.cs
@@ -1,5 +1,6 @@
 ﻿using FF9;
 using Memoria;
+using Memoria.Assets;
 using Memoria.Data;
 using System;
 using System.Collections.Generic;
@@ -79,6 +80,7 @@ public class BattlePlayerCharacter : MonoBehaviour
         btl.gameObject = ModelFactory.CreateModel(btlParam.ModelId, true, true, Configuration.Graphics.ElementsSmoothTexture);
         btl.originalGo = btl.gameObject;
         BattlePlayerCharacter.CreateTranceModel(btl, btlParam.TranceModelId);
+        FbxUdimBlink.SynchronizeBattleState(btl);
         if (p.info.serial_no == CharacterSerialNumber.ZIDANE_SWORD)
         {
             BattlePlayerCharacter.HideZidaneOrichalcum(btl.gameObject);

--- a/Assembly-CSharp/Global/btl_init.cs
+++ b/Assembly-CSharp/Global/btl_init.cs
@@ -1,6 +1,7 @@
 ﻿using Assets.Sources.Scripts.UI.Common;
 using FF9;
 using Memoria;
+using Memoria.Assets;
 using Memoria.Data;
 using Memoria.Prime;
 using System;
@@ -282,6 +283,7 @@ public static class btl_init
                 {
                     GeoTexAnim.geoTexAnimPlay(btl.texanimptr, 2);
                 }
+                FbxUdimBlink.SynchronizeBattleState(btl);
                 if (!FF9StateSystem.Battle.isDebug)
                     objList = objList.next;
                 btlIndex++;
@@ -636,6 +638,7 @@ public static class btl_init
         {
             GeoTexAnim.geoTexAnimPlay(btl.texanimptr, 2);
         }
+        FbxUdimBlink.SynchronizeBattleState(btl);
         btl_sys.AddCharacter(btl);
         // Part of SetupBattlePlayer
         SetupBattlePlayerSingle(btl, (Int32)btl.original_pos[0], battle_start_type_tags.BTL_START_NORMAL_ATTACK);

--- a/Assembly-CSharp/Global/btl_vfx.cs
+++ b/Assembly-CSharp/Global/btl_vfx.cs
@@ -198,6 +198,7 @@ public static class btl_vfx
             btl.ChangeModel(btl.originalGo, btl_init.GetModelID(serialNo, isTrance));
             GeoTexAnim.geoTexAnimPlay(btl.texanimptr, 2);
         }
+        FbxUdimBlink.SynchronizeBattleState(btl);
         btl_util.GeoSetABR(btl.gameObject, "PSX/BattleMap_StatusEffect", btl);
         btl_mot.SetPlayerDefMotion(btl, serialNo, isTrance);
         BattlePlayerCharacter.InitAnimation(btl);

--- a/Assembly-CSharp/Memoria/Assets/3DModel/FbxMaterial.cs
+++ b/Assembly-CSharp/Memoria/Assets/3DModel/FbxMaterial.cs
@@ -1,11 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Memoria.Assets
 {
     /// <summary>API for Material / Texture nodes</summary>
     public class FbxMaterial
     {
+        public const String BlinkOpenUdimProperty = "MemoriaBlinkOpenUDIM";
+        public const String BlinkClosedUdimProperty = "MemoriaBlinkClosedUDIM";
+
         public readonly FbxNode MaterialNode;
         public readonly FbxNode TextureNode = null;
 
@@ -38,6 +42,27 @@ namespace Memoria.Assets
                     break;
                 }
             }
+        }
+
+        public Boolean HasProperty(String propertyName)
+        {
+            return GetProperty(propertyName) != null;
+        }
+
+        public Boolean TryGetInt32Property(String propertyName, out Int32 value)
+        {
+            value = 0;
+            FbxNode property = GetProperty(propertyName);
+            if (property == null || property.Properties.Count < 5 || property.Properties[4] == null)
+                return false;
+
+            String valueText = Convert.ToString(property.Properties[4], CultureInfo.InvariantCulture);
+            return Int32.TryParse(valueText, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+        }
+
+        private FbxNode GetProperty(String propertyName)
+        {
+            return MaterialNode?["Properties70"]?["P", propertyName];
         }
     }
 }

--- a/Assembly-CSharp/Memoria/Assets/3DModel/FbxUdimBlink.cs
+++ b/Assembly-CSharp/Memoria/Assets/3DModel/FbxUdimBlink.cs
@@ -73,7 +73,7 @@ namespace Memoria.Assets
             destinationBlink.InitializeTransferredTargets(transferredTargets, sourceBlink._eyeMode);
             if (sourceBlink != destinationBlink)
             {
-                // Allows the target mesh be the main mesh; pausing the game will not reset the blink state.
+                // Stop the temporary model from changing the copied meshes.
                 sourceBlink._targets = null;
                 sourceBlink.enabled = false;
             }

--- a/Assembly-CSharp/Memoria/Assets/3DModel/FbxUdimBlink.cs
+++ b/Assembly-CSharp/Memoria/Assets/3DModel/FbxUdimBlink.cs
@@ -12,8 +12,8 @@ namespace Memoria.Assets
 
         [SerializeField]
         private BlinkTarget[] _targets;
-        private Single _nextBlinkTime;
-        private Single _openEyeTime;
+        private Single _timeUntilNextBlink;
+        private Single _closedEyeTimeRemaining;
         private Boolean _eyesClosed;
         private EyeMode _eyeMode;
 
@@ -112,11 +112,15 @@ namespace Memoria.Assets
                 return;
             if (_eyeMode != EyeMode.Automatic)
                 return;
+            UIManager uiManager = PersistenSingleton<UIManager>.Instance;
+            if (uiManager != null && uiManager.IsPause)
+                return;
 
-            Single currentTime = Time.realtimeSinceStartup;
+            Single elapsedTime = Time.unscaledDeltaTime;
             if (_eyesClosed)
             {
-                if (currentTime < _openEyeTime)
+                _closedEyeTimeRemaining -= elapsedTime;
+                if (_closedEyeTimeRemaining > 0f)
                     return;
 
                 // Keep the open UVs until the next blink.
@@ -124,12 +128,16 @@ namespace Memoria.Assets
                 _eyesClosed = false;
                 ScheduleNextBlink();
             }
-            else if (currentTime >= _nextBlinkTime)
+            else
             {
+                _timeUntilNextBlink -= elapsedTime;
+                if (_timeUntilNextBlink > 0f)
+                    return;
+
                 // Show the closed eyes for a moment.
                 ApplyUVs(true);
                 _eyesClosed = true;
-                _openEyeTime = currentTime + ClosedEyeDuration;
+                _closedEyeTimeRemaining = ClosedEyeDuration;
             }
         }
 
@@ -186,7 +194,7 @@ namespace Memoria.Assets
 
         private void ScheduleNextBlink()
         {
-            _nextBlinkTime = Time.realtimeSinceStartup + UnityEngine.Random.Range(MinimumBlinkDelay, MaximumBlinkDelay);
+            _timeUntilNextBlink = UnityEngine.Random.Range(MinimumBlinkDelay, MaximumBlinkDelay);
         }
 
         private void ApplyUVs(Boolean useClosedUVs)

--- a/Assembly-CSharp/Memoria/Assets/3DModel/FbxUdimBlink.cs
+++ b/Assembly-CSharp/Memoria/Assets/3DModel/FbxUdimBlink.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using UnityEngine;
+
+namespace Memoria.Assets
+{
+    public sealed class FbxUdimBlink : MonoBehaviour
+    {
+        private const Single MinimumBlinkDelay = 2.5f;
+        private const Single MaximumBlinkDelay = 6f;
+        private const Single ClosedEyeDuration = 0.12f;
+
+        [SerializeField]
+        private BlinkTarget[] _targets;
+        private Single _nextBlinkTime;
+        private Single _openEyeTime;
+        private Boolean _eyesClosed;
+
+        public void Initialize(SkinnedMeshRenderer[] renderers, Mesh[] meshes, Vector2[][] openUVs, Vector2[][] closedUVs)
+        {
+            Int32 targetCount = 0;
+            for (Int32 i = 0; i < meshes.Length; i++)
+                if (meshes[i] != null)
+                    targetCount++;
+
+            _targets = new BlinkTarget[targetCount];
+            Int32 targetIndex = 0;
+            for (Int32 i = 0; i < meshes.Length; i++)
+            {
+                if (meshes[i] == null)
+                    continue;
+
+                _targets[targetIndex++] = new BlinkTarget(renderers[i], meshes[i], openUVs[i], closedUVs[i]);
+            }
+            ApplyUVs(false);
+            _eyesClosed = false;
+            ScheduleNextBlink();
+        }
+
+        public static Boolean Transfer(GameObject sourceRoot, GameObject destinationRoot, SkinnedMeshRenderer[] sourceRenderers, SkinnedMeshRenderer[] destinationRenderers)
+        {
+            if (sourceRoot == null || destinationRoot == null || sourceRenderers == null || destinationRenderers == null || sourceRenderers.Length != destinationRenderers.Length)
+                return false;
+
+            FbxUdimBlink sourceBlink = sourceRoot.GetComponent<FbxUdimBlink>();
+            FbxUdimBlink destinationBlink = destinationRoot.GetComponent<FbxUdimBlink>();
+            if (sourceBlink == null || sourceBlink._targets == null)
+            {
+                Remove(destinationBlink);
+                return false;
+            }
+
+            BlinkTarget[] transferredTargets = new BlinkTarget[sourceRenderers.Length];
+            Int32 transferredTargetCount = 0;
+            for (Int32 i = 0; i < sourceRenderers.Length; i++)
+            {
+                BlinkTarget sourceTarget = sourceBlink.FindTarget(sourceRenderers[i]);
+                SkinnedMeshRenderer destinationRenderer = destinationRenderers[i];
+                if (sourceTarget == null || destinationRenderer == null || destinationRenderer.sharedMesh == null)
+                    continue;
+
+                transferredTargets[transferredTargetCount++] = new BlinkTarget(destinationRenderer, destinationRenderer.sharedMesh, sourceTarget.OpenUVs, sourceTarget.ClosedUVs);
+            }
+            if (transferredTargetCount == 0)
+            {
+                Remove(destinationBlink);
+                return false;
+            }
+            if (transferredTargetCount != transferredTargets.Length)
+                Array.Resize(ref transferredTargets, transferredTargetCount);
+
+            if (destinationBlink == null)
+                destinationBlink = destinationRoot.AddComponent<FbxUdimBlink>();
+            destinationBlink.InitializeTransferredTargets(transferredTargets);
+            return true;
+        }
+
+        private void Update()
+        {
+            if (_targets == null)
+                return;
+
+            Single currentTime = Time.realtimeSinceStartup;
+            if (_eyesClosed)
+            {
+                if (currentTime < _openEyeTime)
+                    return;
+
+                // Keep the open UVs until the next blink.
+                ApplyUVs(false);
+                _eyesClosed = false;
+                ScheduleNextBlink();
+            }
+            else if (currentTime >= _nextBlinkTime)
+            {
+                // Show the closed eyes for a moment.
+                ApplyUVs(true);
+                _eyesClosed = true;
+                _openEyeTime = currentTime + ClosedEyeDuration;
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (_targets == null)
+                return;
+
+            ApplyUVs(false);
+            _eyesClosed = false;
+            ScheduleNextBlink();
+        }
+
+        private void OnDisable()
+        {
+            if (_targets == null)
+                return;
+
+            ApplyUVs(false);
+            _eyesClosed = false;
+        }
+
+        private void OnDestroy()
+        {
+            _targets = null;
+        }
+
+        private void InitializeTransferredTargets(BlinkTarget[] targets)
+        {
+            _targets = targets;
+            _eyesClosed = false;
+            ApplyUVs(false);
+            ScheduleNextBlink();
+            enabled = true;
+        }
+
+        private void ScheduleNextBlink()
+        {
+            _nextBlinkTime = Time.realtimeSinceStartup + UnityEngine.Random.Range(MinimumBlinkDelay, MaximumBlinkDelay);
+        }
+
+        private void ApplyUVs(Boolean useClosedUVs)
+        {
+            for (Int32 i = 0; i < _targets.Length; i++)
+            {
+                BlinkTarget target = _targets[i];
+                Mesh mesh = target.Renderer != null && target.Renderer.sharedMesh != null ? target.Renderer.sharedMesh : target.ImportedMesh;
+                Vector2[] uvs = useClosedUVs ? target.ClosedUVs : target.OpenUVs;
+                if (mesh != null && uvs != null && mesh.vertexCount == uvs.Length)
+                    mesh.uv = uvs;
+            }
+        }
+
+        private BlinkTarget FindTarget(SkinnedMeshRenderer renderer)
+        {
+            if (renderer == null)
+                return null;
+
+            for (Int32 i = 0; i < _targets.Length; i++)
+                if (_targets[i] != null && _targets[i].Renderer == renderer)
+                    return _targets[i];
+            return null;
+        }
+
+        private static void Remove(FbxUdimBlink blink)
+        {
+            if (blink == null)
+                return;
+
+            blink._targets = null;
+            blink.enabled = false;
+        }
+
+        [Serializable]
+        private sealed class BlinkTarget
+        {
+            public SkinnedMeshRenderer Renderer;
+            public Mesh ImportedMesh;
+            public Vector2[] OpenUVs;
+            public Vector2[] ClosedUVs;
+
+            public BlinkTarget(SkinnedMeshRenderer renderer, Mesh importedMesh, Vector2[] openUVs, Vector2[] closedUVs)
+            {
+                Renderer = renderer;
+                ImportedMesh = importedMesh;
+                OpenUVs = openUVs;
+                ClosedUVs = closedUVs;
+            }
+        }
+    }
+}

--- a/Assembly-CSharp/Memoria/Assets/3DModel/FbxUdimBlink.cs
+++ b/Assembly-CSharp/Memoria/Assets/3DModel/FbxUdimBlink.cs
@@ -1,12 +1,13 @@
 ﻿using System;
+using Memoria.Data;
 using UnityEngine;
 
 namespace Memoria.Assets
 {
     public sealed class FbxUdimBlink : MonoBehaviour
     {
-        private const Single MinimumBlinkDelay = 2.5f;
-        private const Single MaximumBlinkDelay = 6f;
+        private const Single MinimumBlinkDelay = 1.5f;
+        private const Single MaximumBlinkDelay = 4f;
         private const Single ClosedEyeDuration = 0.12f;
 
         [SerializeField]
@@ -14,6 +15,7 @@ namespace Memoria.Assets
         private Single _nextBlinkTime;
         private Single _openEyeTime;
         private Boolean _eyesClosed;
+        private EyeMode _eyeMode;
 
         public void Initialize(SkinnedMeshRenderer[] renderers, Mesh[] meshes, Vector2[][] openUVs, Vector2[][] closedUVs)
         {
@@ -31,9 +33,7 @@ namespace Memoria.Assets
 
                 _targets[targetIndex++] = new BlinkTarget(renderers[i], meshes[i], openUVs[i], closedUVs[i]);
             }
-            ApplyUVs(false);
-            _eyesClosed = false;
-            ScheduleNextBlink();
+            SetEyeMode(EyeMode.Automatic, true);
         }
 
         public static Boolean Transfer(GameObject sourceRoot, GameObject destinationRoot, SkinnedMeshRenderer[] sourceRenderers, SkinnedMeshRenderer[] destinationRenderers)
@@ -70,13 +70,47 @@ namespace Memoria.Assets
 
             if (destinationBlink == null)
                 destinationBlink = destinationRoot.AddComponent<FbxUdimBlink>();
-            destinationBlink.InitializeTransferredTargets(transferredTargets);
+            destinationBlink.InitializeTransferredTargets(transferredTargets, sourceBlink._eyeMode);
             return true;
+        }
+
+        internal static void SynchronizeBattleState(BTL_DATA battle)
+        {
+            if (battle == null)
+                return;
+
+            SetBattleEyesClosed(battle, btl_stat.CheckStatus(battle, BattleStatus.Death));
+        }
+
+        internal static void SetBattleEyesClosed(BTL_DATA battle, Boolean eyesClosed)
+        {
+            if (battle == null)
+                return;
+
+            EyeMode eyeMode = eyesClosed ? EyeMode.ForcedClosed : EyeMode.Automatic;
+            SetEyeMode(battle.originalGo, eyeMode);
+            SetEyeMode(battle.tranceGo, eyeMode);
+            SetEyeMode(battle.gameObject, eyeMode);
+        }
+
+        internal static void SynchronizeTextureAnimation(GameObject root, GEOTEXHEADER textureAnimation)
+        {
+            if (root == null || textureAnimation?.geotex == null || textureAnimation.geotex.Length <= 2)
+                return;
+
+            if (IsTextureAnimationActive(textureAnimation, 2))
+                SetEyeMode(root, EyeMode.Automatic);
+            else if (IsTextureAnimationActive(textureAnimation, 0))
+                SetEyeMode(root, EyeMode.ForcedClosed);
+            else
+                SetEyeMode(root, EyeMode.ForcedOpen);
         }
 
         private void Update()
         {
             if (_targets == null)
+                return;
+            if (_eyeMode != EyeMode.Automatic)
                 return;
 
             Single currentTime = Time.realtimeSinceStartup;
@@ -104,9 +138,7 @@ namespace Memoria.Assets
             if (_targets == null)
                 return;
 
-            ApplyUVs(false);
-            _eyesClosed = false;
-            ScheduleNextBlink();
+            ApplyEyeMode();
         }
 
         private void OnDisable()
@@ -123,13 +155,33 @@ namespace Memoria.Assets
             _targets = null;
         }
 
-        private void InitializeTransferredTargets(BlinkTarget[] targets)
+        private void InitializeTransferredTargets(BlinkTarget[] targets, EyeMode sourceEyeMode)
         {
             _targets = targets;
-            _eyesClosed = false;
-            ApplyUVs(false);
-            ScheduleNextBlink();
+            _eyeMode = sourceEyeMode;
+            GeoTexAnim textureAnimation = GetComponent<GeoTexAnim>();
+            if (textureAnimation?.TextureAnim != null)
+                SynchronizeTextureAnimation(gameObject, textureAnimation.TextureAnim);
+            SetEyeMode(_eyeMode, true);
             enabled = true;
+        }
+
+        private void ApplyEyeMode()
+        {
+            Boolean useClosedUVs = _eyeMode == EyeMode.ForcedClosed;
+            ApplyUVs(useClosedUVs);
+            _eyesClosed = useClosedUVs;
+            if (_eyeMode == EyeMode.Automatic)
+                ScheduleNextBlink();
+        }
+
+        private void SetEyeMode(EyeMode eyeMode, Boolean forceApply)
+        {
+            if (!forceApply && _eyeMode == eyeMode)
+                return;
+
+            _eyeMode = eyeMode;
+            ApplyEyeMode();
         }
 
         private void ScheduleNextBlink()
@@ -160,6 +212,21 @@ namespace Memoria.Assets
             return null;
         }
 
+        private static Boolean IsTextureAnimationActive(GEOTEXHEADER textureAnimation, Int32 animationIndex)
+        {
+            return animationIndex >= 0
+                && animationIndex < textureAnimation.geotex.Length
+                && textureAnimation.geotex[animationIndex] != null
+                && (textureAnimation.geotex[animationIndex].flags & 1) != 0;
+        }
+
+        private static void SetEyeMode(GameObject root, EyeMode eyeMode)
+        {
+            FbxUdimBlink blink = root != null ? root.GetComponent<FbxUdimBlink>() : null;
+            if (blink != null && blink._targets != null)
+                blink.SetEyeMode(eyeMode, false);
+        }
+
         private static void Remove(FbxUdimBlink blink)
         {
             if (blink == null)
@@ -167,6 +234,13 @@ namespace Memoria.Assets
 
             blink._targets = null;
             blink.enabled = false;
+        }
+
+        private enum EyeMode
+        {
+            Automatic,
+            ForcedOpen,
+            ForcedClosed
         }
 
         [Serializable]

--- a/Assembly-CSharp/Memoria/Assets/3DModel/FbxUdimBlink.cs
+++ b/Assembly-CSharp/Memoria/Assets/3DModel/FbxUdimBlink.cs
@@ -71,6 +71,12 @@ namespace Memoria.Assets
             if (destinationBlink == null)
                 destinationBlink = destinationRoot.AddComponent<FbxUdimBlink>();
             destinationBlink.InitializeTransferredTargets(transferredTargets, sourceBlink._eyeMode);
+            if (sourceBlink != destinationBlink)
+            {
+                // Allows the target mesh be the main mesh; pausing the game will not reset the blink state.
+                sourceBlink._targets = null;
+                sourceBlink.enabled = false;
+            }
             return true;
         }
 

--- a/Assembly-CSharp/Memoria/Assets/3DModel/FbxUdimTexture.cs
+++ b/Assembly-CSharp/Memoria/Assets/3DModel/FbxUdimTexture.cs
@@ -1,0 +1,307 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+namespace Memoria.Assets
+{
+    internal sealed class FbxUdimTexture
+    {
+        public const String Placeholder = "<UDIM>";
+
+        private const Int32 FirstTileNumber = 1001;
+        private const Int32 TilesPerRow = 10;
+        private const Int32 GutterSize = 2;
+        private const String SafePathPlaceholder = "__MemoriaUdimPlaceholder__";
+
+        public Texture2D Texture { get; private set; }
+
+        private FbxUdimTexture(Texture2D texture, Int32 tileWidth, Int32 tileHeight, Int32 columnCount, Int32 rowCount)
+        {
+            Texture = texture;
+            _tileWidth = tileWidth;
+            _tileHeight = tileHeight;
+            _columnCount = columnCount;
+            _rowCount = rowCount;
+        }
+
+        public static Boolean IsUdimPath(String path)
+        {
+            return !String.IsNullOrEmpty(path) && path.IndexOf(Placeholder, StringComparison.Ordinal) >= 0;
+        }
+
+        public static Boolean TryResolvePath(String defaultFolder, String texturePath, out String safeTexturePath, out String displayTexturePath, out String error)
+        {
+            safeTexturePath = null;
+            displayTexturePath = texturePath;
+            error = null;
+            Int32 placeholderIndex = texturePath.IndexOf(Placeholder, StringComparison.Ordinal);
+            if (placeholderIndex < 0 || texturePath.IndexOf(Placeholder, placeholderIndex + Placeholder.Length, StringComparison.Ordinal) >= 0)
+            {
+                error = "the texture path must contain exactly one <UDIM> placeholder";
+                return false;
+            }
+            if (texturePath.IndexOf(SafePathPlaceholder, StringComparison.Ordinal) >= 0)
+            {
+                error = "the texture path contains a reserved UDIM path token";
+                return false;
+            }
+
+            try
+            {
+                String pathWithoutIllegalCharacters = texturePath.Replace(Placeholder, SafePathPlaceholder);
+                safeTexturePath = pathWithoutIllegalCharacters.Contains("/") ? pathWithoutIllegalCharacters : Path.Combine(defaultFolder, pathWithoutIllegalCharacters);
+                displayTexturePath = safeTexturePath.Replace(SafePathPlaceholder, Placeholder);
+                return true;
+            }
+            catch (Exception exception)
+            {
+                error = exception.Message;
+                return false;
+            }
+        }
+
+        public static Boolean TryCreate(String safeTexturePath, out FbxUdimTexture result, out String error)
+        {
+            result = null;
+            error = null;
+            List<UdimTile> tiles = new List<UdimTile>();
+            Texture2D atlas = null;
+
+            try
+            {
+                String folderPath = Path.GetDirectoryName(safeTexturePath);
+                String fileName = Path.GetFileName(safeTexturePath);
+                Int32 placeholderIndex = fileName.IndexOf(SafePathPlaceholder, StringComparison.Ordinal);
+                if (placeholderIndex < 0 || fileName.IndexOf(SafePathPlaceholder, placeholderIndex + SafePathPlaceholder.Length, StringComparison.Ordinal) >= 0)
+                {
+                    error = "the texture path must contain exactly one <UDIM> placeholder";
+                    return false;
+                }
+                if (String.IsNullOrEmpty(folderPath) || !Directory.Exists(folderPath))
+                {
+                    error = $"the texture folder '{folderPath}' does not exist";
+                    return false;
+                }
+
+                String prefix = fileName.Substring(0, placeholderIndex);
+                String suffix = fileName.Substring(placeholderIndex + SafePathPlaceholder.Length);
+                Dictionary<Int32, String> tilePaths = new Dictionary<Int32, String>();
+                foreach (String candidatePath in Directory.GetFiles(folderPath))
+                {
+                    String candidateName = Path.GetFileName(candidatePath);
+                    if (candidateName.Length != prefix.Length + 4 + suffix.Length ||
+                        !candidateName.StartsWith(prefix, StringComparison.Ordinal) ||
+                        !candidateName.EndsWith(suffix, StringComparison.Ordinal))
+                        continue;
+
+                    String numberText = candidateName.Substring(prefix.Length, 4);
+                    if (!Int32.TryParse(numberText, out Int32 tileNumber) || tileNumber < FirstTileNumber)
+                        continue;
+                    if (tilePaths.ContainsKey(tileNumber))
+                    {
+                        error = $"more than one file matches UDIM tile {tileNumber}";
+                        return false;
+                    }
+                    tilePaths.Add(tileNumber, candidatePath);
+                }
+                if (tilePaths.Count == 0)
+                {
+                    error = "no numbered UDIM tiles were found";
+                    return false;
+                }
+                if (!tilePaths.ContainsKey(FirstTileNumber))
+                {
+                    error = "UDIM tile 1001 is missing";
+                    return false;
+                }
+
+                Int32 maxColumn = 0;
+                Int32 maxRow = 0;
+                foreach (KeyValuePair<Int32, String> pair in tilePaths)
+                {
+                    Int32 tileIndex = pair.Key - FirstTileNumber;
+                    maxColumn = Math.Max(maxColumn, tileIndex % TilesPerRow);
+                    maxRow = Math.Max(maxRow, tileIndex / TilesPerRow);
+                }
+                Int32 columnCount = maxColumn + 1;
+                Int32 rowCount = maxRow + 1;
+                for (Int32 row = 0; row < rowCount; row++)
+                {
+                    for (Int32 column = 0; column < columnCount; column++)
+                    {
+                        Int32 tileNumber = FirstTileNumber + row * TilesPerRow + column;
+                        if (!tilePaths.ContainsKey(tileNumber))
+                        {
+                            error = $"UDIM tile {tileNumber} is missing; tiles must form a rectangle starting at 1001";
+                            return false;
+                        }
+                    }
+                }
+
+                Int32 tileWidth = 0;
+                Int32 tileHeight = 0;
+                List<Int32> tileNumbers = new List<Int32>(tilePaths.Keys);
+                tileNumbers.Sort();
+                foreach (Int32 tileNumber in tileNumbers)
+                {
+                    Byte[] raw = File.ReadAllBytes(tilePaths[tileNumber]);
+                    Texture2D tileTexture = AssetManager.LoadTextureGeneric(raw);
+                    if (tileTexture == null)
+                    {
+                        error = $"UDIM tile {tileNumber} is not a supported image";
+                        return false;
+                    }
+                    tiles.Add(new UdimTile(tileNumber, tileTexture));
+                    if (tileWidth == 0)
+                    {
+                        tileWidth = tileTexture.width;
+                        tileHeight = tileTexture.height;
+                    }
+                    else if (tileTexture.width != tileWidth || tileTexture.height != tileHeight)
+                    {
+                        Int32 incompatibleWidth = tileTexture.width;
+                        Int32 incompatibleHeight = tileTexture.height;
+                        error = $"UDIM tile {tileNumber} is {incompatibleWidth}x{incompatibleHeight}; expected {tileWidth}x{tileHeight}";
+                        return false;
+                    }
+                }
+
+                Int32 cellWidth = checked(tileWidth + GutterSize * 2);
+                Int32 cellHeight = checked(tileHeight + GutterSize * 2);
+                Int32 atlasWidth = checked(cellWidth * columnCount);
+                Int32 atlasHeight = checked(cellHeight * rowCount);
+                Int32 maximumTextureSize = SystemInfo.maxTextureSize;
+                if (maximumTextureSize > 0 && (atlasWidth > maximumTextureSize || atlasHeight > maximumTextureSize))
+                {
+                    error = $"the {atlasWidth}x{atlasHeight} UDIM atlas exceeds the maximum texture size {maximumTextureSize}";
+                    return false;
+                }
+
+                Color32[] atlasPixels = new Color32[checked(atlasWidth * atlasHeight)];
+                foreach (UdimTile tile in tiles)
+                {
+                    Int32 tileIndex = tile.Number - FirstTileNumber;
+                    Int32 column = tileIndex % TilesPerRow;
+                    Int32 row = tileIndex / TilesPerRow;
+                    Int32 originX = column * cellWidth + GutterSize;
+                    Int32 originY = row * cellHeight + GutterSize;
+                    Color32[] tilePixels = tile.Texture.GetPixels32();
+
+                    // Copy the tile and repeat its edge pixels into the gutter.
+                    for (Int32 y = -GutterSize; y < tileHeight + GutterSize; y++)
+                    {
+                        Int32 sourceY = Math.Max(0, Math.Min(tileHeight - 1, y));
+                        Int32 targetY = originY + y;
+                        for (Int32 x = -GutterSize; x < tileWidth + GutterSize; x++)
+                        {
+                            Int32 sourceX = Math.Max(0, Math.Min(tileWidth - 1, x));
+                            Int32 targetX = originX + x;
+                            atlasPixels[targetY * atlasWidth + targetX] = tilePixels[sourceY * tileWidth + sourceX];
+                        }
+                    }
+                }
+
+                atlas = new Texture2D(atlasWidth, atlasHeight, AssetManager.DefaultTextureFormat, false);
+                atlas.name = GetSafeTextureName(fileName);
+                atlas.wrapMode = TextureWrapMode.Clamp;
+                atlas.SetPixels32(atlasPixels);
+                atlas.Apply();
+                result = new FbxUdimTexture(atlas, tileWidth, tileHeight, columnCount, rowCount);
+                atlas = null;
+                return true;
+            }
+            catch (Exception exception)
+            {
+                error = exception.Message;
+                return false;
+            }
+            finally
+            {
+                foreach (UdimTile tile in tiles)
+                    UnityEngine.Object.Destroy(tile.Texture);
+                if (atlas != null)
+                    UnityEngine.Object.Destroy(atlas);
+            }
+        }
+
+        public Boolean TryRemapUVs(Vector2[] uvs, out String error)
+        {
+            error = null;
+            if (uvs == null)
+            {
+                error = "the mesh has no UV coordinates";
+                return false;
+            }
+
+            Single cellWidth = _tileWidth + GutterSize * 2;
+            Single cellHeight = _tileHeight + GutterSize * 2;
+            Single atlasWidth = cellWidth * _columnCount;
+            Single atlasHeight = cellHeight * _rowCount;
+            for (Int32 i = 0; i < uvs.Length; i++)
+            {
+                Vector2 uv = uvs[i];
+                if (!TryGetTileCoordinate(uv.x, _columnCount, out Int32 column, out Single localU) ||
+                    !TryGetTileCoordinate(uv.y, _rowCount, out Int32 row, out Single localV))
+                {
+                    error = $"UV {i} ({uv.x}, {uv.y}) is outside the discovered {_columnCount}x{_rowCount} UDIM layout";
+                    return false;
+                }
+                uv.x = (column * cellWidth + GutterSize + localU * _tileWidth) / atlasWidth;
+                uv.y = (row * cellHeight + GutterSize + localV * _tileHeight) / atlasHeight;
+                uvs[i] = uv;
+            }
+            return true;
+        }
+
+        public void Destroy()
+        {
+            if (Texture != null)
+            {
+                UnityEngine.Object.Destroy(Texture);
+                Texture = null;
+            }
+        }
+
+        private static Boolean TryGetTileCoordinate(Single value, Int32 tileCount, out Int32 coordinate, out Single localValue)
+        {
+            if (Single.IsNaN(value) || Single.IsInfinity(value))
+            {
+                coordinate = -1;
+                localValue = 0f;
+                return false;
+            }
+            coordinate = Mathf.FloorToInt(value);
+            localValue = value - coordinate;
+            if (coordinate == tileCount && Mathf.Approximately(localValue, 0f))
+            {
+                coordinate--;
+                localValue = 1f;
+            }
+            return coordinate >= 0 && coordinate < tileCount;
+        }
+
+        private static String GetSafeTextureName(String fileName)
+        {
+            String name = Path.GetFileNameWithoutExtension(fileName).Replace(SafePathPlaceholder, String.Empty).TrimEnd('.', '-', '_', ' ');
+            return String.IsNullOrEmpty(name) ? "UDIMAtlas" : name + "_UDIMAtlas";
+        }
+
+        private sealed class UdimTile
+        {
+            public readonly Int32 Number;
+            public readonly Texture2D Texture;
+
+            public UdimTile(Int32 number, Texture2D texture)
+            {
+                Number = number;
+                Texture = texture;
+            }
+        }
+
+        private readonly Int32 _tileWidth;
+        private readonly Int32 _tileHeight;
+        private readonly Int32 _columnCount;
+        private readonly Int32 _rowCount;
+    }
+}

--- a/Assembly-CSharp/Memoria/Assets/3DModel/FbxUdimTexture.cs
+++ b/Assembly-CSharp/Memoria/Assets/3DModel/FbxUdimTexture.cs
@@ -188,7 +188,7 @@ namespace Memoria.Assets
                     Int32 originY = row * cellHeight + GutterSize;
                     Color32[] tilePixels = tile.Texture.GetPixels32();
 
-                    // Copy the tile and repeat its edge pixels into the gutter.
+                    // Copies the tile and repeats its edge pixels into the gutter.
                     for (Int32 y = -GutterSize; y < tileHeight + GutterSize; y++)
                     {
                         Int32 sourceY = Math.Max(0, Math.Min(tileHeight - 1, y));
@@ -312,6 +312,13 @@ namespace Memoria.Assets
                 UnityEngine.Object.Destroy(Texture);
                 Texture = null;
             }
+        }
+
+        internal Texture2D TakeTexture()
+        {
+            Texture2D texture = Texture;
+            Texture = null;
+            return texture;
         }
 
         private static Boolean TryGetTileCoordinate(Single value, Int32 tileCount, out Int32 coordinate, out Single localValue)

--- a/Assembly-CSharp/Memoria/Assets/3DModel/FbxUdimTexture.cs
+++ b/Assembly-CSharp/Memoria/Assets/3DModel/FbxUdimTexture.cs
@@ -234,10 +234,6 @@ namespace Memoria.Assets
                 return false;
             }
 
-            Single cellWidth = _tileWidth + GutterSize * 2;
-            Single cellHeight = _tileHeight + GutterSize * 2;
-            Single atlasWidth = cellWidth * _columnCount;
-            Single atlasHeight = cellHeight * _rowCount;
             for (Int32 i = 0; i < uvs.Length; i++)
             {
                 Vector2 uv = uvs[i];
@@ -247,9 +243,64 @@ namespace Memoria.Assets
                     error = $"UV {i} ({uv.x}, {uv.y}) is outside the discovered {_columnCount}x{_rowCount} UDIM layout";
                     return false;
                 }
-                uv.x = (column * cellWidth + GutterSize + localU * _tileWidth) / atlasWidth;
-                uv.y = (row * cellHeight + GutterSize + localV * _tileHeight) / atlasHeight;
-                uvs[i] = uv;
+                uvs[i] = RemapUV(column, row, localU, localV);
+            }
+            return true;
+        }
+
+        public Boolean ContainsTile(Int32 tileNumber)
+        {
+            return TryGetTilePosition(tileNumber, out _, out _);
+        }
+
+        public Boolean TryPrepareBlinkUVs(Vector2[] sourceUVs, Int32 openTileNumber, Int32 closedTileNumber, out Vector2[] openUVs, out Vector2[] closedUVs, out Int32 blinkVertexCount, out String error)
+        {
+            openUVs = null;
+            closedUVs = null;
+            blinkVertexCount = 0;
+            error = null;
+            if (sourceUVs == null)
+            {
+                error = "the mesh has no UV coordinates";
+                return false;
+            }
+            if (!TryGetTilePosition(openTileNumber, out Int32 openColumn, out Int32 openRow))
+            {
+                error = $"open tile {openTileNumber} is unavailable in the discovered UDIM layout";
+                return false;
+            }
+            if (!TryGetTilePosition(closedTileNumber, out _, out _))
+            {
+                error = $"closed tile {closedTileNumber} is unavailable in the discovered UDIM layout";
+                return false;
+            }
+
+            openUVs = new Vector2[sourceUVs.Length];
+            closedUVs = new Vector2[sourceUVs.Length];
+            for (Int32 i = 0; i < sourceUVs.Length; i++)
+            {
+                Vector2 sourceUV = sourceUVs[i];
+                if (!TryGetTileCoordinate(sourceUV.x, _columnCount, out Int32 column, out Single localU) ||
+                    !TryGetTileCoordinate(sourceUV.y, _rowCount, out Int32 row, out Single localV))
+                {
+                    error = $"UV {i} ({sourceUV.x}, {sourceUV.y}) is outside the discovered {_columnCount}x{_rowCount} UDIM layout";
+                    openUVs = null;
+                    closedUVs = null;
+                    blinkVertexCount = 0;
+                    return false;
+                }
+
+                Vector2 atlasUV = RemapUV(column, row, localU, localV);
+                closedUVs[i] = atlasUV;
+                if (GetTileNumber(column, row) == closedTileNumber)
+                {
+                    openUVs[i] = RemapUV(openColumn, openRow, localU, localV);
+                    blinkVertexCount++;
+                }
+                else
+                {
+                    openUVs[i] = atlasUV;
+                }
             }
             return true;
         }
@@ -279,6 +330,36 @@ namespace Memoria.Assets
                 localValue = 1f;
             }
             return coordinate >= 0 && coordinate < tileCount;
+        }
+
+        private Boolean TryGetTilePosition(Int32 tileNumber, out Int32 column, out Int32 row)
+        {
+            Int32 tileIndex = tileNumber - FirstTileNumber;
+            if (tileIndex < 0)
+            {
+                column = -1;
+                row = -1;
+                return false;
+            }
+            column = tileIndex % TilesPerRow;
+            row = tileIndex / TilesPerRow;
+            return column < _columnCount && row < _rowCount;
+        }
+
+        private static Int32 GetTileNumber(Int32 column, Int32 row)
+        {
+            return FirstTileNumber + row * TilesPerRow + column;
+        }
+
+        private Vector2 RemapUV(Int32 column, Int32 row, Single localU, Single localV)
+        {
+            Single cellWidth = _tileWidth + GutterSize * 2;
+            Single cellHeight = _tileHeight + GutterSize * 2;
+            Single atlasWidth = cellWidth * _columnCount;
+            Single atlasHeight = cellHeight * _rowCount;
+            return new Vector2(
+                (column * cellWidth + GutterSize + localU * _tileWidth) / atlasWidth,
+                (row * cellHeight + GutterSize + localV * _tileHeight) / atlasHeight);
         }
 
         private static String GetSafeTextureName(String fileName)

--- a/Assembly-CSharp/Memoria/Assets/3DModel/ModelImporter.cs
+++ b/Assembly-CSharp/Memoria/Assets/3DModel/ModelImporter.cs
@@ -25,6 +25,8 @@ namespace Memoria.Assets
             public Vector2[][] uv;
             public String[] texturePath;
             public Texture2D[] textureAtlas;
+            public Vector2[][] blinkOpenUV;
+            public Vector2[][] blinkClosedUV;
         }
 
         private class CustomModelAnimated
@@ -162,11 +164,24 @@ namespace Memoria.Assets
                         }
                     }
                 }
+                Boolean validBlinkSetup = TryPrepareUdimBlink(geometries, materials, baseMesh.matIndex, texture.uv, udimTextures, out Boolean blinkRequested, out Vector2[][] blinkOpenUV, out Vector2[][] blinkClosedUV, out String blinkError);
+                if (blinkRequested && !validBlinkSetup)
+                    Log.Warning($"Cannot enable UDIM blinking for FBX '{completePath}': {blinkError}. The model will use static UDIM UVs.");
+                else if (blinkRequested)
+                {
+                    texture.blinkOpenUV = blinkOpenUV;
+                    texture.blinkClosedUV = blinkClosedUV;
+                }
                 for (Int32 i = 0; i < geometries.Count; i++)
                 {
                     Int32 materialIndex = baseMesh.matIndex[i];
                     if (materialIndex < 0 || materialIndex >= udimTextures.Length || udimTextures[materialIndex] == null)
                         continue;
+                    if (validBlinkSetup && blinkOpenUV?[i] != null)
+                    {
+                        texture.uv[i] = blinkOpenUV[i];
+                        continue;
+                    }
                     if (!udimTextures[materialIndex].TryRemapUVs(texture.uv[i], out String error))
                     {
                         DestroyUdimTextures(udimTextureCache.Values);
@@ -376,6 +391,8 @@ namespace Memoria.Assets
             Int32 meshCount = baseMesh.vert.Length;
             Int32 materialCount = baseMesh.shader.Length;
             Material[] materials = new Material[materialCount];
+            Mesh[] blinkMeshes = texture?.blinkOpenUV != null ? new Mesh[meshCount] : null;
+            SkinnedMeshRenderer[] blinkRenderers = texture?.blinkOpenUV != null ? new SkinnedMeshRenderer[meshCount] : null;
             Transform[] bones = null;
             Matrix4x4[] bindPoses = null;
             if (anim != null)
@@ -426,6 +443,8 @@ namespace Memoria.Assets
                 mesh.triangles = baseMesh.tri[i];
                 if (texture?.uv?[i] != null && texture.uv[i].Length == vCount)
                     mesh.uv = texture.uv[i];
+                if (blinkMeshes != null && texture.blinkOpenUV[i] != null)
+                    blinkMeshes[i] = mesh;
                 if (extra?.normal?[i] != null && extra.normal[i].Length == vCount)
                     mesh.normals = extra.normal[i];
                 if (extra?.tangent?[i] != null && extra.tangent[i].Length == vCount)
@@ -442,6 +461,8 @@ namespace Memoria.Assets
                 GameObject meshGo = new GameObject(meshName);
                 meshGo.transform.parent = baseObject.transform;
                 SkinnedMeshRenderer meshRenderer = meshGo.AddComponent<SkinnedMeshRenderer>();
+                if (blinkRenderers != null && texture.blinkOpenUV[i] != null)
+                    blinkRenderers[i] = meshRenderer;
                 if (baseMesh.matIndex[i] < 0 || baseMesh.matIndex[i] >= materialCount)
                     throw new IndexOutOfRangeException($"Model mesh: mesh {i} has invalid material index {baseMesh.matIndex[i]} (max is {materialCount - 1})");
                 meshRenderer.material = materials[baseMesh.matIndex[i]];
@@ -449,7 +470,85 @@ namespace Memoria.Assets
                 if (anim != null)
                     meshRenderer.bones = bones;
             }
+            if (blinkMeshes != null)
+                baseObject.AddComponent<FbxUdimBlink>().Initialize(blinkRenderers, blinkMeshes, texture.blinkOpenUV, texture.blinkClosedUV);
             return baseObject;
+        }
+
+        private static Boolean TryPrepareUdimBlink(List<FbxGeometry> geometries, List<FbxMaterial> materials, Int32[] materialIndices, Vector2[][] sourceUVs, FbxUdimTexture[] udimTextures, out Boolean requested, out Vector2[][] openUVs, out Vector2[][] closedUVs, out String error)
+        {
+            requested = false;
+            openUVs = null;
+            closedUVs = null;
+            error = null;
+
+            for (Int32 materialIndex = 0; materialIndex < materials.Count; materialIndex++)
+            {
+                FbxMaterial material = materials[materialIndex];
+                Boolean hasOpenTile = material.HasProperty(FbxMaterial.BlinkOpenUdimProperty);
+                Boolean hasClosedTile = material.HasProperty(FbxMaterial.BlinkClosedUdimProperty);
+                if (!hasOpenTile && !hasClosedTile)
+                    continue;
+
+                requested = true;
+                if (!hasOpenTile || !hasClosedTile)
+                {
+                    error = $"material {materialIndex} must define both {FbxMaterial.BlinkOpenUdimProperty} and {FbxMaterial.BlinkClosedUdimProperty}";
+                    return false;
+                }
+                if (!material.TryGetInt32Property(FbxMaterial.BlinkOpenUdimProperty, out Int32 openTileNumber) ||
+                    !material.TryGetInt32Property(FbxMaterial.BlinkClosedUdimProperty, out Int32 closedTileNumber))
+                {
+                    error = $"material {materialIndex} blink tile properties must be integers";
+                    return false;
+                }
+                if (openTileNumber == closedTileNumber)
+                {
+                    error = $"material {materialIndex} uses the same UDIM tile {openTileNumber} for open and closed eyes";
+                    return false;
+                }
+                FbxUdimTexture udimTexture = materialIndex < udimTextures.Length ? udimTextures[materialIndex] : null;
+                if (udimTexture == null)
+                {
+                    error = $"material {materialIndex} does not use a loaded UDIM texture";
+                    return false;
+                }
+                if (!udimTexture.ContainsTile(openTileNumber) || !udimTexture.ContainsTile(closedTileNumber))
+                {
+                    error = $"material {materialIndex} requests unavailable UDIM tiles {openTileNumber} and {closedTileNumber}";
+                    return false;
+                }
+
+                Int32 materialBlinkVertexCount = 0;
+                for (Int32 geometryIndex = 0; geometryIndex < geometries.Count; geometryIndex++)
+                {
+                    if (materialIndices[geometryIndex] != materialIndex)
+                        continue;
+
+                    if (!udimTexture.TryPrepareBlinkUVs(sourceUVs[geometryIndex], openTileNumber, closedTileNumber, out Vector2[] meshOpenUVs, out Vector2[] meshClosedUVs, out Int32 blinkVertexCount, out String meshError))
+                    {
+                        error = $"mesh '{geometries[geometryIndex].Name}' {meshError}";
+                        return false;
+                    }
+                    if (blinkVertexCount == 0)
+                        continue;
+
+                    if (openUVs == null)
+                    {
+                        openUVs = new Vector2[geometries.Count][];
+                        closedUVs = new Vector2[geometries.Count][];
+                    }
+                    openUVs[geometryIndex] = meshOpenUVs;
+                    closedUVs[geometryIndex] = meshClosedUVs;
+                    materialBlinkVertexCount += blinkVertexCount;
+                }
+                if (materialBlinkVertexCount == 0)
+                {
+                    error = $"material {materialIndex} has no UV vertices in closed UDIM tile {closedTileNumber}";
+                    return false;
+                }
+            }
+            return true;
         }
 
         private static String GetShaderPathFromType(String shaderType, Int32 mode)

--- a/Assembly-CSharp/Memoria/Assets/3DModel/ModelImporter.cs
+++ b/Assembly-CSharp/Memoria/Assets/3DModel/ModelImporter.cs
@@ -24,6 +24,7 @@ namespace Memoria.Assets
         {
             public Vector2[][] uv;
             public String[] texturePath;
+            public Texture2D[] textureAtlas;
         }
 
         private class CustomModelAnimated
@@ -68,6 +69,7 @@ namespace Memoria.Assets
                 baseMesh.vert = new Vector3[geometries.Count][];
                 baseMesh.tri = new Int32[geometries.Count][];
                 texture.uv = new Vector2[geometries.Count][];
+                texture.textureAtlas = new Texture2D[materials.Count];
                 anim.bw = new BoneWeight[geometries.Count][];
                 extra.normal = new Vector3[geometries.Count][];
                 extra.tangent = new Vector4[geometries.Count][];
@@ -118,11 +120,59 @@ namespace Memoria.Assets
                         anim.boneScale[i] = bone.Scale;
                     }
                 }
+                FbxUdimTexture[] udimTextures = new FbxUdimTexture[materials.Count];
+                String[] udimTexturePaths = new String[materials.Count];
+                Dictionary<String, FbxUdimTexture> udimTextureCache = new Dictionary<String, FbxUdimTexture>(StringComparer.Ordinal);
                 for (Int32 i = 0; i < materials.Count; i++)
                 {
                     baseMesh.shader[i] = materials[i].Shader;
                     if (materials[i].TexturePath != null)
-                        texture.texturePath[i] = AssetManager.UsePathWithDefaultFolder(folderPath, materials[i].TexturePath);
+                    {
+                        if (!FbxUdimTexture.IsUdimPath(materials[i].TexturePath))
+                        {
+                            texture.texturePath[i] = AssetManager.UsePathWithDefaultFolder(folderPath, materials[i].TexturePath);
+                        }
+                        else
+                        {
+                            if (!FbxUdimTexture.TryResolvePath(folderPath, materials[i].TexturePath, out String safeTexturePath, out String texturePath, out String pathError))
+                            {
+                                DestroyUdimTextures(udimTextureCache.Values);
+                                Log.Error($"Cannot import UDIM texture '{texturePath}' referenced by FBX '{completePath}': {pathError}");
+                                return null;
+                            }
+                            if (!hasTexture)
+                            {
+                                DestroyUdimTextures(udimTextureCache.Values);
+                                Log.Error($"Cannot import UDIM texture '{texturePath}' referenced by FBX '{completePath}': the model has no UV coordinates");
+                                return null;
+                            }
+                            if (!udimTextureCache.TryGetValue(safeTexturePath, out FbxUdimTexture udimTexture))
+                            {
+                                if (!FbxUdimTexture.TryCreate(safeTexturePath, out udimTexture, out String error))
+                                {
+                                    DestroyUdimTextures(udimTextureCache.Values);
+                                    Log.Error($"Cannot import UDIM texture '{texturePath}' referenced by FBX '{completePath}': {error}");
+                                    return null;
+                                }
+                                udimTextureCache.Add(safeTexturePath, udimTexture);
+                            }
+                            udimTextures[i] = udimTexture;
+                            udimTexturePaths[i] = texturePath;
+                            texture.textureAtlas[i] = udimTexture.Texture;
+                        }
+                    }
+                }
+                for (Int32 i = 0; i < geometries.Count; i++)
+                {
+                    Int32 materialIndex = baseMesh.matIndex[i];
+                    if (materialIndex < 0 || materialIndex >= udimTextures.Length || udimTextures[materialIndex] == null)
+                        continue;
+                    if (!udimTextures[materialIndex].TryRemapUVs(texture.uv[i], out String error))
+                    {
+                        DestroyUdimTextures(udimTextureCache.Values);
+                        Log.Error($"Cannot import UDIM texture '{udimTexturePaths[materialIndex]}' referenced by FBX '{completePath}': mesh '{geometries[i].Name}' {error}");
+                        return null;
+                    }
                 }
                 if (!hasTexture)
                     texture = null;
@@ -361,7 +411,9 @@ namespace Memoria.Assets
                 materials[i] = ShadersLoader.CreateShaderMaterial(GetShaderPathFromType(baseMesh.shader[i], PersistenSingleton<EventEngine>.Instance.gMode));
                 if (materials[i] == null)
                     throw new FileNotFoundException($"Unknown shader {baseMesh.shader[i]}");
-                if (!String.IsNullOrEmpty(texture?.texturePath?[i]))
+                if (texture?.textureAtlas?[i] != null)
+                    materials[i].mainTexture = texture.textureAtlas[i];
+                else if (!String.IsNullOrEmpty(texture?.texturePath?[i]))
                     materials[i].mainTexture = AssetManager.LoadFromDisc<Texture2D>(texture.texturePath[i]);
             }
             for (Int32 i = 0; i < meshCount; i++)
@@ -416,6 +468,12 @@ namespace Memoria.Assets
                 return (mode == 3 ? "WorldMap/SPS_Abr_" : "PSX/FieldSPS_Abr_") + abrType;
             }
             return shaderType;
+        }
+
+        private static void DestroyUdimTextures(IEnumerable<FbxUdimTexture> textures)
+        {
+            foreach (FbxUdimTexture texture in textures)
+                texture.Destroy();
         }
     }
 }

--- a/Assembly-CSharp/Memoria/Assets/3DModel/UdimTextureAtlas.cs
+++ b/Assembly-CSharp/Memoria/Assets/3DModel/UdimTextureAtlas.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using UnityEngine;
+
+namespace Memoria.Assets
+{
+    public static class UdimTextureAtlas
+    {
+        public static Boolean IsTemplatePath(String texturePath)
+        {
+            return FbxUdimTexture.IsUdimPath(texturePath);
+        }
+
+        /// <summary>Attempts to build an atlas to allow textures to be used as UDIM tiles.</summary>
+        public static Boolean TryBuild(String defaultFolder, String templatePath, out Texture2D atlas, out String atlasKey, out String error)
+        {
+            atlas = null;
+            atlasKey = null;
+            error = null;
+
+            if (!IsTemplatePath(templatePath))
+            {
+                error = "the texture path must contain a <UDIM> placeholder";
+                return false;
+            }
+            if (!FbxUdimTexture.TryResolvePath(defaultFolder, templatePath, out String safeTexturePath, out _, out error))
+                return false;
+            if (!FbxUdimTexture.TryCreate(safeTexturePath, out FbxUdimTexture udimTexture, out error))
+                return false;
+
+            try
+            {
+                atlas = udimTexture.TakeTexture();
+                if (atlas == null)
+                {
+                    error = "the UDIM atlas could not be created";
+                    return false;
+                }
+                atlasKey = atlas.name;
+                return true;
+            }
+            finally
+            {
+                udimTexture.Destroy();
+            }
+        }
+    }
+}

--- a/Assembly-CSharp/Memoria/Scripts/DefaultStatus/DeathStatusScript.cs
+++ b/Assembly-CSharp/Memoria/Scripts/DefaultStatus/DeathStatusScript.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Memoria.Assets;
 using Memoria.Data;
 using FF9;
 using Object = System.Object;
@@ -59,6 +60,7 @@ namespace Memoria.DefaultScripts
                 if (btl.bi.player != 0)
                     GeoTexAnim.geoTexAnimPlay(btl.tranceTexanimptr, 2);
             }
+            FbxUdimBlink.SetBattleEyesClosed(btl, false);
             if (!btl_util.IsBtlUsingCommand(btl, out CMD_DATA cmd) || !btl_util.IsCommandDeclarable(cmd.cmd_no))
                 btl.sel_mode = 0;
             foreach (BattleStatusId oprStatus in (Target.PermanentStatus & BattleStatusConst.OprCount & BattleStatusId.Death.GetStatData().ClearOnApply).ToStatusList())

--- a/Assembly-CSharp/Memoria/Scripts/ScriptsLoader.cs
+++ b/Assembly-CSharp/Memoria/Scripts/ScriptsLoader.cs
@@ -316,6 +316,10 @@ namespace Memoria.Scripts
                     throw new FileNotFoundException($"[ScriptsLoader] Cannot load Memoria.Scripts.dll because a file does not exist: [{mainDllPath}].", mainDllPath);
                 }
 
+                foreach (Result result in s_result)
+                    if (result.OverloadableMethodScripts.TryGetValue(typeof(IOverloadOnBattleInitScript), out Type scriptType))
+                        scriptType.GetConstructor(Type.EmptyTypes).Invoke(null);
+
                 BattleVoice.Initialize();
             }
             catch (Exception ex)


### PR DESCRIPTION
This PR adds a new capability to Memoria to handle UDIM textures which essentially use two texture files can be the same texture or two different textures like the example I will show below to move between to UV islands during the blink runtime. This is what I believe essential for custom models now that importing is possible because of the models not being configured the same way as the game. This feature allows the models to not only blink at a what I believe a normal increment, but also during certain scenes or events of the game where the eyes remain closed like Garnet being unconscious or being KO'd in battle. I will show the setup done in Blender in small clips and brief explanation of the steps.

This PR also includes a small snippet from DV's PR #1255 where he makes an adjustment to the ScriptLoader.cs which also allows for things in my upcoming mods and mod updates to do their runtimes at game startup rather than requiring opening and closing the party menu to activate it. Not required specifically for this feature, but for my upcoming Costume Pack version which will not apply costumes at startup unless it is in there.

Below you can see where I have the .png textures named as `NAME.1001.png` and `NAME.1002.png`. The 1001 is the Open eye state and the 1002 is the eyes closed state. Setting up the UDIM tiling is done in Blender's Shading tab and the texture name needs to be renamed to have the `<UDIM>` portion in it. The UDIM atlas is not limited to just two, you can create more tiles to also change textures as well.

[UDIM_Setup_1.webm](https://github.com/user-attachments/assets/361d485d-0fa5-47dd-9914-22d2b6c59f3a)

Under the meshes `Material Properties` you have to setup to custom properties that will be registering the blink runtime.

[UDIM_Setup_2.webm](https://github.com/user-attachments/assets/e1dbd03e-dbf9-449e-bf5c-ebad74914693)

In this section I am in edit mode for the model highlighting all of the portion of the mesh and the upper left pane mode is in UV Editor mode. I then go to the UV editor toggle the options to seleect all the faces I am tracking, and move it to the other texture where the eyes are closed. This is just one example and other custom models if using one texture or just the eyes want to be moved you can. It is crucial that the model is exported in the eyes closed state (1002) as this change maps back to the 1001 tile.

[UDIM_Setup_3.webm](https://github.com/user-attachments/assets/345377c7-e49a-44be-b727-51fbb205cd18)

This step is similar to typical exporting of the model, unchecking the `Add leaf bones` and everything, except now you need to check the `Custom Properties` field which was created in Step 2 above.

[UDIM_Setup_4.webm](https://github.com/user-attachments/assets/da57053e-4fc5-4311-b736-5e986acac7e8)

The three below is showing it in action with normal blinking, in a KO'd state, and Garnet being uncincous with eyes closed then opening them once she is wakes up.

[UDIM_Setup_5.webm](https://github.com/user-attachments/assets/44b04aa4-7388-4f66-a0c7-3f1324f6f293)

[UDIM_Setup_6.webm](https://github.com/user-attachments/assets/71f94224-dae0-4214-8d15-e09072413af2)

[UDIM_ClosedEyes_Blinking.webm](https://github.com/user-attachments/assets/563c3350-d2af-43a1-9e55-d323c88994f4)

This is also useful too when mods use more textures since this will naturally look for Zidane.<UDIM>.png files which my mod will be using too.