### PR TITLE
CI: Fix vcpkg nuget binarycache authentication

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   # VCPKG: Enable Binary Caching
-  VCPKG_BINARY_SOURCES: clear;nuget,github,readwrite
+  VCPKG_BINARY_SOURCES: "clear;nuget,github,${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && 'readwrite' || 'read' }}"
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   # VCPKG: Enable Binary Caching
-  VCPKG_BINARY_SOURCES: clear;nuget,github,readwrite
+  VCPKG_BINARY_SOURCES: "clear;nuget,github,${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && 'readwrite' || 'read' }}"
 
 jobs:
   release:


### PR DESCRIPTION
This PR addresses a new behavior that has changed on Github Action regards to vcpkg binary authentication. The token now given on pipelines that use the read permission are no more silently refusing to do the push action when trying to authenticate for it. Instead now they error directly ( see https://github.com/Albeoris/Memoria/actions/runs/32399305492/job/96523420004?pr=1464 as an example ).

The fix is to use a different policy to authenticate based on the ref of the commit that triggered the action:
- Readonly for PRs, feature branches, etc.
- Readwrite for commits on main, merges, tags

This will fix again CI jobs triggered by PRs.

Any question feel free to ask.