### PR TITLE
Support controller in Launcher

### DIFF
--- a/Memoria.Launcher.Tests/Controller/ControllerButtonRepeaterTests.cs
+++ b/Memoria.Launcher.Tests/Controller/ControllerButtonRepeaterTests.cs
@@ -1,0 +1,33 @@
+using Memoria.Launcher.Controller;
+using Xunit;
+
+namespace Memoria.Launcher.Tests.Controller;
+
+public sealed class ControllerButtonRepeaterTests
+{
+    private static readonly TimeSpan InitialDelay = TimeSpan.FromMilliseconds(350);
+    private static readonly TimeSpan RepeatInterval = TimeSpan.FromMilliseconds(90);
+
+    [Fact]
+    public void Update_EmitsButtonOnlyOnPressEdge()
+    {
+        ControllerButtonRepeater repeater = new ControllerButtonRepeater(InitialDelay, RepeatInterval);
+
+        Assert.Equal(ControllerButton.Confirm, repeater.Update(ControllerButton.Confirm, TimeSpan.Zero));
+        Assert.Equal(ControllerButton.None, repeater.Update(ControllerButton.Confirm, TimeSpan.FromSeconds(1)));
+        Assert.Equal(ControllerButton.None, repeater.Update(ControllerButton.None, TimeSpan.FromSeconds(2)));
+        Assert.Equal(ControllerButton.Confirm, repeater.Update(ControllerButton.Confirm, TimeSpan.FromSeconds(3)));
+    }
+
+    [Fact]
+    public void Update_RepeatsDirectionsAfterDelay()
+    {
+        ControllerButtonRepeater repeater = new ControllerButtonRepeater(InitialDelay, RepeatInterval);
+
+        Assert.Equal(ControllerButton.Down, repeater.Update(ControllerButton.Down, TimeSpan.Zero));
+        Assert.Equal(ControllerButton.None, repeater.Update(ControllerButton.Down, InitialDelay - TimeSpan.FromMilliseconds(1)));
+        Assert.Equal(ControllerButton.Down, repeater.Update(ControllerButton.Down, InitialDelay));
+        Assert.Equal(ControllerButton.None, repeater.Update(ControllerButton.Down, InitialDelay + RepeatInterval - TimeSpan.FromMilliseconds(1)));
+        Assert.Equal(ControllerButton.Down, repeater.Update(ControllerButton.Down, InitialDelay + RepeatInterval));
+    }
+}

--- a/Memoria.Launcher.Tests/Controller/SpatialNavigationTests.cs
+++ b/Memoria.Launcher.Tests/Controller/SpatialNavigationTests.cs
@@ -1,0 +1,103 @@
+using Memoria.Launcher.Controller;
+using Xunit;
+
+namespace Memoria.Launcher.Tests.Controller;
+
+public sealed class SpatialNavigationTests
+{
+    [Fact]
+    public void FindNext_PrefersAlignedControlOverCloserDiagonalControl()
+    {
+        NavigationRectangle origin = Rect(100, 100);
+        SpatialNavigationCandidate<String> aligned = Candidate("aligned", 100, 220);
+        SpatialNavigationCandidate<String> diagonal = Candidate("diagonal", 220, 150);
+
+        SpatialNavigationCandidate<String>? result = SpatialNavigation.FindNext(origin, new[] { diagonal, aligned }, NavigationDirection.Down);
+
+        Assert.NotNull(result);
+        Assert.Equal("aligned", result.Value);
+    }
+
+    [Fact]
+    public void FindNext_OnlyConsidersControlsInRequestedHalfPlane()
+    {
+        NavigationRectangle origin = Rect(100, 100);
+        SpatialNavigationCandidate<String> left = Candidate("left", 0, 100);
+        SpatialNavigationCandidate<String> right = Candidate("right", 200, 100);
+
+        SpatialNavigationCandidate<String>? result = SpatialNavigation.FindNext(origin, new[] { left, right }, NavigationDirection.Right);
+
+        Assert.NotNull(result);
+        Assert.Equal("right", result.Value);
+    }
+
+    [Fact]
+    public void FindNext_ReturnsNullWhenThereIsNoControlInDirection()
+    {
+        NavigationRectangle origin = Rect(100, 100);
+        SpatialNavigationCandidate<String> above = Candidate("above", 100, 0);
+
+        Assert.Null(SpatialNavigation.FindNext(origin, new[] { above }, NavigationDirection.Down));
+    }
+
+    [Fact]
+    public void FindNext_HorizontalNavigationIgnoresOffsetControlInSameColumn()
+    {
+        NavigationRectangle origin = new NavigationRectangle(100, 100, 120, 30);
+        SpatialNavigationCandidate<String> sameColumnBelow = new SpatialNavigationCandidate<string>(
+            "same-column",
+            new NavigationRectangle(110, 160, 140, 30));
+        
+        SpatialNavigationCandidate<String> actualRightNeighbour = new SpatialNavigationCandidate<string>(
+            "right",
+            new NavigationRectangle(280, 105, 80, 30));
+
+        SpatialNavigationCandidate<String>? result = SpatialNavigation.FindNext(
+            origin,
+            new[] { sameColumnBelow, actualRightNeighbour },
+            NavigationDirection.Right);
+
+        Assert.NotNull(result);
+        Assert.Equal("right", result.Value);
+    }
+
+    [Fact]
+    public void FindNext_HorizontalNavigationDoesNothingWithoutEdgeSeparatedNeighbour()
+    {
+        NavigationRectangle origin = new NavigationRectangle(100, 100, 120, 30);
+        SpatialNavigationCandidate<String> overlappingBelow = new SpatialNavigationCandidate<string>(
+            "overlapping",
+            new NavigationRectangle(180, 160, 80, 30));
+
+        Assert.Null(SpatialNavigation.FindNext(
+            origin,
+            new[] { overlappingBelow },
+            NavigationDirection.Right));
+    }
+
+    [Fact]
+    public void FindNext_VerticalNavigationIgnoresOverlappingControlInSameRow()
+    {
+        NavigationRectangle origin = new NavigationRectangle(100, 100, 80, 50);
+        SpatialNavigationCandidate<String> overlappingSameRow = new SpatialNavigationCandidate<string>(
+            "same-row",
+            new NavigationRectangle(0, 110, 80, 50));
+        
+        SpatialNavigationCandidate<String> actualLowerNeighbour = new SpatialNavigationCandidate<string>(
+            "below",
+            new NavigationRectangle(100, 200, 80, 30));
+
+        SpatialNavigationCandidate<String>? result = SpatialNavigation.FindNext(
+            origin,
+            new[] { overlappingSameRow, actualLowerNeighbour },
+            NavigationDirection.Down);
+
+        Assert.NotNull(result);
+        Assert.Equal("below", result.Value);
+    }
+
+    private static SpatialNavigationCandidate<string> Candidate(string value, double x, double y) =>
+        new(value, Rect(x, y));
+
+    private static NavigationRectangle Rect(double x, double y) => new(x, y, 80, 30);
+}

--- a/Memoria.Launcher.Tests/Memoria.Launcher.Tests.csproj
+++ b/Memoria.Launcher.Tests/Memoria.Launcher.Tests.csproj
@@ -23,6 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Memoria.Launcher\Controller\ControllerInput.cs"
+             Link="Production\Controller\ControllerInput.cs" />
+    <Compile Include="..\Memoria.Launcher\Controller\SpatialNavigation.cs"
+             Link="Production\Controller\SpatialNavigation.cs" />
     <Compile Include="..\Memoria.Launcher\Utils\ExceptionDetailsFormatter.cs"
              Link="Production\ExceptionDetailsFormatter.cs" />
     <Compile Include="..\Memoria.Launcher\Utils\Archives\ArchiveEntryPathPolicy.cs"

--- a/Memoria.Launcher/Controller/ControllerControlInteractor.cs
+++ b/Memoria.Launcher/Controller/ControllerControlInteractor.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Windows;
+using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+using System.Windows.Threading;
+
+namespace Memoria.Launcher.Controller
+{
+    /// <summary>
+    /// Applies controller actions to standard WPF controls and owns temporary
+    /// editing sessions such as an open ComboBox or an active Slider.
+    /// </summary>
+    internal sealed class ControllerControlInteractor : IDisposable
+    {
+        private readonly Window _window;
+        private readonly ControllerFocusManager _focus;
+        private ComboBox _openComboBox;
+        private Int32 _openComboBoxInitialIndex;
+        private UIElement _suppressedComboBoxPopupContent;
+        private Boolean _popupContentWasHitTestVisible;
+        private Slider _activeSlider;
+
+        public ControllerControlInteractor(Window window, ControllerFocusManager focus)
+        {
+            _window = window ?? throw new ArgumentNullException(nameof(window));
+            _focus = focus ?? throw new ArgumentNullException(nameof(focus));
+            _focus.FocusChanging += OnFocusChanging;
+        }
+
+        public Boolean IsEditing(Control control) => ReferenceEquals(control, _activeSlider);
+
+        public Control GetFocusedControlOverride(FrameworkElement scope)
+        {
+            return _openComboBox != null && _openComboBox.IsDropDownOpen &&
+                   VisualTree.IsDescendantOf(_openComboBox, scope)
+                ? _openComboBox
+                : null;
+        }
+
+        public Boolean HandleEditingAction(ControllerButton actions)
+        {
+            if (_activeSlider == null)
+                return false;
+            if (!_activeSlider.IsVisible || !_activeSlider.IsEnabled)
+            {
+                _activeSlider = null;
+                return false;
+            }
+
+            if ((actions & (ControllerButton.Confirm | ControllerButton.Cancel)) != 0)
+                EndSliderEditing();
+            else if ((actions & ControllerButton.Left) != 0)
+                AdjustSlider(_activeSlider, -1);
+            else if ((actions & ControllerButton.Right) != 0)
+                AdjustSlider(_activeSlider, 1);
+
+            // Slider editing captures all directional actions until A or B.
+            return true;
+        }
+
+        public Boolean TryHandleDirection(Control current, NavigationDirection direction)
+        {
+            if (current is ComboBox comboBox && comboBox.IsDropDownOpen &&
+                (direction == NavigationDirection.Up || direction == NavigationDirection.Down))
+            {
+                ChangeSelection(comboBox, direction == NavigationDirection.Up ? -1 : 1);
+                return true;
+            }
+
+            if (current is ListBox list &&
+                (direction == NavigationDirection.Up || direction == NavigationDirection.Down))
+            {
+                Int32 nextIndex = list.SelectedIndex < 0
+                    ? direction == NavigationDirection.Up ? list.Items.Count - 1 : 0
+                    : list.SelectedIndex + (direction == NavigationDirection.Up ? -1 : 1);
+                if (nextIndex < 0 || nextIndex >= list.Items.Count)
+                    return false;
+
+                list.SelectedIndex = nextIndex;
+                list.ScrollIntoView(list.SelectedItem);
+                return true;
+            }
+
+            if (current is RichTextBox richText && richText.IsReadOnly &&
+                (direction == NavigationDirection.Up || direction == NavigationDirection.Down))
+            {
+                ScrollViewer viewer = VisualTree.FindDescendant<ScrollViewer>(richText);
+                if (viewer == null)
+                    return false;
+
+                if (direction == NavigationDirection.Up)
+                    viewer.LineUp();
+                else
+                    viewer.LineDown();
+                return true;
+            }
+
+            return false;
+        }
+
+        public void Activate(Control current)
+        {
+            if (GamepadNavigation.RaiseActivated(current))
+                return;
+
+            if (current is Slider slider)
+            {
+                _activeSlider = slider;
+                _focus.ShowControllerAppearance(slider, true);
+                return;
+            }
+
+            if (current is TextBox textBox && !textBox.IsReadOnly)
+            {
+                if (_window.Content is Panel root)
+                    root.Children.Add(new ControllerTextInputOverlay(textBox));
+                return;
+            }
+
+            if (current is ComboBox comboBox)
+            {
+                ToggleComboBox(comboBox);
+                return;
+            }
+
+            if (current is TabItem tab)
+            {
+                tab.IsSelected = true;
+                return;
+            }
+
+            if (current is ToggleButton toggle)
+            {
+                ControllerControlInvoker.Toggle(toggle);
+                return;
+            }
+
+            if (current is Button button)
+                ControllerControlInvoker.Invoke(button);
+        }
+
+        public Boolean TryCancel()
+        {
+            if (_activeSlider != null)
+            {
+                EndSliderEditing();
+                return true;
+            }
+
+            if (_openComboBox == null || !_openComboBox.IsDropDownOpen)
+                return false;
+
+            _openComboBox.SelectedIndex = _openComboBoxInitialIndex;
+            _openComboBox.IsDropDownOpen = false;
+            RestoreComboBoxPointerInput();
+            _openComboBox = null;
+            return true;
+        }
+
+        public void EndSliderEditing()
+        {
+            if (_activeSlider == null)
+                return;
+
+            Slider slider = _activeSlider;
+            _activeSlider = null;
+            _focus.ShowControllerAppearance(slider, false);
+        }
+
+        public void RestorePointerInput() => RestoreComboBoxPointerInput();
+
+        public void Dispose()
+        {
+            _focus.FocusChanging -= OnFocusChanging;
+            RestoreComboBoxPointerInput();
+            _activeSlider = null;
+            _openComboBox = null;
+        }
+
+        private void OnFocusChanging(Control control)
+        {
+            if (_openComboBox != null && !ReferenceEquals(_openComboBox, control))
+            {
+                _openComboBox.IsDropDownOpen = false;
+                RestoreComboBoxPointerInput();
+                _openComboBox = null;
+            }
+
+            if (_activeSlider != null && !ReferenceEquals(_activeSlider, control))
+                _activeSlider = null;
+
+            if (control is ListBox list && list.SelectedIndex < 0 && list.Items.Count > 0)
+            {
+                list.SelectedIndex = 0;
+                list.ScrollIntoView(list.SelectedItem);
+            }
+        }
+
+        private void ToggleComboBox(ComboBox comboBox)
+        {
+            if (!comboBox.IsDropDownOpen)
+            {
+                _openComboBox = comboBox;
+                _openComboBoxInitialIndex = comboBox.SelectedIndex;
+            }
+
+            comboBox.IsDropDownOpen = !comboBox.IsDropDownOpen;
+            if (!comboBox.IsDropDownOpen)
+            {
+                RestoreComboBoxPointerInput();
+                _openComboBox = null;
+                return;
+            }
+
+            comboBox.Dispatcher.BeginInvoke(
+                DispatcherPriority.Input,
+                new Action(() => SuppressComboBoxPointerInput(comboBox)));
+        }
+
+        private static void AdjustSlider(Slider slider, Int32 direction)
+        {
+            Double change = slider.TickFrequency > 0.0 ? slider.TickFrequency : slider.SmallChange;
+            if (change <= 0.0)
+                change = Math.Max((slider.Maximum - slider.Minimum) / 20.0, 1.0);
+            slider.Value = Math.Max(slider.Minimum, Math.Min(slider.Maximum, slider.Value + direction * change));
+        }
+
+        private static void ChangeSelection(Selector selector, Int32 offset)
+        {
+            if (selector.Items.Count == 0)
+                return;
+
+            Int32 index = selector.SelectedIndex < 0 ? 0 : selector.SelectedIndex + offset;
+            selector.SelectedIndex = Math.Max(0, Math.Min(selector.Items.Count - 1, index));
+        }
+
+        private void SuppressComboBoxPointerInput(ComboBox comboBox)
+        {
+            if (!GamepadNavigation.IsControllerInputActive(_window) || !comboBox.IsDropDownOpen)
+                return;
+
+            comboBox.ApplyTemplate();
+            UIElement content = comboBox.Template.FindName("PART_Popup", comboBox) is Popup popup
+                ? popup.Child
+                : null;
+            if (content == null)
+                return;
+
+            RestoreComboBoxPointerInput();
+            _suppressedComboBoxPopupContent = content;
+            _popupContentWasHitTestVisible = content.IsHitTestVisible;
+            content.IsHitTestVisible = false;
+            Mouse.OverrideCursor = Cursors.None;
+        }
+
+        private void RestoreComboBoxPointerInput()
+        {
+            if (_suppressedComboBoxPopupContent == null)
+                return;
+
+            _suppressedComboBoxPopupContent.IsHitTestVisible = _popupContentWasHitTestVisible;
+            _suppressedComboBoxPopupContent = null;
+        }
+    }
+
+    internal static class ControllerControlInvoker
+    {
+        public static void Invoke(Button button)
+        {
+            if (new ButtonAutomationPeer(button).GetPattern(PatternInterface.Invoke) is IInvokeProvider provider)
+                provider.Invoke();
+            else
+                button.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent, button));
+        }
+
+        public static void Toggle(ToggleButton button)
+        {
+            if (new ToggleButtonAutomationPeer(button).GetPattern(PatternInterface.Toggle) is IToggleProvider provider)
+                provider.Toggle();
+            else
+                button.IsChecked = button.IsChecked != true;
+        }
+    }
+}

--- a/Memoria.Launcher/Controller/ControllerFocusManager.cs
+++ b/Memoria.Launcher/Controller/ControllerFocusManager.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace Memoria.Launcher.Controller
+{
+    /// <summary>
+    /// Owns the visual and keyboard focus used while controller input is active.
+    /// </summary>
+    internal sealed class ControllerFocusManager : IDisposable
+    {
+        private ControllerFocusAdorner _adorner;
+        private Control _focusVisualOwner;
+        private Object _previousFocusVisualStyle;
+        private Boolean _controllerAppearanceActive;
+
+        public ControllerFocusManager(Window window)
+        {
+            if (window == null)
+                throw new ArgumentNullException(nameof(window));
+        }
+
+        public event Action<Control> FocusChanging;
+        public event Action<Control> Focused;
+
+        public void Focus(Control control)
+        {
+            if (control == null)
+                return;
+
+            if (!control.Focusable && GamepadNavigation.GetParticipation(control) == NavigationParticipation.Include)
+                control.Focusable = true;
+
+            ApplyControllerFocusVisualStyle(control);
+            if (!control.Focus())
+            {
+                RestoreFocusVisualStyle();
+                return;
+            }
+
+            FocusChanging?.Invoke(control);
+            control.BringIntoView();
+            ShowControllerAppearance(control, false);
+            Focused?.Invoke(control);
+        }
+
+        public void EnsureControllerAppearance(Control control, Boolean isEditing)
+        {
+            if (_controllerAppearanceActive && ReferenceEquals(_focusVisualOwner, control))
+                return;
+
+            ApplyControllerFocusVisualStyle(control);
+            ShowControllerAppearance(control, isEditing);
+        }
+
+        public void ShowControllerAppearance(Control control, Boolean isEditing)
+        {
+            RemoveAdorner();
+            AdornerLayer layer = AdornerLayer.GetAdornerLayer(control);
+            if (layer != null)
+            {
+                _adorner = new ControllerFocusAdorner(control, isEditing);
+                layer.Add(_adorner);
+            }
+
+            _controllerAppearanceActive = true;
+        }
+
+        public void DeactivateControllerAppearance(Boolean clearKeyboardFocus)
+        {
+            RemoveAdorner();
+            RestoreFocusVisualStyle();
+            _controllerAppearanceActive = false;
+            if (clearKeyboardFocus)
+                Keyboard.ClearFocus();
+        }
+
+        public void Dispose()
+        {
+            DeactivateControllerAppearance(false);
+            FocusChanging = null;
+            Focused = null;
+        }
+
+        private void ApplyControllerFocusVisualStyle(Control control)
+        {
+            if (ReferenceEquals(_focusVisualOwner, control))
+                return;
+
+            RestoreFocusVisualStyle();
+            _focusVisualOwner = control;
+            _previousFocusVisualStyle = control.ReadLocalValue(FrameworkElement.FocusVisualStyleProperty);
+            control.SetValue(FrameworkElement.FocusVisualStyleProperty, null);
+        }
+
+        private void RestoreFocusVisualStyle()
+        {
+            if (_focusVisualOwner == null)
+                return;
+
+            if (_previousFocusVisualStyle == DependencyProperty.UnsetValue)
+                _focusVisualOwner.ClearValue(FrameworkElement.FocusVisualStyleProperty);
+            else
+                _focusVisualOwner.SetValue(FrameworkElement.FocusVisualStyleProperty, _previousFocusVisualStyle);
+
+            _focusVisualOwner = null;
+            _previousFocusVisualStyle = null;
+        }
+
+        private void RemoveAdorner()
+        {
+            if (_adorner == null)
+                return;
+
+            AdornerLayer layer = AdornerLayer.GetAdornerLayer(_adorner.AdornedElement);
+            if (layer != null)
+                layer.Remove(_adorner);
+            _adorner = null;
+        }
+    }
+
+    internal sealed class ControllerFocusAdorner : Adorner
+    {
+        private readonly Pen _pen;
+
+        public ControllerFocusAdorner(UIElement adornedElement, Boolean isEditing)
+            : base(adornedElement)
+        {
+            IsHitTestVisible = false;
+            _pen = new Pen(isEditing ? Brushes.Gold : Brushes.DeepSkyBlue, isEditing ? 4.0 : 3.0);
+            _pen.Freeze();
+        }
+
+        protected override void OnRender(DrawingContext drawingContext)
+        {
+            Double inset = _pen.Thickness / 2.0;
+            Rect bounds = new Rect(
+                inset,
+                inset,
+                Math.Max(0.0, AdornedElement.RenderSize.Width - _pen.Thickness),
+                Math.Max(0.0, AdornedElement.RenderSize.Height - _pen.Thickness));
+            drawingContext.DrawRoundedRectangle(null, _pen, bounds, 4.0, 4.0);
+        }
+    }
+}

--- a/Memoria.Launcher/Controller/ControllerFocusNavigator.cs
+++ b/Memoria.Launcher/Controller/ControllerFocusNavigator.cs
@@ -1,0 +1,324 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace Memoria.Launcher.Controller
+{
+    /// <summary>
+    /// Finds controller navigation targets and moves focus between them.
+    /// </summary>
+    internal sealed class ControllerFocusNavigator
+    {
+        private readonly Window _window;
+        private readonly ControllerFocusManager _focus;
+
+        public ControllerFocusNavigator(Window window, ControllerFocusManager focus)
+        {
+            _window = window ?? throw new ArgumentNullException(nameof(window));
+            _focus = focus ?? throw new ArgumentNullException(nameof(focus));
+        }
+
+        public FrameworkElement FindActiveScope()
+        {
+            return VisualTree.Enumerate<FrameworkElement>(_window)
+                       .LastOrDefault(element => element.IsVisible && GamepadNavigation.GetIsModalScope(element))
+                   ?? (FrameworkElement)_window;
+        }
+
+        public Control FindFocusedControl(FrameworkElement scope)
+        {
+            if (Keyboard.FocusedElement is not DependencyObject focused ||
+                !VisualTree.IsDescendantOf(focused, scope))
+            {
+                return null;
+            }
+
+            ListBox ownerList = VisualTree.FindAncestor<ListBox>(focused, true);
+            if (ownerList != null && VisualTree.IsDescendantOf(ownerList, scope))
+                return ownerList;
+
+            Control control = VisualTree.FindAncestor<Control>(focused, true);
+            return control != null && IsNavigationCandidate(control) ? control : null;
+        }
+
+        public void FocusInitialControl(FrameworkElement scope)
+        {
+            List<Control> controls = GetCandidates(scope).ToList();
+            if (controls.Count == 0)
+                return;
+
+            Control target = controls.FirstOrDefault(GamepadNavigation.GetIsDefaultFocus)
+                          ?? controls.OrderBy(control => GetBounds(control).Top)
+                                     .ThenBy(control => GetBounds(control).Left)
+                                     .First();
+            _focus.Focus(target);
+        }
+
+        public void Move(FrameworkElement scope, Control current, NavigationDirection direction)
+        {
+            if (TryNavigateTab(current, direction))
+                return;
+
+            if (current is not TabItem && MoveWithinSelectedTab(current, direction))
+                return;
+
+            NavigationRectangle currentBounds = GetBounds(current);
+            IEnumerable<SpatialNavigationCandidate<Control>> candidates = GetCandidates(scope)
+                .Where(control => !ReferenceEquals(control, current))
+                .Select(control => new SpatialNavigationCandidate<Control>(control, GetBounds(control)));
+
+            SpatialNavigationCandidate<Control> next = SpatialNavigation.FindNext(currentBounds, candidates, direction);
+            if (next != null)
+                _focus.Focus(ResolveVerticalTabEntry(next.Value, direction));
+        }
+
+        public void Cancel(FrameworkElement scope, Control current)
+        {
+            if (GamepadNavigation.GetIsModalScope(scope))
+            {
+                Button cancel = GetCandidates(scope)
+                    .OfType<Button>()
+                    .FirstOrDefault(GamepadNavigation.GetIsCancelAction);
+                if (cancel != null)
+                    ControllerControlInvoker.Invoke(cancel);
+                return;
+            }
+
+            TabControl tabControl = FindNearestTabControl(current);
+            if (tabControl == null)
+                return;
+
+            if (tabControl.SelectedItem is TabItem selectedTab && !ReferenceEquals(current, selectedTab))
+            {
+                _focus.Focus(selectedTab);
+                return;
+            }
+
+            TabControl parent = FindNearestTabControl(VisualTree.GetParent(tabControl));
+            if (parent?.SelectedItem is TabItem parentSelectedTab)
+                _focus.Focus(parentSelectedTab);
+        }
+
+        public void SwitchTab(FrameworkElement scope, Control current, Int32 offset, Boolean root)
+        {
+            TabControl tabControl = root ? FindRootTabControl(scope) : FindNearestTabControl(current);
+            ChangeSelectedTab(tabControl ?? FindRootTabControl(scope), offset);
+        }
+
+        private NavigationRectangle GetBounds(FrameworkElement element)
+        {
+            try
+            {
+                GeneralTransform transform = element.TransformToAncestor(_window);
+                Rect bounds = transform.TransformBounds(new Rect(0.0, 0.0, element.ActualWidth, element.ActualHeight));
+                return new NavigationRectangle(bounds.X, bounds.Y, bounds.Width, bounds.Height);
+            }
+            catch (InvalidOperationException)
+            {
+                return new NavigationRectangle(0.0, 0.0, element.ActualWidth, element.ActualHeight);
+            }
+        }
+
+        private Boolean TryNavigateTab(Control current, NavigationDirection direction)
+        {
+            if (current is not TabItem tab)
+                return false;
+
+            if (direction == NavigationDirection.Down && tab.IsSelected && MoveIntoSelectedTab(tab))
+                return true;
+
+            if (direction != NavigationDirection.Left && direction != NavigationDirection.Right)
+                return false;
+
+            if (ItemsControl.ItemsControlFromItemContainer(tab) is TabControl owner)
+            {
+                ChangeSelectedTab(owner, direction == NavigationDirection.Left ? -1 : 1);
+                return true;
+            }
+
+            return false;
+        }
+
+        private Boolean MoveWithinSelectedTab(Control current, NavigationDirection direction)
+        {
+            TabControl owner = FindNearestTabControl(current);
+            TabItem selectedTab = owner?.SelectedItem as TabItem;
+            FrameworkElement content = selectedTab?.Content as FrameworkElement;
+            if (content == null || !VisualTree.IsDescendantOf(current, content))
+                return false;
+
+            NavigationRectangle currentBounds = GetBounds(current);
+            IEnumerable<SpatialNavigationCandidate<Control>> candidates = GetCandidates(content)
+                .Where(control => !ReferenceEquals(control, current))
+                .Select(control => new SpatialNavigationCandidate<Control>(control, GetBounds(control)));
+            SpatialNavigationCandidate<Control> next = SpatialNavigation.FindNext(currentBounds, candidates, direction);
+            if (next != null)
+            {
+                _focus.Focus(ResolveVerticalTabEntry(next.Value, direction));
+                return true;
+            }
+
+            if (direction == NavigationDirection.Up)
+                _focus.Focus(selectedTab);
+
+            // Page edges are closed so focus cannot leak into another tab's content.
+            return true;
+        }
+
+        private Boolean MoveIntoSelectedTab(TabItem tab)
+        {
+            if (tab.Content is not FrameworkElement content)
+                return false;
+
+            TabItem selectedNestedTab = VisualTree.Enumerate<TabControl>(content)
+                .Where(owner => owner.IsVisible && owner.IsEnabled && owner.Items.Count > 1)
+                .OrderBy(VisualTree.GetDepth)
+                .Select(owner => owner.SelectedItem as TabItem)
+                .FirstOrDefault(candidate => candidate != null && IsNavigationCandidate(candidate));
+
+            if (selectedNestedTab != null)
+            {
+                _focus.Focus(selectedNestedTab);
+                return true;
+            }
+
+            List<Control> controls = GetCandidates(content).ToList();
+            if (controls.Count == 0)
+                return false;
+
+            NavigationRectangle tabBounds = GetBounds(tab);
+            IEnumerable<SpatialNavigationCandidate<Control>> candidates = controls.Select(control =>
+                new SpatialNavigationCandidate<Control>(control, GetBounds(control)));
+            SpatialNavigationCandidate<Control> next = SpatialNavigation.FindNext(
+                tabBounds, candidates, NavigationDirection.Down);
+
+            Control target = next?.Value
+                          ?? controls.OrderBy(control => GetBounds(control).Top)
+                                     .ThenBy(control => Math.Abs(GetBounds(control).CenterX - tabBounds.CenterX))
+                                     .First();
+            _focus.Focus(ResolveVerticalTabEntry(target, NavigationDirection.Down));
+            return true;
+        }
+
+        private static Control ResolveVerticalTabEntry(Control candidate, NavigationDirection direction)
+        {
+            if (direction != NavigationDirection.Up && direction != NavigationDirection.Down)
+                return candidate;
+            if (candidate is not TabItem tab)
+                return candidate;
+
+            TabControl owner = ItemsControl.ItemsControlFromItemContainer(tab) as TabControl;
+            return owner?.SelectedItem as TabItem ?? tab;
+        }
+
+        private IEnumerable<Control> GetCandidates(FrameworkElement scope) =>
+            VisualTree.Enumerate<Control>(scope).Where(IsNavigationCandidate);
+
+        private static Boolean IsNavigationCandidate(Control control)
+        {
+            NavigationParticipation participation = GamepadNavigation.GetParticipation(control);
+            if (participation == NavigationParticipation.Exclude)
+                return false;
+
+            Boolean explicitlyIncluded = participation == NavigationParticipation.Include;
+            if (!control.IsVisible || !control.IsEnabled || !control.IsHitTestVisible ||
+                (!control.Focusable && !explicitlyIncluded))
+            {
+                return false;
+            }
+
+            if ((!KeyboardNavigation.GetIsTabStop(control) && !explicitlyIncluded) || !HasVisibleLayout(control))
+                return false;
+            if (control.TemplatedParent != null && !explicitlyIncluded)
+                return false;
+            if (control is ListBoxItem || control is ComboBoxItem || control is TabControl ||
+                control is ScrollBar || control is Thumb || control is RepeatButton)
+            {
+                return false;
+            }
+
+            if (control is TabItem tab)
+            {
+                TabControl owner = ItemsControl.ItemsControlFromItemContainer(tab) as TabControl;
+                if (owner == null || owner.Items.Count <= 1)
+                    return false;
+            }
+
+            return VisualTree.FindAncestor<ListBoxItem>(control, false) == null
+                && VisualTree.FindAncestor<ComboBoxItem>(control, false) == null;
+        }
+
+        private static Boolean HasVisibleLayout(FrameworkElement element)
+        {
+            DependencyObject current = element;
+            while (current != null)
+            {
+                if (current is FrameworkElement ancestor &&
+                    (!ancestor.IsVisible || ancestor.Opacity <= 0.01 ||
+                     ancestor.Width == 0.0 || ancestor.Height == 0.0 ||
+                     ancestor.ActualWidth <= 1.0 || ancestor.ActualHeight <= 1.0))
+                {
+                    return false;
+                }
+
+                current = VisualTree.GetParent(current);
+            }
+
+            return true;
+        }
+
+        private static TabControl FindNearestTabControl(DependencyObject element)
+        {
+            DependencyObject current = element;
+            while (current != null)
+            {
+                TabControl fromItem = current is TabItem tab
+                    ? ItemsControl.ItemsControlFromItemContainer(tab) as TabControl
+                    : null;
+                if (fromItem != null && fromItem.Items.Count > 1)
+                    return fromItem;
+
+                TabControl ancestor = VisualTree.FindAncestor<TabControl>(current, false);
+                if (ancestor == null)
+                    return null;
+                if (ancestor.Items.Count > 1)
+                    return ancestor;
+                current = VisualTree.GetParent(ancestor);
+            }
+
+            return null;
+        }
+
+        private static TabControl FindRootTabControl(FrameworkElement scope) =>
+            VisualTree.Enumerate<TabControl>(scope)
+                .Where(tab => tab.IsVisible && tab.IsEnabled && tab.Items.Count > 1)
+                .OrderBy(VisualTree.GetDepth)
+                .FirstOrDefault();
+
+        private void ChangeSelectedTab(TabControl tabControl, Int32 offset)
+        {
+            if (tabControl == null || tabControl.Items.Count < 2)
+                return;
+
+            Int32 start = Math.Max(0, tabControl.SelectedIndex);
+            for (Int32 step = 1; step <= tabControl.Items.Count; step++)
+            {
+                Int32 index = (start + offset * step + tabControl.Items.Count) % tabControl.Items.Count;
+                TabItem candidate = tabControl.ItemContainerGenerator.ContainerFromIndex(index) as TabItem
+                                 ?? tabControl.Items[index] as TabItem;
+                if (candidate == null || !candidate.IsEnabled || candidate.Visibility != Visibility.Visible)
+                    continue;
+
+                tabControl.SelectedIndex = index;
+                tabControl.UpdateLayout();
+                _focus.Focus(candidate);
+                return;
+            }
+        }
+    }
+}

--- a/Memoria.Launcher/Controller/ControllerFocusNavigator.cs
+++ b/Memoria.Launcher/Controller/ControllerFocusNavigator.cs
@@ -152,21 +152,48 @@ namespace Memoria.Launcher.Controller
             if (content == null || !VisualTree.IsDescendantOf(current, content))
                 return false;
 
-            NavigationRectangle currentBounds = GetBounds(current);
-            IEnumerable<SpatialNavigationCandidate<Control>> candidates = GetCandidates(content)
-                .Where(control => !ReferenceEquals(control, current))
-                .Select(control => new SpatialNavigationCandidate<Control>(control, GetBounds(control)));
-            SpatialNavigationCandidate<Control> next = SpatialNavigation.FindNext(currentBounds, candidates, direction);
-            if (next != null)
-            {
-                _focus.Focus(ResolveVerticalTabEntry(next.Value, direction));
+            if (TryMoveWithinScope(content, current, direction))
                 return true;
+
+            // A nested TabControl may occupy only part of its parent's page. If no
+            // neighbour exists inside the nested page, continue through the active
+            // parent page so adjacent controls remain reachable. Unselected pages
+            // are never searched because only the selected TabItem content is used.
+            TabControl ancestor = owner;
+            while ((ancestor = FindNearestTabControl(VisualTree.GetParent(ancestor))) != null)
+            {
+                if (ancestor.SelectedItem is not TabItem ancestorTab ||
+                    ancestorTab.Content is not FrameworkElement ancestorContent ||
+                    !VisualTree.IsDescendantOf(current, ancestorContent))
+                {
+                    break;
+                }
+
+                if (TryMoveWithinScope(ancestorContent, current, direction))
+                    return true;
             }
 
             if (direction == NavigationDirection.Up)
                 _focus.Focus(selectedTab);
 
             // Page edges are closed so focus cannot leak into another tab's content.
+            return true;
+        }
+
+        private Boolean TryMoveWithinScope(
+            FrameworkElement scope,
+            Control current,
+            NavigationDirection direction)
+        {
+            NavigationRectangle currentBounds = GetBounds(current);
+            IEnumerable<SpatialNavigationCandidate<Control>> candidates = GetCandidates(scope)
+                .Where(control => !ReferenceEquals(control, current))
+                .Select(control => new SpatialNavigationCandidate<Control>(control, GetBounds(control)));
+            SpatialNavigationCandidate<Control> next = SpatialNavigation.FindNext(currentBounds, candidates, direction);
+            if (next == null)
+                return false;
+
+            _focus.Focus(ResolveVerticalTabEntry(next.Value, direction));
             return true;
         }
 

--- a/Memoria.Launcher/Controller/ControllerInput.cs
+++ b/Memoria.Launcher/Controller/ControllerInput.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+
+namespace Memoria.Launcher.Controller
+{
+    [Flags]
+    internal enum ControllerButton
+    {
+        None = 0,
+        Up = 1 << 0,
+        Down = 1 << 1,
+        Left = 1 << 2,
+        Right = 1 << 3,
+        Confirm = 1 << 4,
+        Cancel = 1 << 5,
+        PreviousTab = 1 << 6,
+        NextTab = 1 << 7,
+        PreviousRootTab = 1 << 8,
+        NextRootTab = 1 << 9,
+        ToggleTooltip = 1 << 10,
+        SubmitTextInput = 1 << 11
+    }
+
+    internal struct ControllerState
+    {
+        public ControllerState(ControllerButton buttons)
+        {
+            Buttons = buttons;
+        }
+
+        public ControllerButton Buttons { get; }
+    }
+
+    internal interface IControllerInputSource : IDisposable
+    {
+        Boolean TryGetState(out ControllerState state);
+    }
+
+    /// <summary>
+    /// Converts polled controller state into edge-triggered actions and applies
+    /// console-like key repeat only to directional navigation.
+    /// </summary>
+    internal sealed class ControllerButtonRepeater
+    {
+        private static readonly ControllerButton[] RepeatableButtons =
+        {
+            ControllerButton.Up,
+            ControllerButton.Down,
+            ControllerButton.Left,
+            ControllerButton.Right
+        };
+
+        private readonly TimeSpan _initialDelay;
+        private readonly TimeSpan _repeatInterval;
+        private readonly Dictionary<ControllerButton, TimeSpan> _nextRepeat = new Dictionary<ControllerButton, TimeSpan>();
+        private ControllerButton _previous;
+
+        public ControllerButtonRepeater(TimeSpan initialDelay, TimeSpan repeatInterval)
+        {
+            if (initialDelay < TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(initialDelay));
+            if (repeatInterval <= TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(repeatInterval));
+
+            _initialDelay = initialDelay;
+            _repeatInterval = repeatInterval;
+        }
+
+        public ControllerButton Update(ControllerButton current, TimeSpan now)
+        {
+            ControllerButton actions = current & ~_previous;
+
+            foreach (ControllerButton button in RepeatableButtons)
+            {
+                Boolean isDown = (current & button) != 0;
+                Boolean wasDown = (_previous & button) != 0;
+                if (!isDown)
+                {
+                    _nextRepeat.Remove(button);
+                    continue;
+                }
+
+                if (!wasDown)
+                {
+                    _nextRepeat[button] = now + _initialDelay;
+                    continue;
+                }
+
+                TimeSpan next;
+                if (!_nextRepeat.TryGetValue(button, out next) || now < next)
+                    continue;
+
+                actions |= button;
+                do
+                {
+                    next += _repeatInterval;
+                } while (next <= now);
+                _nextRepeat[button] = next;
+            }
+
+            _previous = current;
+            return actions;
+        }
+
+        public void Reset()
+        {
+            _previous = ControllerButton.None;
+            _nextRepeat.Clear();
+        }
+    }
+}

--- a/Memoria.Launcher/Controller/ControllerInputModeManager.cs
+++ b/Memoria.Launcher/Controller/ControllerInputModeManager.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace Memoria.Launcher.Controller
+{
+    /// <summary>
+    /// Switches between mouse/keyboard presentation and controller presentation.
+    /// </summary>
+    internal sealed class ControllerInputModeManager : IDisposable
+    {
+        private readonly Window _window;
+        private readonly ControllerFocusManager _focus;
+        private readonly ControllerControlInteractor _interaction;
+        private readonly ControllerTooltipPresenter _tooltips;
+        private Border _mouseInputShield;
+        private NativePointerPosition _controllerPointerPosition;
+        private Boolean _hasControllerPointerPosition;
+        private Cursor _cursorBeforeControllerMode;
+        private Boolean _controllerInputActive;
+        private Boolean _disposed;
+
+        public ControllerInputModeManager(
+            Window window,
+            ControllerFocusManager focus,
+            ControllerControlInteractor interaction,
+            ControllerTooltipPresenter tooltips)
+        {
+            _window = window ?? throw new ArgumentNullException(nameof(window));
+            _focus = focus ?? throw new ArgumentNullException(nameof(focus));
+            _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+            _tooltips = tooltips ?? throw new ArgumentNullException(nameof(tooltips));
+
+            _window.PreviewMouseDown += OnPreviewMouseDown;
+            _window.PreviewMouseMove += OnPreviewMouseMove;
+            _window.PreviewMouseWheel += OnPreviewMouseWheel;
+            InputManager.Current.PreProcessInput += OnPreProcessInput;
+        }
+
+        public void EnterControllerMode()
+        {
+            if (_controllerInputActive)
+            {
+                Mouse.OverrideCursor = Cursors.None;
+                return;
+            }
+
+            _cursorBeforeControllerMode = Mouse.OverrideCursor;
+            _controllerInputActive = true;
+            GamepadNavigation.SetIsControllerInputActive(_window, true);
+            _hasControllerPointerPosition = NativePointer.TryGetPosition(out _controllerPointerPosition);
+            Mouse.OverrideCursor = Cursors.None;
+            _tooltips.CloseAutomaticTooltips();
+            InstallMouseInputShield();
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            _window.PreviewMouseDown -= OnPreviewMouseDown;
+            _window.PreviewMouseMove -= OnPreviewMouseMove;
+            _window.PreviewMouseWheel -= OnPreviewMouseWheel;
+            InputManager.Current.PreProcessInput -= OnPreProcessInput;
+            EnterMouseMode();
+        }
+
+        private void OnPreviewMouseDown(Object sender, MouseButtonEventArgs e)
+        {
+            _interaction.EndSliderEditing();
+            EnterMouseMode();
+        }
+
+        private void OnPreviewMouseMove(Object sender, MouseEventArgs e)
+        {
+            if (_controllerInputActive)
+                RestoreMouseModeAfterPhysicalMovement();
+        }
+
+        private void OnPreviewMouseWheel(Object sender, MouseWheelEventArgs e) => EnterMouseMode();
+
+        private void OnPreProcessInput(Object sender, PreProcessInputEventArgs e)
+        {
+            InputEventArgs input = e.StagingItem.Input;
+            if (input is KeyEventArgs key && key.IsDown)
+            {
+                _tooltips.Disable();
+                _focus.DeactivateControllerAppearance(false);
+                return;
+            }
+
+            if (!_controllerInputActive)
+                return;
+
+            if (input is MouseButtonEventArgs || input is MouseWheelEventArgs)
+            {
+                EnterMouseMode();
+                return;
+            }
+
+            if (input is MouseEventArgs)
+                RestoreMouseModeAfterPhysicalMovement();
+        }
+
+        private void RestoreMouseModeAfterPhysicalMovement()
+        {
+            if (!_hasControllerPointerPosition ||
+                !NativePointer.TryGetPosition(out NativePointerPosition position) ||
+                !position.Equals(_controllerPointerPosition))
+            {
+                EnterMouseMode();
+            }
+        }
+
+        private void EnterMouseMode()
+        {
+            _tooltips.Disable();
+            _focus.DeactivateControllerAppearance(true);
+            if (!_controllerInputActive)
+                return;
+
+            _controllerInputActive = false;
+            GamepadNavigation.SetIsControllerInputActive(_window, false);
+            _hasControllerPointerPosition = false;
+            _interaction.RestorePointerInput();
+            RemoveMouseInputShield();
+            Mouse.OverrideCursor = _cursorBeforeControllerMode;
+            _cursorBeforeControllerMode = null;
+        }
+
+        private void InstallMouseInputShield()
+        {
+            if (_window.Content is not Panel root || _mouseInputShield != null)
+                return;
+
+            _mouseInputShield = new Border
+            {
+                Background = Brushes.Transparent,
+                Cursor = Cursors.None,
+                ForceCursor = true,
+                Focusable = false,
+                IsHitTestVisible = true
+            };
+            Panel.SetZIndex(_mouseInputShield, Int32.MaxValue);
+            root.Children.Add(_mouseInputShield);
+        }
+
+        private void RemoveMouseInputShield()
+        {
+            if (_mouseInputShield?.Parent is Panel parent)
+                parent.Children.Remove(_mouseInputShield);
+            _mouseInputShield = null;
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct NativePointerPosition : IEquatable<NativePointerPosition>
+    {
+        public Int32 X;
+        public Int32 Y;
+
+        public Boolean Equals(NativePointerPosition other) => X == other.X && Y == other.Y;
+        public override Boolean Equals(Object obj) => obj is NativePointerPosition other && Equals(other);
+
+        public override Int32 GetHashCode()
+        {
+            unchecked
+            {
+                return (X * 397) ^ Y;
+            }
+        }
+    }
+
+    internal static class NativePointer
+    {
+        public static Boolean TryGetPosition(out NativePointerPosition position) => GetCursorPos(out position);
+
+        [DllImport("user32.dll")]
+        private static extern Boolean GetCursorPos(out NativePointerPosition point);
+    }
+}

--- a/Memoria.Launcher/Controller/ControllerTextInputOverlay.cs
+++ b/Memoria.Launcher/Controller/ControllerTextInputOverlay.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace Memoria.Launcher.Controller
+{
+    /// <summary>
+    /// Minimal controller-operated text keyboard for launcher search and preset fields.
+    /// </summary>
+    internal sealed class ControllerTextInputOverlay : Grid
+    {
+        private static readonly String[] KeyRows =
+        {
+            "1234567890",
+            "QWERTYUIOP",
+            "ASDFGHJKL",
+            "ZXCVBNM-_.'"
+        };
+
+        private readonly TextBox _target;
+        private readonly String _originalText;
+        private readonly TextBox _preview;
+
+        public ControllerTextInputOverlay(TextBox target)
+        {
+            _target = target ?? throw new ArgumentNullException(nameof(target));
+            _originalText = target.Text;
+
+            Background = new SolidColorBrush(Color.FromArgb(176, 0, 0, 0));
+            HorizontalAlignment = HorizontalAlignment.Stretch;
+            VerticalAlignment = VerticalAlignment.Stretch;
+            // Keep the controller mouse-input shield above this visual while
+            // still presenting the keyboard above regular launcher content.
+            Panel.SetZIndex(this, Int32.MaxValue - 1);
+            GamepadNavigation.SetIsModalScope(this, true);
+
+            Border window = new Border
+            {
+                Width = 660,
+                Padding = new Thickness(18),
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                Background = new SolidColorBrush(Color.FromArgb(245, 10, 10, 10)),
+                BorderBrush = TryFindResource("BrushAccentColor") as Brush ?? Brushes.SteelBlue,
+                BorderThickness = new Thickness(2),
+                CornerRadius = new CornerRadius(8)
+            };
+
+            StackPanel content = new StackPanel();
+            _preview = new TextBox
+            {
+                Text = _target.Text,
+                IsReadOnly = true,
+                Focusable = false,
+                FontSize = 19,
+                Height = 38,
+                Margin = new Thickness(2, 2, 2, 12),
+                Padding = new Thickness(8, 4, 8, 4),
+                CaretIndex = _target.CaretIndex
+            };
+            content.Children.Add(_preview);
+
+            Boolean isFirstKey = true;
+            foreach (String row in KeyRows)
+            {
+                UniformGrid keyRow = new UniformGrid { Columns = row.Length };
+                foreach (Char character in row)
+                {
+                    Button key = CreateButton(character.ToString());
+                    Char captured = character;
+                    key.Click += (sender, args) => Insert(captured.ToString());
+                    if (isFirstKey)
+                    {
+                        GamepadNavigation.SetIsDefaultFocus(key, true);
+                        isFirstKey = false;
+                    }
+                    keyRow.Children.Add(key);
+                }
+                content.Children.Add(keyRow);
+            }
+
+            UniformGrid commandRow = new UniformGrid { Columns = 5, Margin = new Thickness(0, 8, 0, 0) };
+            Button backspace = CreateButton("⌫");
+            backspace.Click += (sender, args) => Backspace();
+            commandRow.Children.Add(backspace);
+
+            Button space = CreateButton("␠");
+            space.Click += (sender, args) => Insert(" ");
+            commandRow.Children.Add(space);
+
+            Button clear = CreateButton("×");
+            clear.Click += (sender, args) => SetText(String.Empty, 0);
+            commandRow.Children.Add(clear);
+
+            Button cancel = CreateButton(null);
+            cancel.Name = "Cancel";
+            cancel.SetResourceReference(ContentControl.ContentProperty, "Launcher.Cancel");
+            cancel.Click += (sender, args) => Close(false);
+            commandRow.Children.Add(cancel);
+
+            Button done = CreateButton(null);
+            done.Name = "Ok";
+            done.SetResourceReference(ContentControl.ContentProperty, "Launcher.OK");
+            done.Click += (sender, args) => Close(true);
+            commandRow.Children.Add(done);
+
+            content.Children.Add(commandRow);
+            window.Child = content;
+            Children.Add(window);
+        }
+
+        private Button CreateButton(String content)
+        {
+            Button button = new Button
+            {
+                Content = content,
+                Height = 42,
+                Margin = new Thickness(2),
+                FontSize = 16
+            };
+            Style style = TryFindResource("ButtonStyle") as Style;
+            if (style != null)
+                button.Style = style;
+            return button;
+        }
+
+        private void Insert(String value)
+        {
+            Int32 selectionStart = Math.Max(0, Math.Min(_target.Text.Length, _target.SelectionStart));
+            Int32 selectionLength = Math.Max(0, Math.Min(_target.Text.Length - selectionStart, _target.SelectionLength));
+            Int32 available = _target.MaxLength <= 0
+                ? value.Length
+                : Math.Max(0, _target.MaxLength - (_target.Text.Length - selectionLength));
+            String inserted = value.Substring(0, Math.Min(value.Length, available));
+            String text = _target.Text.Remove(selectionStart, selectionLength).Insert(selectionStart, inserted);
+            SetText(text, selectionStart + inserted.Length);
+        }
+
+        private void Backspace()
+        {
+            Int32 selectionStart = Math.Max(0, Math.Min(_target.Text.Length, _target.SelectionStart));
+            Int32 selectionLength = Math.Max(0, Math.Min(_target.Text.Length - selectionStart, _target.SelectionLength));
+            if (selectionLength > 0)
+            {
+                SetText(_target.Text.Remove(selectionStart, selectionLength), selectionStart);
+                return;
+            }
+            if (selectionStart > 0)
+                SetText(_target.Text.Remove(selectionStart - 1, 1), selectionStart - 1);
+        }
+
+        private void SetText(String text, Int32 caretIndex)
+        {
+            _target.Text = text;
+            _target.CaretIndex = Math.Max(0, Math.Min(text.Length, caretIndex));
+            _target.SelectionLength = 0;
+            _preview.Text = text;
+            _preview.CaretIndex = _target.CaretIndex;
+            _preview.ScrollToEnd();
+        }
+
+        internal void Accept()
+        {
+            Close(true);
+        }
+
+        private void Close(Boolean accept)
+        {
+            if (!accept)
+                SetText(_originalText, Math.Min(_originalText.Length, _target.CaretIndex));
+
+            Panel parent = Parent as Panel;
+            if (parent != null)
+                parent.Children.Remove(this);
+            _target.Focus();
+            Keyboard.Focus(_target);
+        }
+    }
+}

--- a/Memoria.Launcher/Controller/ControllerTextInputOverlay.cs
+++ b/Memoria.Launcher/Controller/ControllerTextInputOverlay.cs
@@ -97,6 +97,7 @@ namespace Memoria.Launcher.Controller
 
             Button cancel = CreateButton(null);
             cancel.Name = "Cancel";
+            GamepadNavigation.SetIsCancelAction(cancel, true);
             cancel.SetResourceReference(ContentControl.ContentProperty, "Launcher.Cancel");
             cancel.Click += (sender, args) => Close(false);
             commandRow.Children.Add(cancel);

--- a/Memoria.Launcher/Controller/ControllerTooltipPresenter.cs
+++ b/Memoria.Launcher/Controller/ControllerTooltipPresenter.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+
+namespace Memoria.Launcher.Controller
+{
+    /// <summary>
+    /// Displays the focused control's tooltip while controller help mode is enabled.
+    /// </summary>
+    internal sealed class ControllerTooltipPresenter : IDisposable
+    {
+        private readonly Window _window;
+        private readonly ControllerFocusManager _focus;
+        private ToolTip _toolTip;
+        private FrameworkElement _owner;
+        private Boolean _enabled;
+        private Boolean _reusedExistingToolTip;
+        private PlacementMode _previousPlacement;
+        private UIElement _previousTarget;
+        private Double _previousHorizontalOffset;
+        private Double _previousVerticalOffset;
+        private Boolean _previousStaysOpen;
+
+        public ControllerTooltipPresenter(Window window, ControllerFocusManager focus)
+        {
+            _window = window ?? throw new ArgumentNullException(nameof(window));
+            _focus = focus ?? throw new ArgumentNullException(nameof(focus));
+            _focus.Focused += OnFocused;
+        }
+
+        public void Toggle(Control current)
+        {
+            if (_enabled)
+            {
+                Disable();
+                return;
+            }
+
+            _enabled = true;
+            Show(current);
+        }
+
+        public void Disable()
+        {
+            _enabled = false;
+            Close();
+        }
+
+        public void CloseAutomaticTooltips()
+        {
+            foreach (FrameworkElement element in VisualTree.Enumerate<FrameworkElement>(_window))
+            {
+                if (ToolTipService.GetToolTip(element) is ToolTip toolTip && toolTip.IsOpen)
+                    toolTip.IsOpen = false;
+            }
+        }
+
+        public void Dispose()
+        {
+            _focus.Focused -= OnFocused;
+            Disable();
+        }
+
+        private void OnFocused(Control control)
+        {
+            if (_enabled)
+                Show(control);
+        }
+
+        private void Show(Control current)
+        {
+            FrameworkElement owner = ResolveOwner(current);
+            if (owner == null)
+            {
+                Close();
+                return;
+            }
+
+            if (ReferenceEquals(_owner, owner) && _toolTip?.IsOpen == true)
+                return;
+
+            Close();
+            Object value = ToolTipService.GetToolTip(owner);
+            ToolTip toolTip = value as ToolTip;
+            _reusedExistingToolTip = toolTip != null;
+            if (toolTip == null)
+            {
+                toolTip = new ToolTip { Content = value };
+            }
+            else
+            {
+                _previousPlacement = toolTip.Placement;
+                _previousTarget = toolTip.PlacementTarget;
+                _previousHorizontalOffset = toolTip.HorizontalOffset;
+                _previousVerticalOffset = toolTip.VerticalOffset;
+                _previousStaysOpen = toolTip.StaysOpen;
+            }
+
+            _toolTip = toolTip;
+            _owner = owner;
+            toolTip.PlacementTarget = owner;
+            toolTip.Placement = PlacementMode.RelativePoint;
+            toolTip.HorizontalOffset = Math.Max(0.0, owner.ActualWidth - 1.0);
+            toolTip.VerticalOffset = Math.Max(0.0, owner.ActualHeight - 1.0);
+            toolTip.StaysOpen = true;
+            toolTip.IsOpen = true;
+        }
+
+        private static FrameworkElement ResolveOwner(Control current)
+        {
+            if (ToolTipService.GetToolTip(current) != null)
+                return current;
+
+            FrameworkElement configuredOwner = GamepadNavigation.GetTooltipOwner(current);
+            if (configuredOwner != null && ToolTipService.GetToolTip(configuredOwner) != null)
+                return configuredOwner;
+            return null;
+        }
+
+        private void Close()
+        {
+            if (_toolTip == null)
+                return;
+
+            _toolTip.IsOpen = false;
+            if (_reusedExistingToolTip)
+            {
+                _toolTip.Placement = _previousPlacement;
+                _toolTip.PlacementTarget = _previousTarget;
+                _toolTip.HorizontalOffset = _previousHorizontalOffset;
+                _toolTip.VerticalOffset = _previousVerticalOffset;
+                _toolTip.StaysOpen = _previousStaysOpen;
+            }
+
+            _toolTip = null;
+            _owner = null;
+            _reusedExistingToolTip = false;
+        }
+    }
+}

--- a/Memoria.Launcher/Controller/GamepadNavigation.cs
+++ b/Memoria.Launcher/Controller/GamepadNavigation.cs
@@ -1,47 +1,105 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Windows;
-using System.Windows.Automation.Peers;
-using System.Windows.Automation.Provider;
 using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
 using System.Windows.Threading;
 
 namespace Memoria.Launcher.Controller
 {
-    /// <summary>
-    /// Attached metadata used by the generic controller navigation service.
-    /// </summary>
-    public static class GamepadNavigation
+    public enum NavigationParticipation
     {
-        public static Boolean IsControllerInputActive { get; internal set; }
-
-        public static readonly DependencyProperty IsDefaultFocusProperty = DependencyProperty.RegisterAttached(
-            "IsDefaultFocus",
-            typeof(Boolean),
-            typeof(GamepadNavigation),
-            new FrameworkPropertyMetadata(false));
-
-        public static readonly DependencyProperty IsModalScopeProperty = DependencyProperty.RegisterAttached(
-            "IsModalScope",
-            typeof(Boolean),
-            typeof(GamepadNavigation),
-            new FrameworkPropertyMetadata(false));
-
-        public static void SetIsDefaultFocus(DependencyObject element, Boolean value) => element.SetValue(IsDefaultFocusProperty, value);
-        public static Boolean GetIsDefaultFocus(DependencyObject element) => (Boolean)element.GetValue(IsDefaultFocusProperty);
-        public static void SetIsModalScope(DependencyObject element, Boolean value) => element.SetValue(IsModalScopeProperty, value);
-        public static Boolean GetIsModalScope(DependencyObject element) => (Boolean)element.GetValue(IsModalScopeProperty);
+        Auto,
+        Include,
+        Exclude
     }
 
     /// <summary>
-    /// Coordinates controller input, spatial focus navigation and standard WPF
-    /// control actions without coupling individual launcher screens to XInput.
+    /// Declarative controller-navigation metadata for launcher controls.
+    /// </summary>
+    public static class GamepadNavigation
+    {
+        private static readonly DependencyPropertyKey IsControllerInputActivePropertyKey =
+            DependencyProperty.RegisterAttachedReadOnly(
+                "IsControllerInputActive",
+                typeof(Boolean),
+                typeof(GamepadNavigation),
+                new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits));
+
+        public static readonly DependencyProperty IsControllerInputActiveProperty =
+            IsControllerInputActivePropertyKey.DependencyProperty;
+
+        public static readonly DependencyProperty IsDefaultFocusProperty = DependencyProperty.RegisterAttached(
+            "IsDefaultFocus", typeof(Boolean), typeof(GamepadNavigation), new FrameworkPropertyMetadata(false));
+
+        public static readonly DependencyProperty IsModalScopeProperty = DependencyProperty.RegisterAttached(
+            "IsModalScope", typeof(Boolean), typeof(GamepadNavigation), new FrameworkPropertyMetadata(false));
+
+        public static readonly DependencyProperty IsCancelActionProperty = DependencyProperty.RegisterAttached(
+            "IsCancelAction", typeof(Boolean), typeof(GamepadNavigation), new FrameworkPropertyMetadata(false));
+
+        public static readonly DependencyProperty ParticipationProperty = DependencyProperty.RegisterAttached(
+            "Participation", typeof(NavigationParticipation), typeof(GamepadNavigation),
+            new FrameworkPropertyMetadata(NavigationParticipation.Auto));
+
+        public static readonly DependencyProperty TooltipOwnerProperty = DependencyProperty.RegisterAttached(
+            "TooltipOwner", typeof(FrameworkElement), typeof(GamepadNavigation), new FrameworkPropertyMetadata(null));
+
+        public static readonly RoutedEvent ActivatedEvent = EventManager.RegisterRoutedEvent(
+            "Activated", RoutingStrategy.Bubble, typeof(RoutedEventHandler), typeof(GamepadNavigation));
+
+        public static Boolean IsControllerInputActive(DependencyObject element) =>
+            (Boolean)element.GetValue(IsControllerInputActiveProperty);
+
+        public static void SetIsDefaultFocus(DependencyObject element, Boolean value) =>
+            element.SetValue(IsDefaultFocusProperty, value);
+
+        public static Boolean GetIsDefaultFocus(DependencyObject element) =>
+            (Boolean)element.GetValue(IsDefaultFocusProperty);
+
+        public static void SetIsModalScope(DependencyObject element, Boolean value) =>
+            element.SetValue(IsModalScopeProperty, value);
+
+        public static Boolean GetIsModalScope(DependencyObject element) =>
+            (Boolean)element.GetValue(IsModalScopeProperty);
+
+        public static void SetIsCancelAction(DependencyObject element, Boolean value) =>
+            element.SetValue(IsCancelActionProperty, value);
+
+        public static Boolean GetIsCancelAction(DependencyObject element) =>
+            (Boolean)element.GetValue(IsCancelActionProperty);
+
+        public static void SetParticipation(DependencyObject element, NavigationParticipation value) =>
+            element.SetValue(ParticipationProperty, value);
+
+        public static NavigationParticipation GetParticipation(DependencyObject element) =>
+            (NavigationParticipation)element.GetValue(ParticipationProperty);
+
+        public static void SetTooltipOwner(DependencyObject element, FrameworkElement value) =>
+            element.SetValue(TooltipOwnerProperty, value);
+
+        public static FrameworkElement GetTooltipOwner(DependencyObject element) =>
+            (FrameworkElement)element.GetValue(TooltipOwnerProperty);
+
+        public static void AddActivatedHandler(DependencyObject element, RoutedEventHandler handler) =>
+            ((UIElement)element).AddHandler(ActivatedEvent, handler);
+
+        public static void RemoveActivatedHandler(DependencyObject element, RoutedEventHandler handler) =>
+            ((UIElement)element).RemoveHandler(ActivatedEvent, handler);
+
+        internal static void SetIsControllerInputActive(DependencyObject element, Boolean value) =>
+            element.SetValue(IsControllerInputActivePropertyKey, value);
+
+        internal static Boolean RaiseActivated(UIElement element)
+        {
+            RoutedEventArgs args = new RoutedEventArgs(ActivatedEvent, element);
+            element.RaiseEvent(args);
+            return args.Handled;
+        }
+    }
+
+    /// <summary>
+    /// Polls controller input and routes semantic actions to focused UI services.
     /// </summary>
     internal sealed class GamepadNavigationService : IDisposable
     {
@@ -54,46 +112,30 @@ namespace Memoria.Launcher.Controller
         private readonly ControllerButtonRepeater _repeater;
         private readonly DispatcherTimer _timer;
         private readonly Stopwatch _clock = Stopwatch.StartNew();
-
-        private ControllerFocusAdorner _focusAdorner;
-        private Control _focusVisualOwner;
-        private Object _focusVisualPreviousLocalValue;
-        private Boolean _controllerFocusAppearanceActive;
-        private ComboBox _openComboBox;
-        private Int32 _openComboBoxInitialIndex;
-        private UIElement _suppressedComboBoxPopupContent;
-        private Boolean _popupContentWasHitTestVisible;
-        private Slider _activeSlider;
-        private Border _mouseInputShield;
-        private NativePointerPosition _controllerPointerPosition;
-        private Boolean _hasControllerPointerPosition;
-        private Cursor _cursorBeforeControllerMode;
-        private Boolean _controllerInputActive;
-        private ToolTip _controllerToolTip;
-        private FrameworkElement _controllerToolTipOwner;
-        private Boolean _controllerTooltipsEnabled;
-        private Boolean _controllerToolTipReused;
-        private PlacementMode _tooltipPreviousPlacement;
-        private UIElement _tooltipPreviousTarget;
-        private Double _tooltipPreviousHorizontalOffset;
-        private Double _tooltipPreviousVerticalOffset;
-        private Boolean _tooltipPreviousStaysOpen;
+        private readonly ControllerFocusManager _focus;
+        private readonly ControllerFocusNavigator _navigator;
+        private readonly ControllerControlInteractor _interaction;
+        private readonly ControllerTooltipPresenter _tooltips;
+        private readonly ControllerInputModeManager _inputMode;
         private Boolean _disposed;
 
-        private GamepadNavigationService(Window window, IControllerInputSource input)
+        internal GamepadNavigationService(Window window, IControllerInputSource input)
         {
             _window = window ?? throw new ArgumentNullException(nameof(window));
             _input = input ?? throw new ArgumentNullException(nameof(input));
             _repeater = new ControllerButtonRepeater(InitialRepeatDelay, RepeatInterval);
+
+            _focus = new ControllerFocusManager(window);
+            _navigator = new ControllerFocusNavigator(window, _focus);
+            _interaction = new ControllerControlInteractor(window, _focus);
+            _tooltips = new ControllerTooltipPresenter(window, _focus);
+            _inputMode = new ControllerInputModeManager(window, _focus, _interaction, _tooltips);
+
             _timer = new DispatcherTimer(DispatcherPriority.Input, window.Dispatcher)
             {
                 Interval = PollInterval
             };
             _timer.Tick += OnTick;
-            _window.PreviewMouseDown += OnPreviewMouseDown;
-            _window.PreviewMouseMove += OnPreviewMouseMove;
-            _window.PreviewMouseWheel += OnPreviewMouseWheel;
-            InputManager.Current.PreProcessInput += OnPreProcessInput;
             _window.Closed += OnWindowClosed;
             _timer.Start();
         }
@@ -119,13 +161,11 @@ namespace Memoria.Launcher.Controller
             _disposed = true;
             _timer.Stop();
             _timer.Tick -= OnTick;
-            _window.PreviewMouseDown -= OnPreviewMouseDown;
-            _window.PreviewMouseMove -= OnPreviewMouseMove;
-            _window.PreviewMouseWheel -= OnPreviewMouseWheel;
-            InputManager.Current.PreProcessInput -= OnPreProcessInput;
             _window.Closed -= OnWindowClosed;
-            EnterMouseMode();
-            RemoveFocusAdorner();
+            _inputMode.Dispose();
+            _tooltips.Dispose();
+            _interaction.Dispose();
+            _focus.Dispose();
             _input.Dispose();
         }
 
@@ -137,15 +177,15 @@ namespace Memoria.Launcher.Controller
                 return;
             }
 
-            Boolean nativeDialogActive = !_window.IsActive && NativeDialogControllerBridge.IsCurrentProcessInForeground();
+            Boolean nativeDialogActive = !_window.IsActive &&
+                                         NativeDialogControllerBridge.IsMessageBoxActiveForCurrentProcess();
             if (!_window.IsActive && !nativeDialogActive)
             {
                 _repeater.Reset();
                 return;
             }
 
-            ControllerState state;
-            if (!_input.TryGetState(out state))
+            if (!_input.TryGetState(out ControllerState state))
             {
                 _repeater.Reset();
                 return;
@@ -155,75 +195,70 @@ namespace Memoria.Launcher.Controller
             if (actions == ControllerButton.None)
                 return;
 
-            EnterControllerMode();
-
+            _inputMode.EnterControllerMode();
             if (nativeDialogActive)
             {
                 NativeDialogControllerBridge.Send(actions);
                 return;
             }
 
-            FrameworkElement scope = FindActiveScope();
-            if (scope is ControllerTextInputOverlay textInput && (actions & ControllerButton.SubmitTextInput) != 0)
+            ProcessAction(actions);
+        }
+
+        internal void ProcessAction(ControllerButton actions)
+        {
+            FrameworkElement scope = _navigator.FindActiveScope();
+            if (scope is ControllerTextInputOverlay textInput &&
+                (actions & ControllerButton.SubmitTextInput) != 0)
             {
                 textInput.Accept();
                 return;
             }
 
-            Control current = FindFocusedControl(scope);
+            Control current = _interaction.GetFocusedControlOverride(scope)
+                           ?? _navigator.FindFocusedControl(scope);
             if (current == null)
             {
-                FocusInitialControl(scope);
-                current = FindFocusedControl(scope);
+                _navigator.FocusInitialControl(scope);
+                current = _interaction.GetFocusedControlOverride(scope)
+                       ?? _navigator.FindFocusedControl(scope);
                 if (current == null)
                     return;
 
-                ControllerButton tabActions = ControllerButton.PreviousTab
-                                            | ControllerButton.NextTab
-                                            | ControllerButton.PreviousRootTab
-                                            | ControllerButton.NextRootTab;
+                const ControllerButton tabActions = ControllerButton.PreviousTab
+                                                  | ControllerButton.NextTab
+                                                  | ControllerButton.PreviousRootTab
+                                                  | ControllerButton.NextRootTab;
                 if ((actions & tabActions) == 0)
                     return;
             }
 
-            EnsureControllerFocusAppearance(current);
+            _focus.EnsureControllerAppearance(current, _interaction.IsEditing(current));
 
             if ((actions & ControllerButton.ToggleTooltip) != 0)
             {
-                ToggleControllerTooltip(current);
+                _tooltips.Toggle(current);
                 return;
             }
 
-            if (_activeSlider != null)
-            {
-                if (!_activeSlider.IsVisible || !_activeSlider.IsEnabled)
-                    _activeSlider = null;
-                else
-                {
-                    if ((actions & (ControllerButton.Confirm | ControllerButton.Cancel)) != 0)
-                        HandleCancel(scope, _activeSlider);
-                    else if ((actions & ControllerButton.Left) != 0)
-                        Move(scope, _activeSlider, NavigationDirection.Left);
-                    else if ((actions & ControllerButton.Right) != 0)
-                        Move(scope, _activeSlider, NavigationDirection.Right);
-
-                    // A slider keeps directional focus until A or B releases it.
-                    return;
-                }
-            }
+            if (_interaction.HandleEditingAction(actions))
+                return;
 
             if ((actions & ControllerButton.Cancel) != 0)
-                HandleCancel(scope, current);
+            {
+                if (!_interaction.TryCancel())
+                    _navigator.Cancel(scope, current);
+            }
             else if ((actions & ControllerButton.Confirm) != 0)
-                Activate(current);
+                _interaction.Activate(current);
             else if ((actions & ControllerButton.PreviousRootTab) != 0)
-                SwitchTab(scope, current, -1, true);
+                _navigator.SwitchTab(scope, current, -1, true);
             else if ((actions & ControllerButton.NextRootTab) != 0)
-                SwitchTab(scope, current, 1, true);
+                _navigator.SwitchTab(scope, current, 1, true);
             else if ((actions & ControllerButton.PreviousTab) != 0)
-                SwitchTab(scope, current, -1, false);
+                _navigator.SwitchTab(scope, current, -1, false);
             else if ((actions & ControllerButton.NextTab) != 0)
-                SwitchTab(scope, current, 1, false);
+                _navigator.SwitchTab(scope, current, 1, false);
             else if ((actions & ControllerButton.Up) != 0)
                 Move(scope, current, NavigationDirection.Up);
             else if ((actions & ControllerButton.Down) != 0)
@@ -234,1119 +269,18 @@ namespace Memoria.Launcher.Controller
                 Move(scope, current, NavigationDirection.Right);
         }
 
-        private FrameworkElement FindActiveScope()
-        {
-            return VisualTree
-                       .Enumerate<FrameworkElement>(_window)
-                       .LastOrDefault(element => element.IsVisible && GamepadNavigation.GetIsModalScope(element))
-                   ?? (FrameworkElement)_window;
-        }
-
-        private Control FindFocusedControl(FrameworkElement scope)
-        {
-            if (_openComboBox != null && _openComboBox.IsDropDownOpen && VisualTree.IsDescendantOf(_openComboBox, scope))
-                return _openComboBox;
-
-            if (Keyboard.FocusedElement is not DependencyObject focused || !VisualTree.IsDescendantOf(focused, scope))
-                return null;
-
-            ListBox ownerList = VisualTree.FindAncestor<ListBox>(focused, true);
-            if (ownerList != null && VisualTree.IsDescendantOf(ownerList, scope))
-                return ownerList;
-
-            Control control = VisualTree.FindAncestor<Control>(focused, true);
-            return control != null && IsNavigationCandidate(control) ? control : null;
-        }
-
-        private void FocusInitialControl(FrameworkElement scope)
-        {
-            List<Control> controls = GetCandidates(scope).ToList();
-            if (controls.Count == 0)
-                return;
-
-            Control target = controls.FirstOrDefault(GamepadNavigation.GetIsDefaultFocus)
-                          ?? controls.OrderBy(control => GetBounds(control).Top)
-                                     .ThenBy(control => GetBounds(control).Left)
-                                     .First();
-            Focus(target);
-        }
-
         private void Move(FrameworkElement scope, Control current, NavigationDirection direction)
         {
-            if (HandleControlDirection(current, direction))
-                return;
-
-            if (!(current is TabItem) && MoveWithinSelectedTab(current, direction))
-                return;
-
-            NavigationRectangle currentBounds = GetBounds(current);
-            IEnumerable<SpatialNavigationCandidate<Control>> candidates = GetCandidates(scope)
-                .Where(control => !ReferenceEquals(control, current))
-                .Select(control => new SpatialNavigationCandidate<Control>(control, GetBounds(control)));
-            
-            SpatialNavigationCandidate<Control> next = SpatialNavigation.FindNext(currentBounds, candidates, direction);
-            if (next != null)
-                Focus(ResolveVerticalTabEntry(next.Value, direction));
+            if (!_interaction.TryHandleDirection(current, direction))
+                _navigator.Move(scope, current, direction);
         }
 
-        private static Control ResolveVerticalTabEntry(Control candidate, NavigationDirection direction)
-        {
-            if (direction != NavigationDirection.Up && direction != NavigationDirection.Down)
-                return candidate;
-
-            if (candidate is not TabItem candidateTab)
-                return candidate;
-
-            TabItem selectedTab = ItemsControl.ItemsControlFromItemContainer(candidateTab) is not TabControl owner ? null : owner.SelectedItem as TabItem;
-            return selectedTab ?? candidateTab;
-        }
-
-        private Boolean MoveWithinSelectedTab(Control current, NavigationDirection direction)
-        {
-            TabControl owner = FindNearestTabControl(current);
-            TabItem selectedTab = owner == null ? null : owner.SelectedItem as TabItem;
-            FrameworkElement content = selectedTab == null ? null : selectedTab.Content as FrameworkElement;
-            if (content == null || !VisualTree.IsDescendantOf(current, content))
-                return false;
-
-            NavigationRectangle currentBounds = GetBounds(current);
-            IEnumerable<SpatialNavigationCandidate<Control>> candidates = GetCandidates(content)
-                .Where(control => !ReferenceEquals(control, current))
-                .Select(control => new SpatialNavigationCandidate<Control>(control, GetBounds(control)));
-            SpatialNavigationCandidate<Control> next = SpatialNavigation.FindNext(currentBounds, candidates, direction);
-            if (next != null)
-            {
-                Focus(ResolveVerticalTabEntry(next.Value, direction));
-                return true;
-            }
-
-            // Leaving through the top of a page always returns to the header of
-            // that same page. Header position must not redirect the focus to a
-            // different tab that merely happens to be vertically aligned.
-            if (direction == NavigationDirection.Up)
-                Focus(selectedTab);
-
-            // Other edges are closed: without a neighbour on this page the
-            // focus stays in place instead of leaking into another tab.
-            return true;
-        }
-
-        private Boolean HandleControlDirection(Control current, NavigationDirection direction)
-        {
-            if (current is TabItem tab)
-            {
-                if (direction == NavigationDirection.Down && tab.IsSelected && MoveIntoSelectedTab(tab))
-                    return true;
-
-                if (direction == NavigationDirection.Left || direction == NavigationDirection.Right)
-                {
-                    if (ItemsControl.ItemsControlFromItemContainer(tab) is TabControl owner)
-                    {
-                        ChangeSelectedTab(owner, direction == NavigationDirection.Left ? -1 : 1);
-                        return true;
-                    }
-                }
-            }
-
-            if (current is ComboBox comboBox)
-            {
-                if (comboBox.IsDropDownOpen && (direction == NavigationDirection.Up || direction == NavigationDirection.Down))
-                {
-                    ChangeSelection(comboBox, direction == NavigationDirection.Up ? -1 : 1);
-                    return true;
-                }
-            }
-
-            if (current is Slider slider && ReferenceEquals(slider, _activeSlider))
-            {
-                if (direction == NavigationDirection.Left || direction == NavigationDirection.Right)
-                {
-                    Double change = slider.TickFrequency > 0.0 ? slider.TickFrequency : slider.SmallChange;
-                    if (change <= 0.0)
-                        change = Math.Max((slider.Maximum - slider.Minimum) / 20.0, 1.0);
-                    slider.Value = Math.Max(slider.Minimum, Math.Min(slider.Maximum,
-                        slider.Value + (direction == NavigationDirection.Left ? -change : change)));
-                }
-
-                // Editing is modal for directional input. This prevents an
-                // accidental vertical press from leaving the slider before B.
-                return true;
-            }
-
-            if (current is ListBox list && (direction == NavigationDirection.Up || direction == NavigationDirection.Down))
-            {
-                Int32 nextIndex = list.SelectedIndex;
-                if (nextIndex < 0)
-                    nextIndex = direction == NavigationDirection.Up ? list.Items.Count - 1 : 0;
-                else
-                    nextIndex += direction == NavigationDirection.Up ? -1 : 1;
-
-                if (nextIndex >= 0 && nextIndex < list.Items.Count)
-                {
-                    list.SelectedIndex = nextIndex;
-                    list.ScrollIntoView(list.SelectedItem);
-                    return true;
-                }
-
-                // At the first or last item, let spatial navigation leave the
-                // list for a visible control in the requested direction.
-                return false;
-            }
-
-            if (current is RichTextBox richText && richText.IsReadOnly && (direction == NavigationDirection.Up || direction == NavigationDirection.Down))
-            {
-                ScrollViewer viewer = VisualTree.FindDescendant<ScrollViewer>(richText);
-                if (viewer != null)
-                {
-                    if (direction == NavigationDirection.Up)
-                        viewer.LineUp();
-                    else
-                        viewer.LineDown();
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private Boolean MoveIntoSelectedTab(TabItem tab)
-        {
-            if (tab.Content is not FrameworkElement content)
-                return false;
-
-            // A page can start with another TabControl (for example the
-            // Installed Mods / Catalog pair). Crossing that header row must
-            // always land on its selected tab, independent of geometry.
-            TabItem selectedNestedTab = VisualTree.Enumerate<TabControl>(content)
-                .Where(owner => owner.IsVisible && owner.IsEnabled && owner.Items.Count > 1)
-                .OrderBy(VisualTree.GetDepth)
-                .Select(owner => owner.SelectedItem as TabItem)
-                .FirstOrDefault(candidate => candidate != null && IsNavigationCandidate(candidate));
-            
-            if (selectedNestedTab != null)
-            {
-                Focus(selectedNestedTab);
-                return true;
-            }
-
-            List<Control> controls = GetCandidates(content).ToList();
-            if (controls.Count == 0)
-                return false;
-
-            NavigationRectangle tabBounds = GetBounds(tab);
-            IEnumerable<SpatialNavigationCandidate<Control>> candidates = controls.Select(control =>
-                new SpatialNavigationCandidate<Control>(control, GetBounds(control)));
-            
-            SpatialNavigationCandidate<Control> next = SpatialNavigation.FindNext(
-                tabBounds,
-                candidates,
-                NavigationDirection.Down);
-
-            // A custom TabControl template may arrange its content in a separate
-            // presentation branch with coordinates that cannot be compared to
-            // the header. In that case, enter through the top visual row.
-            Control target = next == null
-                ? controls.OrderBy(control => GetBounds(control).Top)
-                          .ThenBy(control => Math.Abs(GetBounds(control).CenterX - tabBounds.CenterX))
-                          .First()
-                : next.Value;
-            
-            Focus(ResolveVerticalTabEntry(target, NavigationDirection.Down));
-            return true;
-        }
-
-        private void Activate(Control current)
-        {
-            if (current is Slider slider)
-            {
-                _activeSlider = slider;
-                ShowFocusAdorner(slider, true);
-                return;
-            }
-
-            if (current is TextBox textBox && !textBox.IsReadOnly)
-            {
-                if (_window.Content is Panel root)
-                    root.Children.Add(new ControllerTextInputOverlay(textBox));
-                return;
-            }
-
-            if (current is ComboBox comboBox)
-            {
-                if (!comboBox.IsDropDownOpen)
-                {
-                    _openComboBox = comboBox;
-                    _openComboBoxInitialIndex = comboBox.SelectedIndex;
-                }
-                comboBox.IsDropDownOpen = !comboBox.IsDropDownOpen;
-                if (comboBox.IsDropDownOpen)
-                {
-                    comboBox.Dispatcher.BeginInvoke(
-                        DispatcherPriority.Input,
-                        new Action(() => SuppressComboBoxPointerInput(comboBox)));
-                }
-                else
-                {
-                    RestoreComboBoxPointerInput();
-                    _openComboBox = null;
-                }
-                return;
-            }
-
-            if (current is TabItem tab)
-            {
-                tab.IsSelected = true;
-                return;
-            }
-
-            if (current is ToggleButton toggle)
-            {
-                Toggle(toggle);
-                return;
-            }
-
-            if (current is Button button)
-            {
-                Invoke(button);
-                return;
-            }
-
-            if (current is ListBox list)
-                ActivateSelectedListItem(list);
-        }
-
-        private void ActivateSelectedListItem(ListBox list)
-        {
-            if (list.SelectedIndex < 0 && list.Items.Count > 0)
-                list.SelectedIndex = 0;
-            if (list.SelectedIndex < 0)
-                return;
-
-            DependencyObject container = list.ItemContainerGenerator.ContainerFromIndex(list.SelectedIndex);
-            ToggleButton toggle = VisualTree.FindDescendant<ToggleButton>(container);
-            if (toggle != null && toggle.IsEnabled && toggle.IsVisible)
-            {
-                Toggle(toggle);
-                return;
-            }
-
-            if (container is Control item)
-            {
-                MouseButtonEventArgs args = new MouseButtonEventArgs(Mouse.PrimaryDevice, Environment.TickCount, MouseButton.Left)
-                {
-                    RoutedEvent = Control.MouseDoubleClickEvent,
-                    Source = item
-                };
-                item.RaiseEvent(args);
-            }
-        }
-
-        private void HandleCancel(FrameworkElement scope, Control current)
-        {
-            if (_activeSlider != null)
-            {
-                Slider slider = _activeSlider;
-                _activeSlider = null;
-                ShowFocusAdorner(slider, false);
-                return;
-            }
-
-            if (_openComboBox != null && _openComboBox.IsDropDownOpen)
-            {
-                _openComboBox.SelectedIndex = _openComboBoxInitialIndex;
-                _openComboBox.IsDropDownOpen = false;
-                RestoreComboBoxPointerInput();
-                _openComboBox = null;
-                return;
-            }
-
-            if (GamepadNavigation.GetIsModalScope(scope))
-            {
-                Button close = GetCandidates(scope).OfType<Button>()
-                    .FirstOrDefault(button => String.Equals(button.Name, "Cancel", StringComparison.OrdinalIgnoreCase))
-                    ?? GetCandidates(scope).OfType<Button>()
-                        .FirstOrDefault(button => String.Equals(button.Name, "Ok", StringComparison.OrdinalIgnoreCase));
-                
-                if (close != null)
-                    Invoke(close);
-                
-                return;
-            }
-
-            TabControl tabControl = FindNearestTabControl(current);
-            if (tabControl != null)
-            {
-                if (tabControl.SelectedItem is TabItem selectedTab && !ReferenceEquals(current, selectedTab))
-                {
-                    Focus(selectedTab);
-                    return;
-                }
-
-                TabControl parentTabControl = FindNearestTabControl(VisualTree.GetParent(tabControl));
-                TabItem parentSelectedTab = parentTabControl == null ? null : parentTabControl.SelectedItem as TabItem;
-                if (parentSelectedTab != null)
-                    Focus(parentSelectedTab);
-            }
-        }
-
-        private void SwitchTab(FrameworkElement scope, Control current, Int32 offset, Boolean root)
-        {
-            TabControl tabControl = root ? FindRootTabControl(scope) : FindNearestTabControl(current);
-            if (tabControl == null)
-                tabControl = FindRootTabControl(scope);
-            if (tabControl != null)
-                ChangeSelectedTab(tabControl, offset);
-        }
-
-        private static TabControl FindNearestTabControl(DependencyObject element)
-        {
-            DependencyObject current = element;
-            while (current != null)
-            {
-                TabControl fromItem = current is not TabItem tab ? null : ItemsControl.ItemsControlFromItemContainer(tab) as TabControl;
-                if (fromItem != null && fromItem.Items.Count > 1)
-                    return fromItem;
-
-                TabControl ancestor = VisualTree.FindAncestor<TabControl>(current, false);
-                if (ancestor == null)
-                    return null;
-                if (ancestor.Items.Count > 1)
-                    return ancestor;
-                current = VisualTree.GetParent(ancestor);
-            }
-            return null;
-        }
-
-        private static TabControl FindRootTabControl(FrameworkElement scope)
-        {
-            return VisualTree.Enumerate<TabControl>(scope)
-                .Where(tab => tab.IsVisible && tab.IsEnabled && tab.Items.Count > 1)
-                .OrderBy(VisualTree.GetDepth)
-                .FirstOrDefault();
-        }
-
-        private void ChangeSelectedTab(TabControl tabControl, Int32 offset)
-        {
-            if (tabControl.Items.Count < 2)
-                return;
-
-            Int32 start = Math.Max(0, tabControl.SelectedIndex);
-            for (Int32 step = 1; step <= tabControl.Items.Count; step++)
-            {
-                Int32 index = (start + offset * step + tabControl.Items.Count) % tabControl.Items.Count;
-                TabItem candidate = tabControl.ItemContainerGenerator.ContainerFromIndex(index) as TabItem
-                                 ?? tabControl.Items[index] as TabItem;
-                if (candidate == null || !candidate.IsEnabled || candidate.Visibility != Visibility.Visible)
-                    continue;
-
-                tabControl.SelectedIndex = index;
-                tabControl.UpdateLayout();
-                Focus(candidate);
-                return;
-            }
-        }
-
-        private static void ChangeSelection(Selector selector, Int32 offset)
-        {
-            if (selector.Items.Count == 0)
-                return;
-
-            Int32 index = selector.SelectedIndex < 0 ? 0 : selector.SelectedIndex + offset;
-            selector.SelectedIndex = Math.Max(0, Math.Min(selector.Items.Count - 1, index));
-        }
-
-        private void Focus(Control control)
-        {
-            if (control == null)
-                return;
-
-            // WPF selectors are not focusable by default. The list itself is
-            // the controller navigation target while its selected row is the
-            // item operated on by the D-pad and action button.
-            ListBox list = control as ListBox;
-            if (list != null)
-                list.Focusable = true;
-
-            ApplyControllerFocusVisualStyle(control);
-            if (!control.Focus())
-            {
-                RestoreFocusVisualStyle();
-                return;
-            }
-
-            if (_openComboBox != null && !ReferenceEquals(_openComboBox, control))
-            {
-                _openComboBox.IsDropDownOpen = false;
-                RestoreComboBoxPointerInput();
-                _openComboBox = null;
-            }
-            if (_activeSlider != null && !ReferenceEquals(_activeSlider, control))
-                _activeSlider = null;
-
-            if (list != null && list.SelectedIndex < 0 && list.Items.Count > 0)
-            {
-                list.SelectedIndex = 0;
-                list.ScrollIntoView(list.SelectedItem);
-            }
-
-            Keyboard.Focus(control);
-            control.BringIntoView();
-            ShowFocusAdorner(control);
-            _controllerFocusAppearanceActive = true;
-            if (_controllerTooltipsEnabled)
-                ShowControllerTooltip(control);
-        }
-
-        private void EnsureControllerFocusAppearance(Control control)
-        {
-            if (_controllerFocusAppearanceActive && ReferenceEquals(_focusVisualOwner, control))
-                return;
-
-            ApplyControllerFocusVisualStyle(control);
-            ShowFocusAdorner(control, ReferenceEquals(control, _activeSlider));
-            _controllerFocusAppearanceActive = true;
-        }
-
-        private void ApplyControllerFocusVisualStyle(Control control)
-        {
-            if (ReferenceEquals(_focusVisualOwner, control))
-                return;
-
-            RestoreFocusVisualStyle();
-            _focusVisualOwner = control;
-            _focusVisualPreviousLocalValue = control.ReadLocalValue(FrameworkElement.FocusVisualStyleProperty);
-            control.SetValue(FrameworkElement.FocusVisualStyleProperty, null);
-        }
-
-        private void RestoreFocusVisualStyle()
-        {
-            if (_focusVisualOwner == null)
-                return;
-
-            if (_focusVisualPreviousLocalValue == DependencyProperty.UnsetValue)
-                _focusVisualOwner.ClearValue(FrameworkElement.FocusVisualStyleProperty);
-            else
-                _focusVisualOwner.SetValue(FrameworkElement.FocusVisualStyleProperty, _focusVisualPreviousLocalValue);
-            _focusVisualOwner = null;
-            _focusVisualPreviousLocalValue = null;
-        }
-
-        private void DeactivateControllerFocusAppearance(Boolean clearKeyboardFocus)
-        {
-            RemoveFocusAdorner();
-            RestoreFocusVisualStyle();
-            _controllerFocusAppearanceActive = false;
-            if (clearKeyboardFocus)
-                Keyboard.ClearFocus();
-        }
-
-        private void ShowFocusAdorner(Control control, Boolean isEditing = false)
-        {
-            RemoveFocusAdorner();
-            AdornerLayer layer = AdornerLayer.GetAdornerLayer(control);
-            if (layer == null)
-                return;
-
-            _focusAdorner = new ControllerFocusAdorner(control, isEditing);
-            layer.Add(_focusAdorner);
-        }
-
-        private void RemoveFocusAdorner()
-        {
-            if (_focusAdorner == null)
-                return;
-
-            AdornerLayer layer = AdornerLayer.GetAdornerLayer(_focusAdorner.AdornedElement);
-            if (layer != null)
-                layer.Remove(_focusAdorner);
-            
-            _focusAdorner = null;
-        }
-
-        private IEnumerable<Control> GetCandidates(FrameworkElement scope)
-        {
-            return VisualTree.Enumerate<Control>(scope).Where(IsNavigationCandidate);
-        }
-
-        private static Boolean IsNavigationCandidate(Control control)
-        {
-            Boolean isList = control is ListBox;
-            if (!control.IsVisible || !control.IsEnabled || !control.IsHitTestVisible ||
-                (!control.Focusable && !isList))
-                return false;
-            
-            if ((!KeyboardNavigation.GetIsTabStop(control) && !isList) || !HasVisibleLayout(control))
-                return false;
-            
-            if (control.TemplatedParent != null)
-                return false;
-            
-            if (control is ListBoxItem || control is ComboBoxItem || control is TabControl ||
-                control is ScrollBar || control is Thumb || control is RepeatButton)
-                return false;
-
-            TabItem tab = control as TabItem;
-            TabControl tabOwner = tab == null ? null : ItemsControl.ItemsControlFromItemContainer(tab) as TabControl;
-            if (tab != null && (tabOwner == null || tabOwner.Items.Count <= 1))
-                return false;
-
-            return VisualTree.FindAncestor<ListBoxItem>(control, false) == null
-                && VisualTree.FindAncestor<ComboBoxItem>(control, false) == null;
-        }
-
-        private static Boolean HasVisibleLayout(FrameworkElement element)
-        {
-            DependencyObject current = element;
-            while (current != null)
-            {
-                if (current is FrameworkElement ancestor &&
-                    (!ancestor.IsVisible || ancestor.Opacity <= 0.01 ||
-                     ancestor.Width == 0.0 || ancestor.Height == 0.0 ||
-                     ancestor.ActualWidth <= 1.0 || ancestor.ActualHeight <= 1.0))
-                {
-                    return false;
-                }
-
-                current = VisualTree.GetParent(current);
-            }
-
-            return true;
-        }
-
-        private NavigationRectangle GetBounds(FrameworkElement element)
-        {
-            try
-            {
-                GeneralTransform transform = element.TransformToAncestor(_window);
-                Rect bounds = transform.TransformBounds(new Rect(0.0, 0.0, element.ActualWidth, element.ActualHeight));
-                return new NavigationRectangle(bounds.X, bounds.Y, bounds.Width, bounds.Height);
-            }
-            catch (InvalidOperationException)
-            {
-                return new NavigationRectangle(0.0, 0.0, element.ActualWidth, element.ActualHeight);
-            }
-        }
-
-        private static void Invoke(Button button)
-        {
-            if (new ButtonAutomationPeer(button).GetPattern(PatternInterface.Invoke) is IInvokeProvider provider)
-                provider.Invoke();
-            else
-                button.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent, button));
-        }
-
-        private static void Toggle(ToggleButton button)
-        {
-            if (new ToggleButtonAutomationPeer(button).GetPattern(PatternInterface.Toggle) is IToggleProvider provider)
-                provider.Toggle();
-            else
-                button.IsChecked = button.IsChecked != true;
-        }
-
-        private void ToggleControllerTooltip(Control current)
-        {
-            if (_controllerTooltipsEnabled)
-            {
-                DisableControllerTooltips();
-                return;
-            }
-
-            _controllerTooltipsEnabled = true;
-            ShowControllerTooltip(current);
-        }
-
-        private void ShowControllerTooltip(Control current)
-        {
-            FrameworkElement owner = FindTooltipOwner(current);
-            if (owner == null)
-            {
-                CloseControllerTooltip();
-                return;
-            }
-
-            if (ReferenceEquals(_controllerToolTipOwner, owner) && _controllerToolTip != null && _controllerToolTip.IsOpen)
-                return;
-
-            CloseControllerTooltip();
-            Object value = ToolTipService.GetToolTip(owner);
-            ToolTip toolTip = value as ToolTip;
-            _controllerToolTipReused = toolTip != null;
-            if (toolTip == null)
-                toolTip = new ToolTip { Content = value };
-            else
-            {
-                _tooltipPreviousPlacement = toolTip.Placement;
-                _tooltipPreviousTarget = toolTip.PlacementTarget;
-                _tooltipPreviousHorizontalOffset = toolTip.HorizontalOffset;
-                _tooltipPreviousVerticalOffset = toolTip.VerticalOffset;
-                _tooltipPreviousStaysOpen = toolTip.StaysOpen;
-            }
-
-            _controllerToolTip = toolTip;
-            _controllerToolTipOwner = owner;
-            toolTip.PlacementTarget = owner;
-            toolTip.Placement = PlacementMode.RelativePoint;
-            toolTip.HorizontalOffset = Math.Max(0.0, owner.ActualWidth - 1.0);
-            toolTip.VerticalOffset = Math.Max(0.0, owner.ActualHeight - 1.0);
-            toolTip.StaysOpen = true;
-            toolTip.IsOpen = true;
-        }
-
-        private void DisableControllerTooltips()
-        {
-            _controllerTooltipsEnabled = false;
-            CloseControllerTooltip();
-        }
-
-        private FrameworkElement FindTooltipOwner(Control current)
-        {
-            if (ToolTipService.GetToolTip(current) != null)
-                return current;
-
-            // Sliders and combo boxes are generated next to their explanatory
-            // text in UiGrid. The tooltip belongs to that text, but from a
-            // controller the pair is perceived as one setting.
-            UiGrid settingsGrid = VisualTree.FindAncestor<UiGrid>(current, false);
-            if (settingsGrid == null)
-                return null;
-
-            Int32 row = Grid.GetRow(current);
-            return VisualTree.Enumerate<FrameworkElement>(settingsGrid)
-                .Where(element => ToolTipService.GetToolTip(element) != null)
-                .Where(element => GetDirectGridRow(element, settingsGrid) == row)
-                .OrderBy(element => DistanceSquared(GetBounds(current), GetBounds(element)))
-                .FirstOrDefault();
-        }
-
-        private static Int32 GetDirectGridRow(DependencyObject element, Grid grid)
-        {
-            DependencyObject current = element;
-            DependencyObject parent;
-            while (current != null && (parent = VisualTree.GetParent(current)) != null)
-            {
-                if (ReferenceEquals(parent, grid))
-                {
-                    return current is not UIElement child ? -1 : Grid.GetRow(child);
-                }
-                current = parent;
-            }
-            return -1;
-        }
-
-        private static Double DistanceSquared(NavigationRectangle first, NavigationRectangle second)
-        {
-            Double x = first.CenterX - second.CenterX;
-            Double y = first.CenterY - second.CenterY;
-            return x * x + y * y;
-        }
-
-        private void CloseControllerTooltip()
-        {
-            if (_controllerToolTip == null)
-                return;
-
-            _controllerToolTip.IsOpen = false;
-            if (_controllerToolTipReused)
-            {
-                _controllerToolTip.Placement = _tooltipPreviousPlacement;
-                _controllerToolTip.PlacementTarget = _tooltipPreviousTarget;
-                _controllerToolTip.HorizontalOffset = _tooltipPreviousHorizontalOffset;
-                _controllerToolTip.VerticalOffset = _tooltipPreviousVerticalOffset;
-                _controllerToolTip.StaysOpen = _tooltipPreviousStaysOpen;
-            }
-
-            _controllerToolTip = null;
-            _controllerToolTipOwner = null;
-            _controllerToolTipReused = false;
-        }
-
-        private void CloseAutomaticTooltips()
-        {
-            foreach (FrameworkElement element in VisualTree.Enumerate<FrameworkElement>(_window))
-            {
-                if (ToolTipService.GetToolTip(element) is ToolTip toolTip && toolTip.IsOpen)
-                    toolTip.IsOpen = false;
-            }
-        }
-
-        private void OnPreviewMouseDown(Object sender, MouseButtonEventArgs e)
-        {
-            EnterMouseMode();
-            _activeSlider = null;
-            RemoveFocusAdorner();
-        }
-
-        private void OnPreviewMouseMove(Object sender, MouseEventArgs e)
-        {
-            if (!_controllerInputActive)
-                return;
-            RestoreMouseModeAfterPhysicalMovement();
-        }
-
-        private void OnPreviewMouseWheel(Object sender, MouseWheelEventArgs e)
-        {
-            EnterMouseMode();
-        }
-
-        private void OnPreProcessInput(Object sender, PreProcessInputEventArgs e)
-        {
-            InputEventArgs input = e.StagingItem.Input;
-            if (input is KeyEventArgs key && key.IsDown)
-            {
-                DisableControllerTooltips();
-                DeactivateControllerFocusAppearance(false);
-                return;
-            }
-
-            if (!_controllerInputActive)
-                return;
-
-            if (input is MouseButtonEventArgs || input is MouseWheelEventArgs)
-            {
-                EnterMouseMode();
-                return;
-            }
-
-            if (input is MouseEventArgs)
-                RestoreMouseModeAfterPhysicalMovement();
-        }
-
-        private void RestoreMouseModeAfterPhysicalMovement()
-        {
-            NativePointerPosition position;
-            if (!_hasControllerPointerPosition ||
-                !NativePointer.TryGetPosition(out position) ||
-                !position.Equals(_controllerPointerPosition))
-            {
-                EnterMouseMode();
-            }
-        }
-
-        private void EnterControllerMode()
-        {
-            if (_controllerInputActive)
-            {
-                Mouse.OverrideCursor = Cursors.None;
-                return;
-            }
-
-            _cursorBeforeControllerMode = Mouse.OverrideCursor;
-            _controllerInputActive = true;
-            GamepadNavigation.IsControllerInputActive = true;
-            _hasControllerPointerPosition = NativePointer.TryGetPosition(out _controllerPointerPosition);
-            Mouse.OverrideCursor = Cursors.None;
-            CloseAutomaticTooltips();
-            InstallMouseInputShield();
-        }
-
-        private void EnterMouseMode()
-        {
-            DisableControllerTooltips();
-            DeactivateControllerFocusAppearance(true);
-            if (!_controllerInputActive)
-                return;
-
-            _controllerInputActive = false;
-            GamepadNavigation.IsControllerInputActive = false;
-            _hasControllerPointerPosition = false;
-            RestoreComboBoxPointerInput();
-            RemoveMouseInputShield();
-            Mouse.OverrideCursor = _cursorBeforeControllerMode;
-            _cursorBeforeControllerMode = null;
-        }
-
-        private void SuppressComboBoxPointerInput(ComboBox comboBox)
-        {
-            if (!_controllerInputActive || !comboBox.IsDropDownOpen)
-                return;
-
-            comboBox.ApplyTemplate();
-            UIElement content = comboBox.Template.FindName("PART_Popup", comboBox) is not Popup popup ? null : popup.Child;
-            if (content == null)
-                return;
-
-            RestoreComboBoxPointerInput();
-            _suppressedComboBoxPopupContent = content;
-            _popupContentWasHitTestVisible = content.IsHitTestVisible;
-            content.IsHitTestVisible = false;
-            Mouse.OverrideCursor = Cursors.None;
-        }
-
-        private void RestoreComboBoxPointerInput()
-        {
-            if (_suppressedComboBoxPopupContent == null)
-                return;
-
-            _suppressedComboBoxPopupContent.IsHitTestVisible = _popupContentWasHitTestVisible;
-            _suppressedComboBoxPopupContent = null;
-        }
-
-        private void InstallMouseInputShield()
-        {
-            if (_window.Content is not Panel root || _mouseInputShield != null)
-                return;
-
-            _mouseInputShield = new Border
-            {
-                Background = Brushes.Transparent,
-                Cursor = Cursors.None,
-                ForceCursor = true,
-                Focusable = false,
-                IsHitTestVisible = true
-            };
-            
-            Panel.SetZIndex(_mouseInputShield, Int32.MaxValue);
-            root.Children.Add(_mouseInputShield);
-        }
-
-        private void RemoveMouseInputShield()
-        {
-            if (_mouseInputShield == null)
-                return;
-
-            if (_mouseInputShield.Parent is Panel parent)
-                parent.Children.Remove(_mouseInputShield);
-            
-            _mouseInputShield = null;
-        }
-
-        private void OnWindowClosed(Object sender, EventArgs e)
-        {
-            Dispose();
-        }
+        private void OnWindowClosed(Object sender, EventArgs e) => Dispose();
 
         private sealed class EmptyDisposable : IDisposable
         {
             public static readonly EmptyDisposable Instance = new EmptyDisposable();
             public void Dispose() { }
         }
-    }
-
-    internal sealed class ControllerFocusAdorner : Adorner
-    {
-        private const Double StrokeThickness = 3.0;
-        private readonly Boolean _isEditing;
-
-        public ControllerFocusAdorner(UIElement adornedElement, Boolean isEditing)
-            : base(adornedElement)
-        {
-            _isEditing = isEditing;
-            IsHitTestVisible = false;
-        }
-
-        protected override void OnRender(DrawingContext drawingContext)
-        {
-            Brush brush = TryFindResource("BrushAccentColorPressed") as Brush ?? Brushes.DeepSkyBlue;
-            Double thickness = _isEditing ? StrokeThickness + 2.0 : StrokeThickness;
-            Pen pen = new Pen(brush, thickness);
-            Rect bounds = new Rect(
-                -thickness,
-                -thickness,
-                Math.Max(0.0, AdornedElement.RenderSize.Width + thickness * 2.0),
-                Math.Max(0.0, AdornedElement.RenderSize.Height + thickness * 2.0));
-            
-            drawingContext.DrawRoundedRectangle(null, pen, bounds, 5.0, 5.0);
-        }
-    }
-
-    internal static class VisualTree
-    {
-        public static IEnumerable<T> Enumerate<T>(DependencyObject root) where T : DependencyObject
-        {
-            if (root == null)
-                yield break;
-
-            if (root is T typed)
-                yield return typed;
-
-            Int32 count = VisualTreeHelper.GetChildrenCount(root);
-            for (Int32 index = 0; index < count; index++)
-            {
-                foreach (T descendant in Enumerate<T>(VisualTreeHelper.GetChild(root, index)))
-                    yield return descendant;
-            }
-        }
-
-        public static T FindAncestor<T>(DependencyObject element, Boolean includeSelf) where T : DependencyObject
-        {
-            DependencyObject current = includeSelf ? element : GetParent(element);
-            while (current != null)
-            {
-                if (current is T typed)
-                    return typed;
-                current = GetParent(current);
-            }
-            return null;
-        }
-
-        public static T FindDescendant<T>(DependencyObject root) where T : DependencyObject
-        {
-            return Enumerate<T>(root).FirstOrDefault();
-        }
-
-        public static Boolean IsDescendantOf(DependencyObject element, DependencyObject ancestor)
-        {
-            DependencyObject current = element;
-            while (current != null)
-            {
-                if (ReferenceEquals(current, ancestor))
-                    return true;
-                current = GetParent(current);
-            }
-            return false;
-        }
-
-        public static DependencyObject GetParent(DependencyObject element)
-        {
-            if (element == null)
-                return null;
-            
-            if (element is Visual || element is System.Windows.Media.Media3D.Visual3D)
-                return VisualTreeHelper.GetParent(element);
-            
-            return (element is not ContentElement content ? null : ContentOperations.GetParent(content))
-                   ?? LogicalTreeHelper.GetParent(element);
-        }
-
-        public static Int32 GetDepth(DependencyObject element)
-        {
-            Int32 depth = 0;
-            
-            while ((element = GetParent(element)) != null)
-                depth++;
-            
-            return depth;
-        }
-    }
-
-    internal struct NativePointerPosition : IEquatable<NativePointerPosition>
-    {
-        public Int32 X;
-        public Int32 Y;
-
-        public Boolean Equals(NativePointerPosition other)
-        {
-            return X == other.X && Y == other.Y;
-        }
-
-        public override Boolean Equals(Object obj)
-        {
-            return obj is NativePointerPosition && Equals((NativePointerPosition)obj);
-        }
-
-        public override Int32 GetHashCode()
-        {
-            unchecked
-            {
-                return (X * 397) ^ Y;
-            }
-        }
-    }
-
-    internal static class NativePointer
-    {
-        public static Boolean TryGetPosition(out NativePointerPosition position)
-        {
-            return GetCursorPos(out position);
-        }
-
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        private static extern Boolean GetCursorPos(out NativePointerPosition point);
-    }
-
-    internal static class NativeDialogControllerBridge
-    {
-        private const UInt32 Command = 0x0111;
-        private const UInt32 KeyDown = 0x0100;
-        private const UInt32 KeyUp = 0x0101;
-        private const Int32 OkButton = 1;
-        private const Int32 CancelButton = 2;
-        private const Int32 NoButton = 7;
-        private const Int32 Enter = 0x0D;
-        private const Int32 Escape = 0x1B;
-        private const Int32 ArrowLeft = 0x25;
-        private const Int32 ArrowUp = 0x26;
-        private const Int32 ArrowRight = 0x27;
-        private const Int32 ArrowDown = 0x28;
-
-        public static Boolean IsCurrentProcessInForeground()
-        {
-            IntPtr window = GetForegroundWindow();
-            if (window == IntPtr.Zero)
-                return false;
-
-            UInt32 processId;
-            GetWindowThreadProcessId(window, out processId);
-            return processId == (UInt32)Process.GetCurrentProcess().Id;
-        }
-
-        public static void Send(ControllerButton actions)
-        {
-            if ((actions & ControllerButton.Cancel) != 0)
-                Cancel();
-            else if ((actions & ControllerButton.Confirm) != 0)
-                SendKey(Enter);
-            else if ((actions & ControllerButton.Up) != 0)
-                SendKey(ArrowUp);
-            else if ((actions & ControllerButton.Down) != 0)
-                SendKey(ArrowDown);
-            else if ((actions & ControllerButton.Left) != 0)
-                SendKey(ArrowLeft);
-            else if ((actions & ControllerButton.Right) != 0)
-                SendKey(ArrowRight);
-        }
-
-        private static void Cancel()
-        {
-            IntPtr window = GetForegroundWindow();
-            if (window == IntPtr.Zero)
-                return;
-
-            // MessageBox does not accept Escape for Yes/No dialogs. Invoke its
-            // semantic cancel choice directly: Cancel, then No, or OK for an
-            // informational dialog. Non-MessageBox modal windows fall back to
-            // the ordinary Escape key path.
-            if (TryInvokeDialogButton(window, CancelButton) ||
-                TryInvokeDialogButton(window, NoButton) ||
-                TryInvokeDialogButton(window, OkButton))
-            {
-                return;
-            }
-
-            SendKey(window, Escape);
-        }
-
-        private static Boolean TryInvokeDialogButton(IntPtr window, Int32 buttonId)
-        {
-            IntPtr button = GetDlgItem(window, buttonId);
-            return button != IntPtr.Zero &&
-                   PostMessage(window, Command, new IntPtr(buttonId), button);
-        }
-
-        private static void SendKey(Int32 virtualKey)
-        {
-            IntPtr window = GetForegroundWindow();
-            if (window == IntPtr.Zero)
-                return;
-            SendKey(window, virtualKey);
-        }
-
-        private static void SendKey(IntPtr window, Int32 virtualKey)
-        {
-            PostMessage(window, KeyDown, new IntPtr(virtualKey), IntPtr.Zero);
-            PostMessage(window, KeyUp, new IntPtr(virtualKey), IntPtr.Zero);
-        }
-
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        private static extern IntPtr GetForegroundWindow();
-
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        private static extern UInt32 GetWindowThreadProcessId(IntPtr window, out UInt32 processId);
-
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        private static extern IntPtr GetDlgItem(IntPtr dialog, Int32 itemId);
-
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        private static extern Boolean PostMessage(IntPtr window, UInt32 message, IntPtr wParam, IntPtr lParam);
     }
 }

--- a/Memoria.Launcher/Controller/GamepadNavigation.cs
+++ b/Memoria.Launcher/Controller/GamepadNavigation.cs
@@ -1,0 +1,1352 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Windows;
+using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Threading;
+
+namespace Memoria.Launcher.Controller
+{
+    /// <summary>
+    /// Attached metadata used by the generic controller navigation service.
+    /// </summary>
+    public static class GamepadNavigation
+    {
+        public static Boolean IsControllerInputActive { get; internal set; }
+
+        public static readonly DependencyProperty IsDefaultFocusProperty = DependencyProperty.RegisterAttached(
+            "IsDefaultFocus",
+            typeof(Boolean),
+            typeof(GamepadNavigation),
+            new FrameworkPropertyMetadata(false));
+
+        public static readonly DependencyProperty IsModalScopeProperty = DependencyProperty.RegisterAttached(
+            "IsModalScope",
+            typeof(Boolean),
+            typeof(GamepadNavigation),
+            new FrameworkPropertyMetadata(false));
+
+        public static void SetIsDefaultFocus(DependencyObject element, Boolean value) => element.SetValue(IsDefaultFocusProperty, value);
+        public static Boolean GetIsDefaultFocus(DependencyObject element) => (Boolean)element.GetValue(IsDefaultFocusProperty);
+        public static void SetIsModalScope(DependencyObject element, Boolean value) => element.SetValue(IsModalScopeProperty, value);
+        public static Boolean GetIsModalScope(DependencyObject element) => (Boolean)element.GetValue(IsModalScopeProperty);
+    }
+
+    /// <summary>
+    /// Coordinates controller input, spatial focus navigation and standard WPF
+    /// control actions without coupling individual launcher screens to XInput.
+    /// </summary>
+    internal sealed class GamepadNavigationService : IDisposable
+    {
+        private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(16);
+        private static readonly TimeSpan InitialRepeatDelay = TimeSpan.FromMilliseconds(350);
+        private static readonly TimeSpan RepeatInterval = TimeSpan.FromMilliseconds(90);
+
+        private readonly Window _window;
+        private readonly IControllerInputSource _input;
+        private readonly ControllerButtonRepeater _repeater;
+        private readonly DispatcherTimer _timer;
+        private readonly Stopwatch _clock = Stopwatch.StartNew();
+
+        private ControllerFocusAdorner _focusAdorner;
+        private Control _focusVisualOwner;
+        private Object _focusVisualPreviousLocalValue;
+        private Boolean _controllerFocusAppearanceActive;
+        private ComboBox _openComboBox;
+        private Int32 _openComboBoxInitialIndex;
+        private UIElement _suppressedComboBoxPopupContent;
+        private Boolean _popupContentWasHitTestVisible;
+        private Slider _activeSlider;
+        private Border _mouseInputShield;
+        private NativePointerPosition _controllerPointerPosition;
+        private Boolean _hasControllerPointerPosition;
+        private Cursor _cursorBeforeControllerMode;
+        private Boolean _controllerInputActive;
+        private ToolTip _controllerToolTip;
+        private FrameworkElement _controllerToolTipOwner;
+        private Boolean _controllerTooltipsEnabled;
+        private Boolean _controllerToolTipReused;
+        private PlacementMode _tooltipPreviousPlacement;
+        private UIElement _tooltipPreviousTarget;
+        private Double _tooltipPreviousHorizontalOffset;
+        private Double _tooltipPreviousVerticalOffset;
+        private Boolean _tooltipPreviousStaysOpen;
+        private Boolean _disposed;
+
+        private GamepadNavigationService(Window window, IControllerInputSource input)
+        {
+            _window = window ?? throw new ArgumentNullException(nameof(window));
+            _input = input ?? throw new ArgumentNullException(nameof(input));
+            _repeater = new ControllerButtonRepeater(InitialRepeatDelay, RepeatInterval);
+            _timer = new DispatcherTimer(DispatcherPriority.Input, window.Dispatcher)
+            {
+                Interval = PollInterval
+            };
+            _timer.Tick += OnTick;
+            _window.PreviewMouseDown += OnPreviewMouseDown;
+            _window.PreviewMouseMove += OnPreviewMouseMove;
+            _window.PreviewMouseWheel += OnPreviewMouseWheel;
+            InputManager.Current.PreProcessInput += OnPreProcessInput;
+            _window.Closed += OnWindowClosed;
+            _timer.Start();
+        }
+
+        public static IDisposable Attach(Window window)
+        {
+            try
+            {
+                return new GamepadNavigationService(window, new XInputControllerInputSource());
+            }
+            catch (Exception exception)
+            {
+                AppLogger.GetLogger().Warn(exception, "Controller navigation could not be initialized.");
+                return EmptyDisposable.Instance;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            _timer.Stop();
+            _timer.Tick -= OnTick;
+            _window.PreviewMouseDown -= OnPreviewMouseDown;
+            _window.PreviewMouseMove -= OnPreviewMouseMove;
+            _window.PreviewMouseWheel -= OnPreviewMouseWheel;
+            InputManager.Current.PreProcessInput -= OnPreProcessInput;
+            _window.Closed -= OnWindowClosed;
+            EnterMouseMode();
+            RemoveFocusAdorner();
+            _input.Dispose();
+        }
+
+        private void OnTick(Object sender, EventArgs e)
+        {
+            if (_window.WindowState == WindowState.Minimized)
+            {
+                _repeater.Reset();
+                return;
+            }
+
+            Boolean nativeDialogActive = !_window.IsActive && NativeDialogControllerBridge.IsCurrentProcessInForeground();
+            if (!_window.IsActive && !nativeDialogActive)
+            {
+                _repeater.Reset();
+                return;
+            }
+
+            ControllerState state;
+            if (!_input.TryGetState(out state))
+            {
+                _repeater.Reset();
+                return;
+            }
+
+            ControllerButton actions = _repeater.Update(state.Buttons, _clock.Elapsed);
+            if (actions == ControllerButton.None)
+                return;
+
+            EnterControllerMode();
+
+            if (nativeDialogActive)
+            {
+                NativeDialogControllerBridge.Send(actions);
+                return;
+            }
+
+            FrameworkElement scope = FindActiveScope();
+            if (scope is ControllerTextInputOverlay textInput && (actions & ControllerButton.SubmitTextInput) != 0)
+            {
+                textInput.Accept();
+                return;
+            }
+
+            Control current = FindFocusedControl(scope);
+            if (current == null)
+            {
+                FocusInitialControl(scope);
+                current = FindFocusedControl(scope);
+                if (current == null)
+                    return;
+
+                ControllerButton tabActions = ControllerButton.PreviousTab
+                                            | ControllerButton.NextTab
+                                            | ControllerButton.PreviousRootTab
+                                            | ControllerButton.NextRootTab;
+                if ((actions & tabActions) == 0)
+                    return;
+            }
+
+            EnsureControllerFocusAppearance(current);
+
+            if ((actions & ControllerButton.ToggleTooltip) != 0)
+            {
+                ToggleControllerTooltip(current);
+                return;
+            }
+
+            if (_activeSlider != null)
+            {
+                if (!_activeSlider.IsVisible || !_activeSlider.IsEnabled)
+                    _activeSlider = null;
+                else
+                {
+                    if ((actions & (ControllerButton.Confirm | ControllerButton.Cancel)) != 0)
+                        HandleCancel(scope, _activeSlider);
+                    else if ((actions & ControllerButton.Left) != 0)
+                        Move(scope, _activeSlider, NavigationDirection.Left);
+                    else if ((actions & ControllerButton.Right) != 0)
+                        Move(scope, _activeSlider, NavigationDirection.Right);
+
+                    // A slider keeps directional focus until A or B releases it.
+                    return;
+                }
+            }
+
+            if ((actions & ControllerButton.Cancel) != 0)
+                HandleCancel(scope, current);
+            else if ((actions & ControllerButton.Confirm) != 0)
+                Activate(current);
+            else if ((actions & ControllerButton.PreviousRootTab) != 0)
+                SwitchTab(scope, current, -1, true);
+            else if ((actions & ControllerButton.NextRootTab) != 0)
+                SwitchTab(scope, current, 1, true);
+            else if ((actions & ControllerButton.PreviousTab) != 0)
+                SwitchTab(scope, current, -1, false);
+            else if ((actions & ControllerButton.NextTab) != 0)
+                SwitchTab(scope, current, 1, false);
+            else if ((actions & ControllerButton.Up) != 0)
+                Move(scope, current, NavigationDirection.Up);
+            else if ((actions & ControllerButton.Down) != 0)
+                Move(scope, current, NavigationDirection.Down);
+            else if ((actions & ControllerButton.Left) != 0)
+                Move(scope, current, NavigationDirection.Left);
+            else if ((actions & ControllerButton.Right) != 0)
+                Move(scope, current, NavigationDirection.Right);
+        }
+
+        private FrameworkElement FindActiveScope()
+        {
+            return VisualTree
+                       .Enumerate<FrameworkElement>(_window)
+                       .LastOrDefault(element => element.IsVisible && GamepadNavigation.GetIsModalScope(element))
+                   ?? (FrameworkElement)_window;
+        }
+
+        private Control FindFocusedControl(FrameworkElement scope)
+        {
+            if (_openComboBox != null && _openComboBox.IsDropDownOpen && VisualTree.IsDescendantOf(_openComboBox, scope))
+                return _openComboBox;
+
+            if (Keyboard.FocusedElement is not DependencyObject focused || !VisualTree.IsDescendantOf(focused, scope))
+                return null;
+
+            ListBox ownerList = VisualTree.FindAncestor<ListBox>(focused, true);
+            if (ownerList != null && VisualTree.IsDescendantOf(ownerList, scope))
+                return ownerList;
+
+            Control control = VisualTree.FindAncestor<Control>(focused, true);
+            return control != null && IsNavigationCandidate(control) ? control : null;
+        }
+
+        private void FocusInitialControl(FrameworkElement scope)
+        {
+            List<Control> controls = GetCandidates(scope).ToList();
+            if (controls.Count == 0)
+                return;
+
+            Control target = controls.FirstOrDefault(GamepadNavigation.GetIsDefaultFocus)
+                          ?? controls.OrderBy(control => GetBounds(control).Top)
+                                     .ThenBy(control => GetBounds(control).Left)
+                                     .First();
+            Focus(target);
+        }
+
+        private void Move(FrameworkElement scope, Control current, NavigationDirection direction)
+        {
+            if (HandleControlDirection(current, direction))
+                return;
+
+            if (!(current is TabItem) && MoveWithinSelectedTab(current, direction))
+                return;
+
+            NavigationRectangle currentBounds = GetBounds(current);
+            IEnumerable<SpatialNavigationCandidate<Control>> candidates = GetCandidates(scope)
+                .Where(control => !ReferenceEquals(control, current))
+                .Select(control => new SpatialNavigationCandidate<Control>(control, GetBounds(control)));
+            
+            SpatialNavigationCandidate<Control> next = SpatialNavigation.FindNext(currentBounds, candidates, direction);
+            if (next != null)
+                Focus(ResolveVerticalTabEntry(next.Value, direction));
+        }
+
+        private static Control ResolveVerticalTabEntry(Control candidate, NavigationDirection direction)
+        {
+            if (direction != NavigationDirection.Up && direction != NavigationDirection.Down)
+                return candidate;
+
+            if (candidate is not TabItem candidateTab)
+                return candidate;
+
+            TabItem selectedTab = ItemsControl.ItemsControlFromItemContainer(candidateTab) is not TabControl owner ? null : owner.SelectedItem as TabItem;
+            return selectedTab ?? candidateTab;
+        }
+
+        private Boolean MoveWithinSelectedTab(Control current, NavigationDirection direction)
+        {
+            TabControl owner = FindNearestTabControl(current);
+            TabItem selectedTab = owner == null ? null : owner.SelectedItem as TabItem;
+            FrameworkElement content = selectedTab == null ? null : selectedTab.Content as FrameworkElement;
+            if (content == null || !VisualTree.IsDescendantOf(current, content))
+                return false;
+
+            NavigationRectangle currentBounds = GetBounds(current);
+            IEnumerable<SpatialNavigationCandidate<Control>> candidates = GetCandidates(content)
+                .Where(control => !ReferenceEquals(control, current))
+                .Select(control => new SpatialNavigationCandidate<Control>(control, GetBounds(control)));
+            SpatialNavigationCandidate<Control> next = SpatialNavigation.FindNext(currentBounds, candidates, direction);
+            if (next != null)
+            {
+                Focus(ResolveVerticalTabEntry(next.Value, direction));
+                return true;
+            }
+
+            // Leaving through the top of a page always returns to the header of
+            // that same page. Header position must not redirect the focus to a
+            // different tab that merely happens to be vertically aligned.
+            if (direction == NavigationDirection.Up)
+                Focus(selectedTab);
+
+            // Other edges are closed: without a neighbour on this page the
+            // focus stays in place instead of leaking into another tab.
+            return true;
+        }
+
+        private Boolean HandleControlDirection(Control current, NavigationDirection direction)
+        {
+            if (current is TabItem tab)
+            {
+                if (direction == NavigationDirection.Down && tab.IsSelected && MoveIntoSelectedTab(tab))
+                    return true;
+
+                if (direction == NavigationDirection.Left || direction == NavigationDirection.Right)
+                {
+                    if (ItemsControl.ItemsControlFromItemContainer(tab) is TabControl owner)
+                    {
+                        ChangeSelectedTab(owner, direction == NavigationDirection.Left ? -1 : 1);
+                        return true;
+                    }
+                }
+            }
+
+            if (current is ComboBox comboBox)
+            {
+                if (comboBox.IsDropDownOpen && (direction == NavigationDirection.Up || direction == NavigationDirection.Down))
+                {
+                    ChangeSelection(comboBox, direction == NavigationDirection.Up ? -1 : 1);
+                    return true;
+                }
+            }
+
+            if (current is Slider slider && ReferenceEquals(slider, _activeSlider))
+            {
+                if (direction == NavigationDirection.Left || direction == NavigationDirection.Right)
+                {
+                    Double change = slider.TickFrequency > 0.0 ? slider.TickFrequency : slider.SmallChange;
+                    if (change <= 0.0)
+                        change = Math.Max((slider.Maximum - slider.Minimum) / 20.0, 1.0);
+                    slider.Value = Math.Max(slider.Minimum, Math.Min(slider.Maximum,
+                        slider.Value + (direction == NavigationDirection.Left ? -change : change)));
+                }
+
+                // Editing is modal for directional input. This prevents an
+                // accidental vertical press from leaving the slider before B.
+                return true;
+            }
+
+            if (current is ListBox list && (direction == NavigationDirection.Up || direction == NavigationDirection.Down))
+            {
+                Int32 nextIndex = list.SelectedIndex;
+                if (nextIndex < 0)
+                    nextIndex = direction == NavigationDirection.Up ? list.Items.Count - 1 : 0;
+                else
+                    nextIndex += direction == NavigationDirection.Up ? -1 : 1;
+
+                if (nextIndex >= 0 && nextIndex < list.Items.Count)
+                {
+                    list.SelectedIndex = nextIndex;
+                    list.ScrollIntoView(list.SelectedItem);
+                    return true;
+                }
+
+                // At the first or last item, let spatial navigation leave the
+                // list for a visible control in the requested direction.
+                return false;
+            }
+
+            if (current is RichTextBox richText && richText.IsReadOnly && (direction == NavigationDirection.Up || direction == NavigationDirection.Down))
+            {
+                ScrollViewer viewer = VisualTree.FindDescendant<ScrollViewer>(richText);
+                if (viewer != null)
+                {
+                    if (direction == NavigationDirection.Up)
+                        viewer.LineUp();
+                    else
+                        viewer.LineDown();
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private Boolean MoveIntoSelectedTab(TabItem tab)
+        {
+            if (tab.Content is not FrameworkElement content)
+                return false;
+
+            // A page can start with another TabControl (for example the
+            // Installed Mods / Catalog pair). Crossing that header row must
+            // always land on its selected tab, independent of geometry.
+            TabItem selectedNestedTab = VisualTree.Enumerate<TabControl>(content)
+                .Where(owner => owner.IsVisible && owner.IsEnabled && owner.Items.Count > 1)
+                .OrderBy(VisualTree.GetDepth)
+                .Select(owner => owner.SelectedItem as TabItem)
+                .FirstOrDefault(candidate => candidate != null && IsNavigationCandidate(candidate));
+            
+            if (selectedNestedTab != null)
+            {
+                Focus(selectedNestedTab);
+                return true;
+            }
+
+            List<Control> controls = GetCandidates(content).ToList();
+            if (controls.Count == 0)
+                return false;
+
+            NavigationRectangle tabBounds = GetBounds(tab);
+            IEnumerable<SpatialNavigationCandidate<Control>> candidates = controls.Select(control =>
+                new SpatialNavigationCandidate<Control>(control, GetBounds(control)));
+            
+            SpatialNavigationCandidate<Control> next = SpatialNavigation.FindNext(
+                tabBounds,
+                candidates,
+                NavigationDirection.Down);
+
+            // A custom TabControl template may arrange its content in a separate
+            // presentation branch with coordinates that cannot be compared to
+            // the header. In that case, enter through the top visual row.
+            Control target = next == null
+                ? controls.OrderBy(control => GetBounds(control).Top)
+                          .ThenBy(control => Math.Abs(GetBounds(control).CenterX - tabBounds.CenterX))
+                          .First()
+                : next.Value;
+            
+            Focus(ResolveVerticalTabEntry(target, NavigationDirection.Down));
+            return true;
+        }
+
+        private void Activate(Control current)
+        {
+            if (current is Slider slider)
+            {
+                _activeSlider = slider;
+                ShowFocusAdorner(slider, true);
+                return;
+            }
+
+            if (current is TextBox textBox && !textBox.IsReadOnly)
+            {
+                if (_window.Content is Panel root)
+                    root.Children.Add(new ControllerTextInputOverlay(textBox));
+                return;
+            }
+
+            if (current is ComboBox comboBox)
+            {
+                if (!comboBox.IsDropDownOpen)
+                {
+                    _openComboBox = comboBox;
+                    _openComboBoxInitialIndex = comboBox.SelectedIndex;
+                }
+                comboBox.IsDropDownOpen = !comboBox.IsDropDownOpen;
+                if (comboBox.IsDropDownOpen)
+                {
+                    comboBox.Dispatcher.BeginInvoke(
+                        DispatcherPriority.Input,
+                        new Action(() => SuppressComboBoxPointerInput(comboBox)));
+                }
+                else
+                {
+                    RestoreComboBoxPointerInput();
+                    _openComboBox = null;
+                }
+                return;
+            }
+
+            if (current is TabItem tab)
+            {
+                tab.IsSelected = true;
+                return;
+            }
+
+            if (current is ToggleButton toggle)
+            {
+                Toggle(toggle);
+                return;
+            }
+
+            if (current is Button button)
+            {
+                Invoke(button);
+                return;
+            }
+
+            if (current is ListBox list)
+                ActivateSelectedListItem(list);
+        }
+
+        private void ActivateSelectedListItem(ListBox list)
+        {
+            if (list.SelectedIndex < 0 && list.Items.Count > 0)
+                list.SelectedIndex = 0;
+            if (list.SelectedIndex < 0)
+                return;
+
+            DependencyObject container = list.ItemContainerGenerator.ContainerFromIndex(list.SelectedIndex);
+            ToggleButton toggle = VisualTree.FindDescendant<ToggleButton>(container);
+            if (toggle != null && toggle.IsEnabled && toggle.IsVisible)
+            {
+                Toggle(toggle);
+                return;
+            }
+
+            if (container is Control item)
+            {
+                MouseButtonEventArgs args = new MouseButtonEventArgs(Mouse.PrimaryDevice, Environment.TickCount, MouseButton.Left)
+                {
+                    RoutedEvent = Control.MouseDoubleClickEvent,
+                    Source = item
+                };
+                item.RaiseEvent(args);
+            }
+        }
+
+        private void HandleCancel(FrameworkElement scope, Control current)
+        {
+            if (_activeSlider != null)
+            {
+                Slider slider = _activeSlider;
+                _activeSlider = null;
+                ShowFocusAdorner(slider, false);
+                return;
+            }
+
+            if (_openComboBox != null && _openComboBox.IsDropDownOpen)
+            {
+                _openComboBox.SelectedIndex = _openComboBoxInitialIndex;
+                _openComboBox.IsDropDownOpen = false;
+                RestoreComboBoxPointerInput();
+                _openComboBox = null;
+                return;
+            }
+
+            if (GamepadNavigation.GetIsModalScope(scope))
+            {
+                Button close = GetCandidates(scope).OfType<Button>()
+                    .FirstOrDefault(button => String.Equals(button.Name, "Cancel", StringComparison.OrdinalIgnoreCase))
+                    ?? GetCandidates(scope).OfType<Button>()
+                        .FirstOrDefault(button => String.Equals(button.Name, "Ok", StringComparison.OrdinalIgnoreCase));
+                
+                if (close != null)
+                    Invoke(close);
+                
+                return;
+            }
+
+            TabControl tabControl = FindNearestTabControl(current);
+            if (tabControl != null)
+            {
+                if (tabControl.SelectedItem is TabItem selectedTab && !ReferenceEquals(current, selectedTab))
+                {
+                    Focus(selectedTab);
+                    return;
+                }
+
+                TabControl parentTabControl = FindNearestTabControl(VisualTree.GetParent(tabControl));
+                TabItem parentSelectedTab = parentTabControl == null ? null : parentTabControl.SelectedItem as TabItem;
+                if (parentSelectedTab != null)
+                    Focus(parentSelectedTab);
+            }
+        }
+
+        private void SwitchTab(FrameworkElement scope, Control current, Int32 offset, Boolean root)
+        {
+            TabControl tabControl = root ? FindRootTabControl(scope) : FindNearestTabControl(current);
+            if (tabControl == null)
+                tabControl = FindRootTabControl(scope);
+            if (tabControl != null)
+                ChangeSelectedTab(tabControl, offset);
+        }
+
+        private static TabControl FindNearestTabControl(DependencyObject element)
+        {
+            DependencyObject current = element;
+            while (current != null)
+            {
+                TabControl fromItem = current is not TabItem tab ? null : ItemsControl.ItemsControlFromItemContainer(tab) as TabControl;
+                if (fromItem != null && fromItem.Items.Count > 1)
+                    return fromItem;
+
+                TabControl ancestor = VisualTree.FindAncestor<TabControl>(current, false);
+                if (ancestor == null)
+                    return null;
+                if (ancestor.Items.Count > 1)
+                    return ancestor;
+                current = VisualTree.GetParent(ancestor);
+            }
+            return null;
+        }
+
+        private static TabControl FindRootTabControl(FrameworkElement scope)
+        {
+            return VisualTree.Enumerate<TabControl>(scope)
+                .Where(tab => tab.IsVisible && tab.IsEnabled && tab.Items.Count > 1)
+                .OrderBy(VisualTree.GetDepth)
+                .FirstOrDefault();
+        }
+
+        private void ChangeSelectedTab(TabControl tabControl, Int32 offset)
+        {
+            if (tabControl.Items.Count < 2)
+                return;
+
+            Int32 start = Math.Max(0, tabControl.SelectedIndex);
+            for (Int32 step = 1; step <= tabControl.Items.Count; step++)
+            {
+                Int32 index = (start + offset * step + tabControl.Items.Count) % tabControl.Items.Count;
+                TabItem candidate = tabControl.ItemContainerGenerator.ContainerFromIndex(index) as TabItem
+                                 ?? tabControl.Items[index] as TabItem;
+                if (candidate == null || !candidate.IsEnabled || candidate.Visibility != Visibility.Visible)
+                    continue;
+
+                tabControl.SelectedIndex = index;
+                tabControl.UpdateLayout();
+                Focus(candidate);
+                return;
+            }
+        }
+
+        private static void ChangeSelection(Selector selector, Int32 offset)
+        {
+            if (selector.Items.Count == 0)
+                return;
+
+            Int32 index = selector.SelectedIndex < 0 ? 0 : selector.SelectedIndex + offset;
+            selector.SelectedIndex = Math.Max(0, Math.Min(selector.Items.Count - 1, index));
+        }
+
+        private void Focus(Control control)
+        {
+            if (control == null)
+                return;
+
+            // WPF selectors are not focusable by default. The list itself is
+            // the controller navigation target while its selected row is the
+            // item operated on by the D-pad and action button.
+            ListBox list = control as ListBox;
+            if (list != null)
+                list.Focusable = true;
+
+            ApplyControllerFocusVisualStyle(control);
+            if (!control.Focus())
+            {
+                RestoreFocusVisualStyle();
+                return;
+            }
+
+            if (_openComboBox != null && !ReferenceEquals(_openComboBox, control))
+            {
+                _openComboBox.IsDropDownOpen = false;
+                RestoreComboBoxPointerInput();
+                _openComboBox = null;
+            }
+            if (_activeSlider != null && !ReferenceEquals(_activeSlider, control))
+                _activeSlider = null;
+
+            if (list != null && list.SelectedIndex < 0 && list.Items.Count > 0)
+            {
+                list.SelectedIndex = 0;
+                list.ScrollIntoView(list.SelectedItem);
+            }
+
+            Keyboard.Focus(control);
+            control.BringIntoView();
+            ShowFocusAdorner(control);
+            _controllerFocusAppearanceActive = true;
+            if (_controllerTooltipsEnabled)
+                ShowControllerTooltip(control);
+        }
+
+        private void EnsureControllerFocusAppearance(Control control)
+        {
+            if (_controllerFocusAppearanceActive && ReferenceEquals(_focusVisualOwner, control))
+                return;
+
+            ApplyControllerFocusVisualStyle(control);
+            ShowFocusAdorner(control, ReferenceEquals(control, _activeSlider));
+            _controllerFocusAppearanceActive = true;
+        }
+
+        private void ApplyControllerFocusVisualStyle(Control control)
+        {
+            if (ReferenceEquals(_focusVisualOwner, control))
+                return;
+
+            RestoreFocusVisualStyle();
+            _focusVisualOwner = control;
+            _focusVisualPreviousLocalValue = control.ReadLocalValue(FrameworkElement.FocusVisualStyleProperty);
+            control.SetValue(FrameworkElement.FocusVisualStyleProperty, null);
+        }
+
+        private void RestoreFocusVisualStyle()
+        {
+            if (_focusVisualOwner == null)
+                return;
+
+            if (_focusVisualPreviousLocalValue == DependencyProperty.UnsetValue)
+                _focusVisualOwner.ClearValue(FrameworkElement.FocusVisualStyleProperty);
+            else
+                _focusVisualOwner.SetValue(FrameworkElement.FocusVisualStyleProperty, _focusVisualPreviousLocalValue);
+            _focusVisualOwner = null;
+            _focusVisualPreviousLocalValue = null;
+        }
+
+        private void DeactivateControllerFocusAppearance(Boolean clearKeyboardFocus)
+        {
+            RemoveFocusAdorner();
+            RestoreFocusVisualStyle();
+            _controllerFocusAppearanceActive = false;
+            if (clearKeyboardFocus)
+                Keyboard.ClearFocus();
+        }
+
+        private void ShowFocusAdorner(Control control, Boolean isEditing = false)
+        {
+            RemoveFocusAdorner();
+            AdornerLayer layer = AdornerLayer.GetAdornerLayer(control);
+            if (layer == null)
+                return;
+
+            _focusAdorner = new ControllerFocusAdorner(control, isEditing);
+            layer.Add(_focusAdorner);
+        }
+
+        private void RemoveFocusAdorner()
+        {
+            if (_focusAdorner == null)
+                return;
+
+            AdornerLayer layer = AdornerLayer.GetAdornerLayer(_focusAdorner.AdornedElement);
+            if (layer != null)
+                layer.Remove(_focusAdorner);
+            
+            _focusAdorner = null;
+        }
+
+        private IEnumerable<Control> GetCandidates(FrameworkElement scope)
+        {
+            return VisualTree.Enumerate<Control>(scope).Where(IsNavigationCandidate);
+        }
+
+        private static Boolean IsNavigationCandidate(Control control)
+        {
+            Boolean isList = control is ListBox;
+            if (!control.IsVisible || !control.IsEnabled || !control.IsHitTestVisible ||
+                (!control.Focusable && !isList))
+                return false;
+            
+            if ((!KeyboardNavigation.GetIsTabStop(control) && !isList) || !HasVisibleLayout(control))
+                return false;
+            
+            if (control.TemplatedParent != null)
+                return false;
+            
+            if (control is ListBoxItem || control is ComboBoxItem || control is TabControl ||
+                control is ScrollBar || control is Thumb || control is RepeatButton)
+                return false;
+
+            TabItem tab = control as TabItem;
+            TabControl tabOwner = tab == null ? null : ItemsControl.ItemsControlFromItemContainer(tab) as TabControl;
+            if (tab != null && (tabOwner == null || tabOwner.Items.Count <= 1))
+                return false;
+
+            return VisualTree.FindAncestor<ListBoxItem>(control, false) == null
+                && VisualTree.FindAncestor<ComboBoxItem>(control, false) == null;
+        }
+
+        private static Boolean HasVisibleLayout(FrameworkElement element)
+        {
+            DependencyObject current = element;
+            while (current != null)
+            {
+                if (current is FrameworkElement ancestor &&
+                    (!ancestor.IsVisible || ancestor.Opacity <= 0.01 ||
+                     ancestor.Width == 0.0 || ancestor.Height == 0.0 ||
+                     ancestor.ActualWidth <= 1.0 || ancestor.ActualHeight <= 1.0))
+                {
+                    return false;
+                }
+
+                current = VisualTree.GetParent(current);
+            }
+
+            return true;
+        }
+
+        private NavigationRectangle GetBounds(FrameworkElement element)
+        {
+            try
+            {
+                GeneralTransform transform = element.TransformToAncestor(_window);
+                Rect bounds = transform.TransformBounds(new Rect(0.0, 0.0, element.ActualWidth, element.ActualHeight));
+                return new NavigationRectangle(bounds.X, bounds.Y, bounds.Width, bounds.Height);
+            }
+            catch (InvalidOperationException)
+            {
+                return new NavigationRectangle(0.0, 0.0, element.ActualWidth, element.ActualHeight);
+            }
+        }
+
+        private static void Invoke(Button button)
+        {
+            if (new ButtonAutomationPeer(button).GetPattern(PatternInterface.Invoke) is IInvokeProvider provider)
+                provider.Invoke();
+            else
+                button.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent, button));
+        }
+
+        private static void Toggle(ToggleButton button)
+        {
+            if (new ToggleButtonAutomationPeer(button).GetPattern(PatternInterface.Toggle) is IToggleProvider provider)
+                provider.Toggle();
+            else
+                button.IsChecked = button.IsChecked != true;
+        }
+
+        private void ToggleControllerTooltip(Control current)
+        {
+            if (_controllerTooltipsEnabled)
+            {
+                DisableControllerTooltips();
+                return;
+            }
+
+            _controllerTooltipsEnabled = true;
+            ShowControllerTooltip(current);
+        }
+
+        private void ShowControllerTooltip(Control current)
+        {
+            FrameworkElement owner = FindTooltipOwner(current);
+            if (owner == null)
+            {
+                CloseControllerTooltip();
+                return;
+            }
+
+            if (ReferenceEquals(_controllerToolTipOwner, owner) && _controllerToolTip != null && _controllerToolTip.IsOpen)
+                return;
+
+            CloseControllerTooltip();
+            Object value = ToolTipService.GetToolTip(owner);
+            ToolTip toolTip = value as ToolTip;
+            _controllerToolTipReused = toolTip != null;
+            if (toolTip == null)
+                toolTip = new ToolTip { Content = value };
+            else
+            {
+                _tooltipPreviousPlacement = toolTip.Placement;
+                _tooltipPreviousTarget = toolTip.PlacementTarget;
+                _tooltipPreviousHorizontalOffset = toolTip.HorizontalOffset;
+                _tooltipPreviousVerticalOffset = toolTip.VerticalOffset;
+                _tooltipPreviousStaysOpen = toolTip.StaysOpen;
+            }
+
+            _controllerToolTip = toolTip;
+            _controllerToolTipOwner = owner;
+            toolTip.PlacementTarget = owner;
+            toolTip.Placement = PlacementMode.RelativePoint;
+            toolTip.HorizontalOffset = Math.Max(0.0, owner.ActualWidth - 1.0);
+            toolTip.VerticalOffset = Math.Max(0.0, owner.ActualHeight - 1.0);
+            toolTip.StaysOpen = true;
+            toolTip.IsOpen = true;
+        }
+
+        private void DisableControllerTooltips()
+        {
+            _controllerTooltipsEnabled = false;
+            CloseControllerTooltip();
+        }
+
+        private FrameworkElement FindTooltipOwner(Control current)
+        {
+            if (ToolTipService.GetToolTip(current) != null)
+                return current;
+
+            // Sliders and combo boxes are generated next to their explanatory
+            // text in UiGrid. The tooltip belongs to that text, but from a
+            // controller the pair is perceived as one setting.
+            UiGrid settingsGrid = VisualTree.FindAncestor<UiGrid>(current, false);
+            if (settingsGrid == null)
+                return null;
+
+            Int32 row = Grid.GetRow(current);
+            return VisualTree.Enumerate<FrameworkElement>(settingsGrid)
+                .Where(element => ToolTipService.GetToolTip(element) != null)
+                .Where(element => GetDirectGridRow(element, settingsGrid) == row)
+                .OrderBy(element => DistanceSquared(GetBounds(current), GetBounds(element)))
+                .FirstOrDefault();
+        }
+
+        private static Int32 GetDirectGridRow(DependencyObject element, Grid grid)
+        {
+            DependencyObject current = element;
+            DependencyObject parent;
+            while (current != null && (parent = VisualTree.GetParent(current)) != null)
+            {
+                if (ReferenceEquals(parent, grid))
+                {
+                    return current is not UIElement child ? -1 : Grid.GetRow(child);
+                }
+                current = parent;
+            }
+            return -1;
+        }
+
+        private static Double DistanceSquared(NavigationRectangle first, NavigationRectangle second)
+        {
+            Double x = first.CenterX - second.CenterX;
+            Double y = first.CenterY - second.CenterY;
+            return x * x + y * y;
+        }
+
+        private void CloseControllerTooltip()
+        {
+            if (_controllerToolTip == null)
+                return;
+
+            _controllerToolTip.IsOpen = false;
+            if (_controllerToolTipReused)
+            {
+                _controllerToolTip.Placement = _tooltipPreviousPlacement;
+                _controllerToolTip.PlacementTarget = _tooltipPreviousTarget;
+                _controllerToolTip.HorizontalOffset = _tooltipPreviousHorizontalOffset;
+                _controllerToolTip.VerticalOffset = _tooltipPreviousVerticalOffset;
+                _controllerToolTip.StaysOpen = _tooltipPreviousStaysOpen;
+            }
+
+            _controllerToolTip = null;
+            _controllerToolTipOwner = null;
+            _controllerToolTipReused = false;
+        }
+
+        private void CloseAutomaticTooltips()
+        {
+            foreach (FrameworkElement element in VisualTree.Enumerate<FrameworkElement>(_window))
+            {
+                if (ToolTipService.GetToolTip(element) is ToolTip toolTip && toolTip.IsOpen)
+                    toolTip.IsOpen = false;
+            }
+        }
+
+        private void OnPreviewMouseDown(Object sender, MouseButtonEventArgs e)
+        {
+            EnterMouseMode();
+            _activeSlider = null;
+            RemoveFocusAdorner();
+        }
+
+        private void OnPreviewMouseMove(Object sender, MouseEventArgs e)
+        {
+            if (!_controllerInputActive)
+                return;
+            RestoreMouseModeAfterPhysicalMovement();
+        }
+
+        private void OnPreviewMouseWheel(Object sender, MouseWheelEventArgs e)
+        {
+            EnterMouseMode();
+        }
+
+        private void OnPreProcessInput(Object sender, PreProcessInputEventArgs e)
+        {
+            InputEventArgs input = e.StagingItem.Input;
+            if (input is KeyEventArgs key && key.IsDown)
+            {
+                DisableControllerTooltips();
+                DeactivateControllerFocusAppearance(false);
+                return;
+            }
+
+            if (!_controllerInputActive)
+                return;
+
+            if (input is MouseButtonEventArgs || input is MouseWheelEventArgs)
+            {
+                EnterMouseMode();
+                return;
+            }
+
+            if (input is MouseEventArgs)
+                RestoreMouseModeAfterPhysicalMovement();
+        }
+
+        private void RestoreMouseModeAfterPhysicalMovement()
+        {
+            NativePointerPosition position;
+            if (!_hasControllerPointerPosition ||
+                !NativePointer.TryGetPosition(out position) ||
+                !position.Equals(_controllerPointerPosition))
+            {
+                EnterMouseMode();
+            }
+        }
+
+        private void EnterControllerMode()
+        {
+            if (_controllerInputActive)
+            {
+                Mouse.OverrideCursor = Cursors.None;
+                return;
+            }
+
+            _cursorBeforeControllerMode = Mouse.OverrideCursor;
+            _controllerInputActive = true;
+            GamepadNavigation.IsControllerInputActive = true;
+            _hasControllerPointerPosition = NativePointer.TryGetPosition(out _controllerPointerPosition);
+            Mouse.OverrideCursor = Cursors.None;
+            CloseAutomaticTooltips();
+            InstallMouseInputShield();
+        }
+
+        private void EnterMouseMode()
+        {
+            DisableControllerTooltips();
+            DeactivateControllerFocusAppearance(true);
+            if (!_controllerInputActive)
+                return;
+
+            _controllerInputActive = false;
+            GamepadNavigation.IsControllerInputActive = false;
+            _hasControllerPointerPosition = false;
+            RestoreComboBoxPointerInput();
+            RemoveMouseInputShield();
+            Mouse.OverrideCursor = _cursorBeforeControllerMode;
+            _cursorBeforeControllerMode = null;
+        }
+
+        private void SuppressComboBoxPointerInput(ComboBox comboBox)
+        {
+            if (!_controllerInputActive || !comboBox.IsDropDownOpen)
+                return;
+
+            comboBox.ApplyTemplate();
+            UIElement content = comboBox.Template.FindName("PART_Popup", comboBox) is not Popup popup ? null : popup.Child;
+            if (content == null)
+                return;
+
+            RestoreComboBoxPointerInput();
+            _suppressedComboBoxPopupContent = content;
+            _popupContentWasHitTestVisible = content.IsHitTestVisible;
+            content.IsHitTestVisible = false;
+            Mouse.OverrideCursor = Cursors.None;
+        }
+
+        private void RestoreComboBoxPointerInput()
+        {
+            if (_suppressedComboBoxPopupContent == null)
+                return;
+
+            _suppressedComboBoxPopupContent.IsHitTestVisible = _popupContentWasHitTestVisible;
+            _suppressedComboBoxPopupContent = null;
+        }
+
+        private void InstallMouseInputShield()
+        {
+            if (_window.Content is not Panel root || _mouseInputShield != null)
+                return;
+
+            _mouseInputShield = new Border
+            {
+                Background = Brushes.Transparent,
+                Cursor = Cursors.None,
+                ForceCursor = true,
+                Focusable = false,
+                IsHitTestVisible = true
+            };
+            
+            Panel.SetZIndex(_mouseInputShield, Int32.MaxValue);
+            root.Children.Add(_mouseInputShield);
+        }
+
+        private void RemoveMouseInputShield()
+        {
+            if (_mouseInputShield == null)
+                return;
+
+            if (_mouseInputShield.Parent is Panel parent)
+                parent.Children.Remove(_mouseInputShield);
+            
+            _mouseInputShield = null;
+        }
+
+        private void OnWindowClosed(Object sender, EventArgs e)
+        {
+            Dispose();
+        }
+
+        private sealed class EmptyDisposable : IDisposable
+        {
+            public static readonly EmptyDisposable Instance = new EmptyDisposable();
+            public void Dispose() { }
+        }
+    }
+
+    internal sealed class ControllerFocusAdorner : Adorner
+    {
+        private const Double StrokeThickness = 3.0;
+        private readonly Boolean _isEditing;
+
+        public ControllerFocusAdorner(UIElement adornedElement, Boolean isEditing)
+            : base(adornedElement)
+        {
+            _isEditing = isEditing;
+            IsHitTestVisible = false;
+        }
+
+        protected override void OnRender(DrawingContext drawingContext)
+        {
+            Brush brush = TryFindResource("BrushAccentColorPressed") as Brush ?? Brushes.DeepSkyBlue;
+            Double thickness = _isEditing ? StrokeThickness + 2.0 : StrokeThickness;
+            Pen pen = new Pen(brush, thickness);
+            Rect bounds = new Rect(
+                -thickness,
+                -thickness,
+                Math.Max(0.0, AdornedElement.RenderSize.Width + thickness * 2.0),
+                Math.Max(0.0, AdornedElement.RenderSize.Height + thickness * 2.0));
+            
+            drawingContext.DrawRoundedRectangle(null, pen, bounds, 5.0, 5.0);
+        }
+    }
+
+    internal static class VisualTree
+    {
+        public static IEnumerable<T> Enumerate<T>(DependencyObject root) where T : DependencyObject
+        {
+            if (root == null)
+                yield break;
+
+            if (root is T typed)
+                yield return typed;
+
+            Int32 count = VisualTreeHelper.GetChildrenCount(root);
+            for (Int32 index = 0; index < count; index++)
+            {
+                foreach (T descendant in Enumerate<T>(VisualTreeHelper.GetChild(root, index)))
+                    yield return descendant;
+            }
+        }
+
+        public static T FindAncestor<T>(DependencyObject element, Boolean includeSelf) where T : DependencyObject
+        {
+            DependencyObject current = includeSelf ? element : GetParent(element);
+            while (current != null)
+            {
+                if (current is T typed)
+                    return typed;
+                current = GetParent(current);
+            }
+            return null;
+        }
+
+        public static T FindDescendant<T>(DependencyObject root) where T : DependencyObject
+        {
+            return Enumerate<T>(root).FirstOrDefault();
+        }
+
+        public static Boolean IsDescendantOf(DependencyObject element, DependencyObject ancestor)
+        {
+            DependencyObject current = element;
+            while (current != null)
+            {
+                if (ReferenceEquals(current, ancestor))
+                    return true;
+                current = GetParent(current);
+            }
+            return false;
+        }
+
+        public static DependencyObject GetParent(DependencyObject element)
+        {
+            if (element == null)
+                return null;
+            
+            if (element is Visual || element is System.Windows.Media.Media3D.Visual3D)
+                return VisualTreeHelper.GetParent(element);
+            
+            return (element is not ContentElement content ? null : ContentOperations.GetParent(content))
+                   ?? LogicalTreeHelper.GetParent(element);
+        }
+
+        public static Int32 GetDepth(DependencyObject element)
+        {
+            Int32 depth = 0;
+            
+            while ((element = GetParent(element)) != null)
+                depth++;
+            
+            return depth;
+        }
+    }
+
+    internal struct NativePointerPosition : IEquatable<NativePointerPosition>
+    {
+        public Int32 X;
+        public Int32 Y;
+
+        public Boolean Equals(NativePointerPosition other)
+        {
+            return X == other.X && Y == other.Y;
+        }
+
+        public override Boolean Equals(Object obj)
+        {
+            return obj is NativePointerPosition && Equals((NativePointerPosition)obj);
+        }
+
+        public override Int32 GetHashCode()
+        {
+            unchecked
+            {
+                return (X * 397) ^ Y;
+            }
+        }
+    }
+
+    internal static class NativePointer
+    {
+        public static Boolean TryGetPosition(out NativePointerPosition position)
+        {
+            return GetCursorPos(out position);
+        }
+
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        private static extern Boolean GetCursorPos(out NativePointerPosition point);
+    }
+
+    internal static class NativeDialogControllerBridge
+    {
+        private const UInt32 Command = 0x0111;
+        private const UInt32 KeyDown = 0x0100;
+        private const UInt32 KeyUp = 0x0101;
+        private const Int32 OkButton = 1;
+        private const Int32 CancelButton = 2;
+        private const Int32 NoButton = 7;
+        private const Int32 Enter = 0x0D;
+        private const Int32 Escape = 0x1B;
+        private const Int32 ArrowLeft = 0x25;
+        private const Int32 ArrowUp = 0x26;
+        private const Int32 ArrowRight = 0x27;
+        private const Int32 ArrowDown = 0x28;
+
+        public static Boolean IsCurrentProcessInForeground()
+        {
+            IntPtr window = GetForegroundWindow();
+            if (window == IntPtr.Zero)
+                return false;
+
+            UInt32 processId;
+            GetWindowThreadProcessId(window, out processId);
+            return processId == (UInt32)Process.GetCurrentProcess().Id;
+        }
+
+        public static void Send(ControllerButton actions)
+        {
+            if ((actions & ControllerButton.Cancel) != 0)
+                Cancel();
+            else if ((actions & ControllerButton.Confirm) != 0)
+                SendKey(Enter);
+            else if ((actions & ControllerButton.Up) != 0)
+                SendKey(ArrowUp);
+            else if ((actions & ControllerButton.Down) != 0)
+                SendKey(ArrowDown);
+            else if ((actions & ControllerButton.Left) != 0)
+                SendKey(ArrowLeft);
+            else if ((actions & ControllerButton.Right) != 0)
+                SendKey(ArrowRight);
+        }
+
+        private static void Cancel()
+        {
+            IntPtr window = GetForegroundWindow();
+            if (window == IntPtr.Zero)
+                return;
+
+            // MessageBox does not accept Escape for Yes/No dialogs. Invoke its
+            // semantic cancel choice directly: Cancel, then No, or OK for an
+            // informational dialog. Non-MessageBox modal windows fall back to
+            // the ordinary Escape key path.
+            if (TryInvokeDialogButton(window, CancelButton) ||
+                TryInvokeDialogButton(window, NoButton) ||
+                TryInvokeDialogButton(window, OkButton))
+            {
+                return;
+            }
+
+            SendKey(window, Escape);
+        }
+
+        private static Boolean TryInvokeDialogButton(IntPtr window, Int32 buttonId)
+        {
+            IntPtr button = GetDlgItem(window, buttonId);
+            return button != IntPtr.Zero &&
+                   PostMessage(window, Command, new IntPtr(buttonId), button);
+        }
+
+        private static void SendKey(Int32 virtualKey)
+        {
+            IntPtr window = GetForegroundWindow();
+            if (window == IntPtr.Zero)
+                return;
+            SendKey(window, virtualKey);
+        }
+
+        private static void SendKey(IntPtr window, Int32 virtualKey)
+        {
+            PostMessage(window, KeyDown, new IntPtr(virtualKey), IntPtr.Zero);
+            PostMessage(window, KeyUp, new IntPtr(virtualKey), IntPtr.Zero);
+        }
+
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        private static extern IntPtr GetForegroundWindow();
+
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        private static extern UInt32 GetWindowThreadProcessId(IntPtr window, out UInt32 processId);
+
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        private static extern IntPtr GetDlgItem(IntPtr dialog, Int32 itemId);
+
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        private static extern Boolean PostMessage(IntPtr window, UInt32 message, IntPtr wParam, IntPtr lParam);
+    }
+}

--- a/Memoria.Launcher/Controller/NativeDialogControllerBridge.cs
+++ b/Memoria.Launcher/Controller/NativeDialogControllerBridge.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Memoria.Launcher.Controller
+{
+    /// <summary>
+    /// Maps controller actions to the native Win32 MessageBox owned by Launcher.
+    /// </summary>
+    internal static class NativeDialogControllerBridge
+    {
+        private const UInt32 Command = 0x0111;
+        private const UInt32 KeyDown = 0x0100;
+        private const UInt32 KeyUp = 0x0101;
+        private const Int32 OkButton = 1;
+        private const Int32 CancelButton = 2;
+        private const Int32 NoButton = 7;
+        private const Int32 Enter = 0x0D;
+        private const Int32 Escape = 0x1B;
+        private const Int32 ArrowLeft = 0x25;
+        private const Int32 ArrowUp = 0x26;
+        private const Int32 ArrowRight = 0x27;
+        private const Int32 ArrowDown = 0x28;
+        private const String DialogWindowClass = "#32770";
+
+        public static Boolean IsMessageBoxActiveForCurrentProcess()
+        {
+            IntPtr window = GetForegroundWindow();
+            if (window == IntPtr.Zero || !String.Equals(GetWindowClass(window), DialogWindowClass, StringComparison.Ordinal))
+                return false;
+
+            GetWindowThreadProcessId(window, out UInt32 processId);
+            return processId == (UInt32)Process.GetCurrentProcess().Id;
+        }
+
+        public static void Send(ControllerButton actions)
+        {
+            if ((actions & ControllerButton.Cancel) != 0)
+                Cancel();
+            else if ((actions & ControllerButton.Confirm) != 0)
+                SendKey(Enter);
+            else if ((actions & ControllerButton.Up) != 0)
+                SendKey(ArrowUp);
+            else if ((actions & ControllerButton.Down) != 0)
+                SendKey(ArrowDown);
+            else if ((actions & ControllerButton.Left) != 0)
+                SendKey(ArrowLeft);
+            else if ((actions & ControllerButton.Right) != 0)
+                SendKey(ArrowRight);
+        }
+
+        private static String GetWindowClass(IntPtr window)
+        {
+            StringBuilder result = new StringBuilder(64);
+            return GetClassName(window, result, result.Capacity) > 0 ? result.ToString() : String.Empty;
+        }
+
+        private static void Cancel()
+        {
+            IntPtr window = GetForegroundWindow();
+            if (window == IntPtr.Zero)
+                return;
+
+            if (TryInvokeDialogButton(window, CancelButton) ||
+                TryInvokeDialogButton(window, NoButton) ||
+                TryInvokeDialogButton(window, OkButton))
+            {
+                return;
+            }
+
+            SendKey(window, Escape);
+        }
+
+        private static Boolean TryInvokeDialogButton(IntPtr window, Int32 buttonId)
+        {
+            IntPtr button = GetDlgItem(window, buttonId);
+            return button != IntPtr.Zero && PostMessage(window, Command, new IntPtr(buttonId), button);
+        }
+
+        private static void SendKey(Int32 virtualKey)
+        {
+            IntPtr window = GetForegroundWindow();
+            if (window != IntPtr.Zero)
+                SendKey(window, virtualKey);
+        }
+
+        private static void SendKey(IntPtr window, Int32 virtualKey)
+        {
+            PostMessage(window, KeyDown, new IntPtr(virtualKey), IntPtr.Zero);
+            PostMessage(window, KeyUp, new IntPtr(virtualKey), IntPtr.Zero);
+        }
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr GetForegroundWindow();
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern Int32 GetClassName(IntPtr window, StringBuilder className, Int32 maximumCount);
+
+        [DllImport("user32.dll")]
+        private static extern UInt32 GetWindowThreadProcessId(IntPtr window, out UInt32 processId);
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr GetDlgItem(IntPtr dialog, Int32 itemId);
+
+        [DllImport("user32.dll")]
+        private static extern Boolean PostMessage(IntPtr window, UInt32 message, IntPtr wParam, IntPtr lParam);
+    }
+}

--- a/Memoria.Launcher/Controller/SpatialNavigation.cs
+++ b/Memoria.Launcher/Controller/SpatialNavigation.cs
@@ -1,0 +1,150 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace Memoria.Launcher.Controller
+{
+    internal enum NavigationDirection
+    {
+        Up,
+        Down,
+        Left,
+        Right
+    }
+
+    internal readonly struct NavigationRectangle(Double x, Double y, Double width, Double height)
+    {
+        public Double X { get; } = x;
+        public Double Y { get; } = y;
+        public Double Width { get; } = width;
+        public Double Height { get; } = height;
+        public Double Left => X;
+        public Double Top => Y;
+        public Double Right => X + Width;
+        public Double Bottom => Y + Height;
+        public Double CenterX => X + Width / 2.0;
+        public Double CenterY => Y + Height / 2.0;
+    }
+
+    internal sealed class SpatialNavigationCandidate<T>(T value, NavigationRectangle bounds)
+    {
+        public T Value { get; } = value;
+        public NavigationRectangle Bounds { get; } = bounds;
+    }
+
+    /// <summary>
+    /// Finds the geometrically most natural neighbour. Alignment is weighted
+    /// more heavily than raw distance so navigation remains within visual rows
+    /// and columns whenever possible.
+    /// </summary>
+    internal static class SpatialNavigation
+    {
+        private const Double DirectionTolerance = 1.0;
+
+        public static SpatialNavigationCandidate<T>? FindNext<T>(
+            NavigationRectangle origin,
+            IEnumerable<SpatialNavigationCandidate<T>> candidates,
+            NavigationDirection direction)
+        {
+            SpatialNavigationCandidate<T>? best = null;
+            Double bestScore = Double.PositiveInfinity;
+
+            foreach (SpatialNavigationCandidate<T> candidate in candidates)
+            {
+                if (!IsStrictlyInDirection(origin, candidate.Bounds, direction))
+                    continue;
+
+                Double primaryCenter = GetPrimaryCenterDistance(origin, candidate.Bounds, direction);
+                if (primaryCenter <= 1.0)
+                    continue;
+
+                Double primaryGap = GetPrimaryGap(origin, candidate.Bounds, direction);
+                Double perpendicularGap = GetPerpendicularGap(origin, candidate.Bounds, direction);
+                Double perpendicularCenter = GetPerpendicularCenterDistance(origin, candidate.Bounds, direction);
+                Double score = Math.Max(0.0, primaryGap)
+                             + perpendicularGap * 5.0
+                             + perpendicularCenter * 0.01;
+
+                if (score < bestScore)
+                {
+                    best = candidate;
+                    bestScore = score;
+                }
+            }
+
+            return best;
+        }
+
+        private static Boolean IsStrictlyInDirection(
+            NavigationRectangle origin,
+            NavigationRectangle candidate,
+            NavigationDirection direction)
+        {
+            switch (direction)
+            {
+                // Horizontal navigation must cross the corresponding edge.
+                // Comparing centres incorrectly treats differently-sized
+                // controls in the same column as left/right neighbours.
+                case NavigationDirection.Left:
+                    return candidate.Right <= origin.Left + DirectionTolerance;
+                case NavigationDirection.Right:
+                    return candidate.Left >= origin.Right - DirectionTolerance;
+                case NavigationDirection.Up:
+                    return candidate.Bottom <= origin.Top + DirectionTolerance;
+                case NavigationDirection.Down:
+                    return candidate.Top >= origin.Bottom - DirectionTolerance;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(direction));
+            }
+        }
+
+        private static Double GetPrimaryCenterDistance(NavigationRectangle origin, NavigationRectangle candidate, NavigationDirection direction)
+        {
+            switch (direction)
+            {
+                case NavigationDirection.Up: return origin.CenterY - candidate.CenterY;
+                case NavigationDirection.Down: return candidate.CenterY - origin.CenterY;
+                case NavigationDirection.Left: return origin.CenterX - candidate.CenterX;
+                case NavigationDirection.Right: return candidate.CenterX - origin.CenterX;
+                default: throw new ArgumentOutOfRangeException(nameof(direction));
+            }
+        }
+
+        private static Double GetPrimaryGap(NavigationRectangle origin, NavigationRectangle candidate, NavigationDirection direction)
+        {
+            switch (direction)
+            {
+                case NavigationDirection.Up: return origin.Top - candidate.Bottom;
+                case NavigationDirection.Down: return candidate.Top - origin.Bottom;
+                case NavigationDirection.Left: return origin.Left - candidate.Right;
+                case NavigationDirection.Right: return candidate.Left - origin.Right;
+                default: throw new ArgumentOutOfRangeException(nameof(direction));
+            }
+        }
+
+        private static Double GetPerpendicularGap(NavigationRectangle origin, NavigationRectangle candidate, NavigationDirection direction)
+        {
+            Boolean vertical = direction == NavigationDirection.Up || direction == NavigationDirection.Down;
+            Double firstStart = vertical ? origin.Left : origin.Top;
+            Double firstEnd = vertical ? origin.Right : origin.Bottom;
+            Double secondStart = vertical ? candidate.Left : candidate.Top;
+            Double secondEnd = vertical ? candidate.Right : candidate.Bottom;
+
+            if (firstEnd < secondStart)
+                return secondStart - firstEnd;
+            
+            if (secondEnd < firstStart)
+                return firstStart - secondEnd;
+            
+            return 0.0;
+        }
+
+        private static Double GetPerpendicularCenterDistance(NavigationRectangle origin, NavigationRectangle candidate, NavigationDirection direction)
+        {
+            return direction == NavigationDirection.Up || direction == NavigationDirection.Down
+                ? Math.Abs(origin.CenterX - candidate.CenterX)
+                : Math.Abs(origin.CenterY - candidate.CenterY);
+        }
+    }
+}

--- a/Memoria.Launcher/Controller/VisualTree.cs
+++ b/Memoria.Launcher/Controller/VisualTree.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Media;
+
+namespace Memoria.Launcher.Controller
+{
+    internal static class VisualTree
+    {
+        public static IEnumerable<T> Enumerate<T>(DependencyObject root) where T : DependencyObject
+        {
+            if (root == null)
+                yield break;
+
+            if (root is T typed)
+                yield return typed;
+
+            Int32 count = VisualTreeHelper.GetChildrenCount(root);
+            for (Int32 index = 0; index < count; index++)
+            {
+                foreach (T descendant in Enumerate<T>(VisualTreeHelper.GetChild(root, index)))
+                    yield return descendant;
+            }
+        }
+
+        public static T FindAncestor<T>(DependencyObject element, Boolean includeSelf) where T : DependencyObject
+        {
+            DependencyObject current = includeSelf ? element : GetParent(element);
+            while (current != null)
+            {
+                if (current is T typed)
+                    return typed;
+                current = GetParent(current);
+            }
+
+            return null;
+        }
+
+        public static T FindDescendant<T>(DependencyObject root) where T : DependencyObject =>
+            Enumerate<T>(root).FirstOrDefault();
+
+        public static Boolean IsDescendantOf(DependencyObject element, DependencyObject ancestor)
+        {
+            DependencyObject current = element;
+            while (current != null)
+            {
+                if (ReferenceEquals(current, ancestor))
+                    return true;
+                current = GetParent(current);
+            }
+
+            return false;
+        }
+
+        public static DependencyObject GetParent(DependencyObject element)
+        {
+            if (element == null)
+                return null;
+            if (element is Visual || element is System.Windows.Media.Media3D.Visual3D)
+                return VisualTreeHelper.GetParent(element);
+            if (element is ContentElement content)
+                return ContentOperations.GetParent(content) ?? LogicalTreeHelper.GetParent(element);
+            return LogicalTreeHelper.GetParent(element);
+        }
+
+        public static Int32 GetDepth(DependencyObject element)
+        {
+            Int32 depth = 0;
+            while ((element = GetParent(element)) != null)
+                depth++;
+            return depth;
+        }
+    }
+}

--- a/Memoria.Launcher/Controller/XInputControllerInputSource.cs
+++ b/Memoria.Launcher/Controller/XInputControllerInputSource.cs
@@ -1,0 +1,152 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace Memoria.Launcher.Controller
+{
+    /// <summary>
+    /// Small dependency-free XInput adapter. Steam Input and most Windows
+    /// controller drivers expose their devices through this API as well.
+    /// </summary>
+    internal sealed class XInputControllerInputSource : IControllerInputSource
+    {
+        private const Int32 ErrorSuccess = 0;
+        private const Int16 ThumbDeadZone = 16000;
+        private const Byte TriggerThreshold = 30;
+
+        private readonly XInputGetState _getState;
+        private Int32 _preferredPlayer = -1;
+
+        public XInputControllerInputSource()
+        {
+            _getState = LoadGetState();
+        }
+
+        public Boolean TryGetState(out ControllerState state)
+        {
+            XInputState nativeState;
+            if (_preferredPlayer >= 0 && TryReadPlayer(_preferredPlayer, out nativeState))
+            {
+                state = Convert(nativeState.Gamepad);
+                return true;
+            }
+
+            for (Int32 player = 0; player < 4; player++)
+            {
+                if (!TryReadPlayer(player, out nativeState))
+                    continue;
+
+                _preferredPlayer = player;
+                state = Convert(nativeState.Gamepad);
+                return true;
+            }
+
+            _preferredPlayer = -1;
+            state = new ControllerState(ControllerButton.None);
+            return false;
+        }
+
+        public void Dispose()
+        {
+            // The native module intentionally remains loaded for the process lifetime.
+        }
+
+        private Boolean TryReadPlayer(Int32 player, out XInputState state)
+        {
+            return _getState((UInt32)player, out state) == ErrorSuccess;
+        }
+
+        private static ControllerState Convert(XInputGamepad gamepad)
+        {
+            ControllerButton buttons = ControllerButton.None;
+            XInputButton nativeButtons = (XInputButton)gamepad.Buttons;
+
+            if ((nativeButtons & XInputButton.DPadUp) != 0 || gamepad.ThumbLeftY > ThumbDeadZone)
+                buttons |= ControllerButton.Up;
+            if ((nativeButtons & XInputButton.DPadDown) != 0 || gamepad.ThumbLeftY < -ThumbDeadZone)
+                buttons |= ControllerButton.Down;
+            if ((nativeButtons & XInputButton.DPadLeft) != 0 || gamepad.ThumbLeftX < -ThumbDeadZone)
+                buttons |= ControllerButton.Left;
+            if ((nativeButtons & XInputButton.DPadRight) != 0 || gamepad.ThumbLeftX > ThumbDeadZone)
+                buttons |= ControllerButton.Right;
+            if ((nativeButtons & XInputButton.A) != 0)
+                buttons |= ControllerButton.Confirm;
+            if ((nativeButtons & XInputButton.B) != 0)
+                buttons |= ControllerButton.Cancel;
+            if ((nativeButtons & XInputButton.X) != 0)
+                buttons |= ControllerButton.ToggleTooltip;
+            if ((nativeButtons & XInputButton.Start) != 0)
+                buttons |= ControllerButton.SubmitTextInput;
+            if ((nativeButtons & XInputButton.LeftShoulder) != 0)
+                buttons |= ControllerButton.PreviousTab;
+            if ((nativeButtons & XInputButton.RightShoulder) != 0)
+                buttons |= ControllerButton.NextTab;
+            if (gamepad.LeftTrigger > TriggerThreshold)
+                buttons |= ControllerButton.PreviousRootTab;
+            if (gamepad.RightTrigger > TriggerThreshold)
+                buttons |= ControllerButton.NextRootTab;
+
+            return new ControllerState(buttons);
+        }
+
+        private static XInputGetState LoadGetState()
+        {
+            String[] candidates = { "xinput1_4.dll", "xinput1_3.dll", "xinput9_1_0.dll" };
+            foreach (String candidate in candidates)
+            {
+                IntPtr module = LoadLibrary(candidate);
+                if (module == IntPtr.Zero)
+                    continue;
+
+                IntPtr address = GetProcAddress(module, "XInputGetState");
+                if (address != IntPtr.Zero)
+                    return (XInputGetState)Marshal.GetDelegateForFunctionPointer(address, typeof(XInputGetState));
+            }
+
+            throw new Win32Exception("No supported XInput library is available.");
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        private delegate UInt32 XInputGetState(UInt32 playerIndex, out XInputState state);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct XInputState
+        {
+            public UInt32 PacketNumber;
+            public XInputGamepad Gamepad;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct XInputGamepad
+        {
+            public UInt16 Buttons;
+            public Byte LeftTrigger;
+            public Byte RightTrigger;
+            public Int16 ThumbLeftX;
+            public Int16 ThumbLeftY;
+            public Int16 ThumbRightX;
+            public Int16 ThumbRightY;
+        }
+
+        [Flags]
+        private enum XInputButton : UInt16
+        {
+            DPadUp = 0x0001,
+            DPadDown = 0x0002,
+            DPadLeft = 0x0004,
+            DPadRight = 0x0008,
+            Start = 0x0010,
+            LeftShoulder = 0x0100,
+            RightShoulder = 0x0200,
+            A = 0x1000,
+            B = 0x2000,
+            X = 0x4000
+        }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr LoadLibrary(String fileName);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Ansi, SetLastError = true)]
+        private static extern IntPtr GetProcAddress(IntPtr module, String procedureName);
+    }
+}

--- a/Memoria.Launcher/Launcher/SettingsGrid_Presets.cs
+++ b/Memoria.Launcher/Launcher/SettingsGrid_Presets.cs
@@ -144,7 +144,9 @@ namespace Memoria.Launcher
             {
                 MakeTooltip(PresetsComboBox, Presets[PresetsComboBox.SelectedIndex].Description);
 
-                if (PresetsComboBox.ToolTip is ToolTip newToolTip && PresetsComboBox.IsMouseOver)
+                if (!Controller.GamepadNavigation.IsControllerInputActive &&
+                    PresetsComboBox.ToolTip is ToolTip newToolTip &&
+                    PresetsComboBox.IsMouseOver)
                     newToolTip.IsOpen = true;
             }
         }

--- a/Memoria.Launcher/Launcher/SettingsGrid_Presets.cs
+++ b/Memoria.Launcher/Launcher/SettingsGrid_Presets.cs
@@ -144,7 +144,7 @@ namespace Memoria.Launcher
             {
                 MakeTooltip(PresetsComboBox, Presets[PresetsComboBox.SelectedIndex].Description);
 
-                if (!Controller.GamepadNavigation.IsControllerInputActive &&
+                if (!Controller.GamepadNavigation.IsControllerInputActive(PresetsComboBox) &&
                     PresetsComboBox.ToolTip is ToolTip newToolTip &&
                     PresetsComboBox.IsMouseOver)
                     newToolTip.IsOpen = true;

--- a/Memoria.Launcher/Launcher/UiGrid.cs
+++ b/Memoria.Launcher/Launcher/UiGrid.cs
@@ -270,7 +270,7 @@ namespace Memoria.Launcher
                         if (uiElement.ToolTip is ToolTip)
                         {
                             ((ToolTip)uiElement.ToolTip).IsOpen = true;
-                            if (uiElement.IsMouseOver && !Controller.GamepadNavigation.IsControllerInputActive)
+                            if (uiElement.IsMouseOver && !Controller.GamepadNavigation.IsControllerInputActive(uiElement))
                             {
                                 if (curstorType == "mog")
                                     Mouse.OverrideCursor = new Cursor(Application.GetResourceStream(new Uri("pack://application:,,,/images/moogle.cur")).Stream);
@@ -284,7 +284,7 @@ namespace Memoria.Launcher
                         if (uiElement.ToolTip is ToolTip)
                         {
                             ((ToolTip)uiElement.ToolTip).IsOpen = false; // Force close the tooltip when the mouse leaves the element
-                            if (!uiElement.IsMouseOver && !Controller.GamepadNavigation.IsControllerInputActive)
+                            if (!uiElement.IsMouseOver && !Controller.GamepadNavigation.IsControllerInputActive(uiElement))
                                 Mouse.OverrideCursor = null;
                         }
                     };
@@ -371,7 +371,7 @@ namespace Memoria.Launcher
             };
             uiElement.MouseEnter += (sender, e) =>
             {
-                if (!Controller.GamepadNavigation.IsControllerInputActive &&
+                if (!Controller.GamepadNavigation.IsControllerInputActive(uiElement) &&
                     uiElement.SelectedValue is String selectedFont &&
                     !selectedFont.StartsWith("Final Fantasy IX"))
                 {
@@ -392,7 +392,7 @@ namespace Memoria.Launcher
                     tooltipTextBlock.FontWeight = bold ? FontWeights.Bold : FontWeights.Normal;
                     ToolTipService.SetToolTip(uiElement, toolTip);
                     ToolTipService.SetInitialShowDelay(uiElement, 0);
-                    toolTip.IsOpen = !Controller.GamepadNavigation.IsControllerInputActive && uiElement.IsMouseOver;
+                    toolTip.IsOpen = !Controller.GamepadNavigation.IsControllerInputActive(uiElement) && uiElement.IsMouseOver;
                 }
                 else
                 {
@@ -440,7 +440,7 @@ namespace Memoria.Launcher
             checkBox.SetValue(ColumnSpanProperty, MaxColumns);
             Children.Add(checkBox);
         }
-        public void CreateTextbloc(String text, String tooltip = "", String tooltipImage = "", Int32 columns = 100)
+        public TextBlock CreateTextbloc(String text, String tooltip = "", String tooltipImage = "", Int32 columns = 100)
         {
             Row++;
             RowDefinitions.Add(new RowDefinition());
@@ -470,6 +470,7 @@ namespace Memoria.Launcher
             border.SetValue(ColumnSpanProperty, columns);
             border.Child = textbloc;
             Children.Add(border);
+            return textbloc;
         }
 
         public void CreateHeading(String text)
@@ -515,9 +516,10 @@ namespace Memoria.Launcher
 
         public ComboBox CreateCombobox(String property, IEnumerable<ComboBoxOption> options, Int32 firstColumn = 50, String text = "", String tooltip = "", String tooltipImage = "", ComboBoxSelectionMode selectionMode = ComboBoxSelectionMode.Index)
         {
+            FrameworkElement tooltipOwner = null;
             if (text != "")
             {
-                CreateTextbloc(text, tooltip, tooltipImage, firstColumn);
+                tooltipOwner = CreateTextbloc(text, tooltip, tooltipImage, firstColumn);
             }
             else if (firstColumn == 0)
             {
@@ -565,14 +567,17 @@ namespace Memoria.Launcher
             {
                 comboBox.Focus();
             };
+            if (tooltipOwner != null)
+                Controller.GamepadNavigation.SetTooltipOwner(comboBox, tooltipOwner);
             Children.Add(comboBox);
             return comboBox;
         }
         public void CreateSlider(String indexproperty, String sliderproperty, double min, double max, double tickFrequency, String stringFormat = "", Int32 firstColumn = 0, String text = "", String tooltip = "", String tooltipImage = "")
         {
+            FrameworkElement tooltipOwner = null;
             if (text != "" && firstColumn > 0)
             {
-                CreateTextbloc(text, tooltip, tooltipImage, firstColumn - 2);
+                tooltipOwner = CreateTextbloc(text, tooltip, tooltipImage, firstColumn - 2);
             }
             else if (firstColumn == 0)
             {
@@ -599,6 +604,8 @@ namespace Memoria.Launcher
             {
                 slider.Value = Math.Max(Math.Min(slider.Value + Math.Sign(e.Delta) * tickFrequency, max), min);
             };
+            if (tooltipOwner != null)
+                Controller.GamepadNavigation.SetTooltipOwner(slider, tooltipOwner);
             Children.Add(slider);
 
             TextBlock textbloc = new TextBlock();

--- a/Memoria.Launcher/Launcher/UiGrid.cs
+++ b/Memoria.Launcher/Launcher/UiGrid.cs
@@ -270,7 +270,7 @@ namespace Memoria.Launcher
                         if (uiElement.ToolTip is ToolTip)
                         {
                             ((ToolTip)uiElement.ToolTip).IsOpen = true;
-                            if (uiElement.IsMouseOver)
+                            if (uiElement.IsMouseOver && !Controller.GamepadNavigation.IsControllerInputActive)
                             {
                                 if (curstorType == "mog")
                                     Mouse.OverrideCursor = new Cursor(Application.GetResourceStream(new Uri("pack://application:,,,/images/moogle.cur")).Stream);
@@ -284,7 +284,8 @@ namespace Memoria.Launcher
                         if (uiElement.ToolTip is ToolTip)
                         {
                             ((ToolTip)uiElement.ToolTip).IsOpen = false; // Force close the tooltip when the mouse leaves the element
-                            if (!uiElement.IsMouseOver) Mouse.OverrideCursor = null;
+                            if (!uiElement.IsMouseOver && !Controller.GamepadNavigation.IsControllerInputActive)
+                                Mouse.OverrideCursor = null;
                         }
                     };
                 }
@@ -370,7 +371,9 @@ namespace Memoria.Launcher
             };
             uiElement.MouseEnter += (sender, e) =>
             {
-                if (uiElement.SelectedValue is String selectedFont && !selectedFont.StartsWith("Final Fantasy IX"))
+                if (!Controller.GamepadNavigation.IsControllerInputActive &&
+                    uiElement.SelectedValue is String selectedFont &&
+                    !selectedFont.StartsWith("Final Fantasy IX"))
                 {
                     ToolTipService.SetToolTip(uiElement, toolTip);
                     ToolTipService.SetInitialShowDelay(uiElement, 0);
@@ -389,7 +392,7 @@ namespace Memoria.Launcher
                     tooltipTextBlock.FontWeight = bold ? FontWeights.Bold : FontWeights.Normal;
                     ToolTipService.SetToolTip(uiElement, toolTip);
                     ToolTipService.SetInitialShowDelay(uiElement, 0);
-                    toolTip.IsOpen = uiElement.IsMouseOver;
+                    toolTip.IsOpen = !Controller.GamepadNavigation.IsControllerInputActive && uiElement.IsMouseOver;
                 }
                 else
                 {

--- a/Memoria.Launcher/Launcher/UiLauncherButton.xaml
+++ b/Memoria.Launcher/Launcher/UiLauncherButton.xaml
@@ -29,6 +29,12 @@
                     Opacity="0"
                     CornerRadius="7">
                 </Border>
+                <Border
+                    BorderBrush="White"
+                    BorderThickness="1"
+                    CornerRadius="7"
+                    IsHitTestVisible="False"
+                    SnapsToDevicePixels="True" />
                 <TextBlock TextWrapping="Wrap"
                     Text="{Binding Label, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type launcher:UiLauncherButton}}, FallbackValue='PLAY'}"
                     FontWeight="Normal"

--- a/Memoria.Launcher/Launcher/Window_ChangeLog.xaml
+++ b/Memoria.Launcher/Launcher/Window_ChangeLog.xaml
@@ -86,6 +86,7 @@
                     </ScrollViewer>
                     <Button
                         x:Name="Ok"
+                        controller:GamepadNavigation.IsCancelAction="True"
                         Content="{DynamicResource Launcher.OK}"
                         Margin="0,10,0,0"
                         Style="{StaticResource ButtonStyle}"

--- a/Memoria.Launcher/Launcher/Window_ChangeLog.xaml
+++ b/Memoria.Launcher/Launcher/Window_ChangeLog.xaml
@@ -1,10 +1,12 @@
 ﻿<UserControl x:Class="Memoria.Launcher.Window_ChangeLog"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controller="clr-namespace:Memoria.Launcher.Controller"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              HorizontalAlignment="Stretch"
              VerticalAlignment="Stretch"
+             controller:GamepadNavigation.IsModalScope="True"
              mc:Ignorable="d">
     <UserControl.Resources>
     <Style x:Key="TextBoxStyle" TargetType="{x:Type TextBox}">
@@ -69,6 +71,7 @@
                         PreviewMouseWheel="DocumentScrollViewer_PreviewMouseWheel">
                         <RichTextBox
                             x:Name="Document"
+                            controller:GamepadNavigation.IsDefaultFocus="True"
                             Padding="15,0"
                             Foreground="{StaticResource WhiteUI}"
                             FontFamily="{StaticResource Overpass}"

--- a/Memoria.Launcher/Launcher/Window_ModDescription.xaml
+++ b/Memoria.Launcher/Launcher/Window_ModDescription.xaml
@@ -86,6 +86,7 @@
                     </ScrollViewer>
                     <Button
                         x:Name="Ok"
+                        controller:GamepadNavigation.IsCancelAction="True"
                         Content="{DynamicResource Launcher.OK}"
                         Margin="0,10,0,0"
                         Style="{StaticResource ButtonStyle}"

--- a/Memoria.Launcher/Launcher/Window_ModDescription.xaml
+++ b/Memoria.Launcher/Launcher/Window_ModDescription.xaml
@@ -1,10 +1,12 @@
 ﻿<UserControl x:Class="Memoria.Launcher.Window_ModDescription"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controller="clr-namespace:Memoria.Launcher.Controller"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              HorizontalAlignment="Stretch"
              VerticalAlignment="Stretch"
+             controller:GamepadNavigation.IsModalScope="True"
              mc:Ignorable="d">
     <UserControl.Resources>
     <Style x:Key="TextBoxStyle" TargetType="{x:Type TextBox}">
@@ -69,6 +71,7 @@
                         PreviewMouseWheel="DocumentScrollViewer_PreviewMouseWheel">
                         <RichTextBox
                             x:Name="Document"
+                            controller:GamepadNavigation.IsDefaultFocus="True"
                             Padding="15,0"
                             Foreground="{StaticResource WhiteUI}"
                             FontFamily="{StaticResource Overpass}"

--- a/Memoria.Launcher/Launcher/Window_NewPreset.xaml
+++ b/Memoria.Launcher/Launcher/Window_NewPreset.xaml
@@ -1,10 +1,12 @@
 ﻿<UserControl x:Class="Memoria.Launcher.Window_NewPreset"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controller="clr-namespace:Memoria.Launcher.Controller"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              HorizontalAlignment="Stretch"
              VerticalAlignment="Stretch"
+             controller:GamepadNavigation.IsModalScope="True"
              mc:Ignorable="d">
     <UserControl.Resources>
         <Style x:Key="TextBoxStyle" TargetType="{x:Type TextBox}">
@@ -59,6 +61,7 @@
                     Margin="0,6"/>
                 <TextBox
                     x:Name="PresetName"
+                    controller:GamepadNavigation.IsDefaultFocus="True"
                     Style="{StaticResource TextBoxStyle}"
                     TextWrapping="NoWrap"
                     Width="346"

--- a/Memoria.Launcher/Launcher/Window_NewPreset.xaml
+++ b/Memoria.Launcher/Launcher/Window_NewPreset.xaml
@@ -87,6 +87,7 @@
                 <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                     <Button
                         x:Name="Cancel"
+                        controller:GamepadNavigation.IsCancelAction="True"
                         Content="{DynamicResource Launcher.Cancel}"
                         Style="{StaticResource ButtonStyle}"
                         Height="30"

--- a/Memoria.Launcher/MainWindow.cs
+++ b/Memoria.Launcher/MainWindow.cs
@@ -18,12 +18,14 @@ using System.Windows.Navigation;
 using System.Windows.Threading;
 using Memoria.Launcher.Utils.Archives;
 using Memoria.Launcher.Utils.Mods;
+using Memoria.Launcher.Controller;
 
 namespace Memoria.Launcher
 {
     public partial class MainWindow : Window, IComponentConnector
     {
         private static readonly NLog.Logger _log = AppLogger.GetLogger();
+        private readonly IDisposable _gamepadNavigation;
 
         //public ModManagerWindow ModdingWindow;
         public static DateTime MemoriaAssemblyCompileDate;
@@ -55,6 +57,8 @@ namespace Memoria.Launcher
             _log.Info("Memoria Launcher started (v{Version})", MainWindow.MemoriaAssemblyCompileDate.ToString("yyyy.MM.dd"));
 
             InitializeComponent();
+
+            _gamepadNavigation = GamepadNavigationService.Attach(this);
 
             PlayButton.GameSettings = GameSettings;
             PlayButton.GameSettingsDisplay = GameSettingsDisplay;
@@ -96,7 +100,7 @@ namespace Memoria.Launcher
             lstCatalogMods.SelectionChanged += OnModListSelect;
             lstMods.SelectionChanged += OnModListSelect;
             tabCtrlMain.SelectionChanged += OnModListSelect;
-            ModOptionsHeaderButton.MouseUp += ModOptionsHeaderButton_MouseUp;
+            ModOptionsHeaderButton.Click += ModOptionsHeaderButton_Click;
             if (ModListInstalled.Count == 0)
                 tabCtrlMain.SelectedIndex = 1;
             UpdateModDetails((Mod)null);
@@ -168,7 +172,7 @@ namespace Memoria.Launcher
             }
         }
 
-        private void ModOptionsHeaderButton_MouseUp(Object sender, MouseButtonEventArgs e)
+        private void ModOptionsHeaderButton_Click(Object sender, RoutedEventArgs e)
         {
             Boolean collapsed = (String)ModOptionsHeaderArrow.Content == "▲";
             ModOptionsHeaderArrow.Content = collapsed ? "▼" : "▲";
@@ -493,7 +497,7 @@ namespace Memoria.Launcher
             SendMessage(new WindowInteropHelper(this).Handle, 161, 2, 0);
         }
 
-        private void ShowReleaseNotes(Object sender, MouseButtonEventArgs e)
+        private void ShowReleaseNotes(Object sender, RoutedEventArgs e)
         {
             var releaseWindow = new Window_ChangeLog();
             MainWindowGrid.Children.Add(releaseWindow);

--- a/Memoria.Launcher/MainWindow.xaml
+++ b/Memoria.Launcher/MainWindow.xaml
@@ -347,6 +347,8 @@
                                                     BorderThickness="1"
                                                     CaretBrush="#ccc" />
                                                 <ListView x:Name="lstMods"
+                                                    controller:GamepadNavigation.Participation="Include"
+                                                    controller:GamepadNavigation.Activated="InstalledMods_ControllerActivated"
                                                     Margin="6,0,0,0"
                                                     Grid.Row="1"
                                                     Grid.Column="1"
@@ -550,6 +552,7 @@
                                                         <Image Source="/images/btnDownloadimg.png" />
                                                     </Button>
                                                     <Button x:Name="btnPriority"
+                                                        controller:GamepadNavigation.Participation="Exclude"
                                                         Margin="0,3,0,3"
                                                         MouseRightButtonDown="OnClickPriority"
                                                         TabIndex="12"
@@ -574,6 +577,8 @@
                                                     BorderThickness="1"
                                                     CaretBrush="#ccc" />
                                                 <ListView x:Name="lstCatalogMods"
+                                                    controller:GamepadNavigation.Participation="Include"
+                                                    controller:GamepadNavigation.Activated="CatalogMods_ControllerActivated"
                                                     Margin="6,0,0,0"
                                                     Grid.Row="1"
                                                     Grid.Column="1"
@@ -702,6 +707,7 @@
                                                     </Button>
                                                 </StackPanel>
                                                 <ListView x:Name="lstDownloads"
+                                                    controller:GamepadNavigation.Participation="Exclude"
                                                     Margin="6,0,0,0"
                                                     Grid.Row="2"
                                                     Grid.Column="1"
@@ -762,6 +768,7 @@
                                     Background="{StaticResource LightGreyUI}"
                                     SelectedIndex="0">
                                     <TabItem x:Name="GroupModInfo"
+                                        controller:GamepadNavigation.Participation="Exclude"
                                         Style="{StaticResource GroupModInfo}"
                                         Foreground="{StaticResource WhiteUI}"
                                         Grid.Row="1"

--- a/Memoria.Launcher/MainWindow.xaml
+++ b/Memoria.Launcher/MainWindow.xaml
@@ -987,6 +987,7 @@
                                                     <RowDefinition Height="1*"/>
                                                 </Grid.RowDefinitions>
                                                 <Button x:Name="ModOptionsHeaderButton"
+                                                        controller:GamepadNavigation.Participation="Include"
                                                         Grid.Row="0"
                                                         Padding="5"
                                                         BorderThickness="0"

--- a/Memoria.Launcher/MainWindow.xaml
+++ b/Memoria.Launcher/MainWindow.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:launcher="clr-namespace:Memoria.Launcher"
+    xmlns:controller="clr-namespace:Memoria.Launcher.Controller"
     Title="{DynamicResource Settings.LauncherWindowTitle}"
     Width="1000"
     Height="700"
@@ -683,6 +684,7 @@
                                                 </ListView>
                                                 <StackPanel x:Name="btnCancelStackpanel"
                                                     Height="0"
+                                                    Visibility="Collapsed"
                                                     Grid.Row="2"
                                                     Grid.Column="0"
                                                     Margin="0,0,0,0"
@@ -706,6 +708,7 @@
                                                     MinHeight="0"
                                                     MaxHeight="100"
                                                     Height="0"
+                                                    Visibility="Collapsed"
                                                     ItemsSource="{Binding DownloadList, UpdateSourceTrigger=PropertyChanged}">
                                                     <ListView.View>
                                                         <GridView>
@@ -976,7 +979,13 @@
                                                     <RowDefinition Height="auto"/>
                                                     <RowDefinition Height="1*"/>
                                                 </Grid.RowDefinitions>
-                                                <Border x:Name="ModOptionsHeaderButton" Grid.Row="0" Padding="5" Cursor="Hand">
+                                                <Button x:Name="ModOptionsHeaderButton"
+                                                        Grid.Row="0"
+                                                        Padding="5"
+                                                        BorderThickness="0"
+                                                        Background="#3CCC"
+                                                        Cursor="Hand"
+                                                        HorizontalContentAlignment="Stretch">
                                                     <Grid>
                                                         <Image Source="images/modOptions.png" Width="22" Height="22" Margin="3,0,0,0" HorizontalAlignment="Left" Opacity="0.8"/>
                                                         <Label x:Name="ModOptionsHeaderLabel"
@@ -994,17 +1003,30 @@
                                                                HorizontalAlignment="Right"
                                                                Content="▲"/>
                                                     </Grid>
-                                                    <Border.Style>
-                                                        <Style>
-                                                            <Setter Property="Border.Background" Value="#3CCC"/>
+                                                    <Button.Style>
+                                                        <Style TargetType="Button">
+                                                            <Setter Property="Template">
+                                                                <Setter.Value>
+                                                                    <ControlTemplate TargetType="Button">
+                                                                        <Border Background="{TemplateBinding Background}"
+                                                                                Padding="{TemplateBinding Padding}">
+                                                                            <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                                                              VerticalAlignment="Center"/>
+                                                                        </Border>
+                                                                    </ControlTemplate>
+                                                                </Setter.Value>
+                                                            </Setter>
                                                             <Style.Triggers>
-                                                                <Trigger Property="Border.IsMouseOver" Value="True">
-                                                                    <Setter Property="Border.Background" Value="#5CCC"/>
+                                                                <Trigger Property="IsMouseOver" Value="True">
+                                                                    <Setter Property="Background" Value="#5CCC"/>
+                                                                </Trigger>
+                                                                <Trigger Property="IsPressed" Value="True">
+                                                                    <Setter Property="Background" Value="#6CCC"/>
                                                                 </Trigger>
                                                             </Style.Triggers>
                                                         </Style>
-                                                    </Border.Style>
-                                                </Border>
+                                                    </Button.Style>
+                                                </Button>
                                                 <ScrollViewer x:Name="ModOptionsScrollViewer" Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
                                                     <StackPanel Margin="7,7,7,3" x:Name="ModOptionsPanel"/>
                                                 </ScrollViewer>
@@ -1021,23 +1043,25 @@
 
         <!-- Play Button -->
         <launcher:UiLauncherPlayButton x:Name="PlayButton"
+            controller:GamepadNavigation.IsDefaultFocus="True"
             Width="260"
             Height="70"
             Margin="0,46,20,0"
             HorizontalAlignment="Right"
             VerticalAlignment="Top" />
 
-        <TextBlock x:Name="Nameandversion"
-            Text="{DynamicResource Settings.MemoriaEngine}"
+        <Button x:Name="Nameandversion"
+            Content="{DynamicResource Settings.MemoriaEngine}"
             Foreground="#6fff"
             FontSize="15"
             FontWeight="Normal"
             FontFamily="{DynamicResource CenturyGothic}"
+            Style="{StaticResource ButtonStyleLabel}"
             Margin="22,0,0,2"
             HorizontalAlignment="Left"
             VerticalAlignment="Bottom"
             Cursor="Hand"
-            MouseUp="ShowReleaseNotes"/>
+            Click="ShowReleaseNotes"/>
 
         <Border x:Name="dropBackground" Background="#d000" Visibility="Hidden">
             <Label

--- a/Memoria.Launcher/MainWindow_ModManager.cs
+++ b/Memoria.Launcher/MainWindow_ModManager.cs
@@ -372,6 +372,11 @@ namespace Memoria.Launcher
         private void CheckBox_Click(object sender, RoutedEventArgs e)
         {
             Mod mod = (sender as CheckBox)?.DataContext as Mod;
+            ApplyModActivation(mod);
+        }
+
+        private void ApplyModActivation(Mod mod)
+        {
             if (mod != null && mod.IsActive)
                 mod.TryApplyPreset();
             CheckOutdatedAndIncompatibleMods();
@@ -651,6 +656,23 @@ namespace Memoria.Launcher
         private void OnCatalogListDoubleClick(Object sender, RoutedEventArgs e)
         {
             OnClickDownload(sender, e);
+        }
+
+        private void InstalledMods_ControllerActivated(Object sender, RoutedEventArgs e)
+        {
+            if (lstMods.SelectedItem is not Mod mod)
+                return;
+
+            mod.IsActive = !mod.IsActive;
+            ApplyModActivation(mod);
+            lstMods.Items.Refresh();
+            e.Handled = true;
+        }
+
+        private void CatalogMods_ControllerActivated(Object sender, RoutedEventArgs e)
+        {
+            OnClickDownload(sender, e);
+            e.Handled = true;
         }
 
         private void OnClickUninstall(Object sender, RoutedEventArgs e)

--- a/Memoria.Launcher/MainWindow_ModManager.cs
+++ b/Memoria.Launcher/MainWindow_ModManager.cs
@@ -991,9 +991,19 @@ namespace Memoria.Launcher
             downloadClient.ProgressChanged += (_, args) => DownloadLoop(mod, args);
             downloadClient.Completed += (_, args) => DownloadEnd(args, mod, plan);
             downloadClient.StartInDirectory(downloadUri, plan.DownloadDirectory);
-            lstDownloads.MinHeight = 100;
-            lstDownloads.Height = 100;
-            btnCancelStackpanel.Height = 100;
+            SetDownloadPanelVisible(true);
+        }
+
+        private void SetDownloadPanelVisible(Boolean visible)
+        {
+            Double height = visible ? 100.0 : 0.0;
+            Visibility visibility = visible ? Visibility.Visible : Visibility.Collapsed;
+
+            lstDownloads.MinHeight = height;
+            lstDownloads.Height = height;
+            lstDownloads.Visibility = visibility;
+            btnCancelStackpanel.Height = height;
+            btnCancelStackpanel.Visibility = visibility;
         }
         private void DownloadLoop(Mod mod, FileDownloadProgressEventArgs e)
         {
@@ -1229,9 +1239,7 @@ namespace Memoria.Launcher
                         DownloadStart(DownloadList[0]);
                     else
                     {
-                        lstDownloads.MinHeight = 0;
-                        lstDownloads.Height = 0;
-                        btnCancelStackpanel.Height = 0;
+                        SetDownloadPanelVisible(false);
                     }
                     UpdateCatalogInstallationState();
                 });
@@ -1320,9 +1328,7 @@ namespace Memoria.Launcher
                         DownloadStart(DownloadList[0]);
                     else
                     {
-                        lstDownloads.MinHeight = 0;
-                        lstDownloads.Height = 0;
-                        btnCancelStackpanel.Height = 0;
+                        SetDownloadPanelVisible(false);
                     }
                     UpdateModListInstalled();
                     CheckForValidModFolder();

--- a/Memoria.Launcher/MainWindow_ModManager.cs
+++ b/Memoria.Launcher/MainWindow_ModManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Memoria.Launcher.Controller;
 using Memoria.Launcher.Utils.Archives;
 using Memoria.Launcher.Utils.Catalog;
 using Memoria.Launcher.Utils.Downloads;
@@ -1850,12 +1851,14 @@ namespace Memoria.Launcher
                 checkBox.IsEnabled = isEnabled && mod.IsActive;
                 checkBox.Style = (Style)Application.Current.FindResource("CheckBoxStyle");
                 checkBox.Margin = new Thickness(0, 0, 0, 4);
+                GamepadNavigation.SetParticipation(checkBox, NavigationParticipation.Include);
 
                 checkBox.Checked += SubMod_CheckChanged;
                 checkBox.Unchecked += SubMod_CheckChanged;
 
                 Grid grid = new Grid();
                 grid.Children.Add(checkBox);
+                GamepadNavigation.SetTooltipOwner(checkBox, grid);
                 ModOptionsPanel.Children.Add(grid);
 
                 if (!String.IsNullOrEmpty(submod.Description))

--- a/Memoria.Launcher/Memoria.Launcher.csproj
+++ b/Memoria.Launcher/Memoria.Launcher.csproj
@@ -75,6 +75,11 @@
     <Compile Include="Languages\Lang.cs" />
     <Compile Include="Languages\XmlDocumentExm.cs" />
     <Compile Include="Languages\XmlHelper.cs" />
+    <Compile Include="Controller\ControllerInput.cs" />
+    <Compile Include="Controller\ControllerTextInputOverlay.cs" />
+    <Compile Include="Controller\GamepadNavigation.cs" />
+    <Compile Include="Controller\SpatialNavigation.cs" />
+    <Compile Include="Controller\XInputControllerInputSource.cs" />
     <Compile Include="Launcher\ALChColor.cs" />
     <Compile Include="Launcher\Window_ModDescription.xaml.cs">
       <DependentUpon>Window_ModDescription.xaml</DependentUpon>

--- a/Memoria.Launcher/Memoria.Launcher.csproj
+++ b/Memoria.Launcher/Memoria.Launcher.csproj
@@ -76,9 +76,16 @@
     <Compile Include="Languages\XmlDocumentExm.cs" />
     <Compile Include="Languages\XmlHelper.cs" />
     <Compile Include="Controller\ControllerInput.cs" />
+    <Compile Include="Controller\ControllerControlInteractor.cs" />
+    <Compile Include="Controller\ControllerFocusManager.cs" />
+    <Compile Include="Controller\ControllerFocusNavigator.cs" />
+    <Compile Include="Controller\ControllerInputModeManager.cs" />
     <Compile Include="Controller\ControllerTextInputOverlay.cs" />
+    <Compile Include="Controller\ControllerTooltipPresenter.cs" />
     <Compile Include="Controller\GamepadNavigation.cs" />
+    <Compile Include="Controller\NativeDialogControllerBridge.cs" />
     <Compile Include="Controller\SpatialNavigation.cs" />
+    <Compile Include="Controller\VisualTree.cs" />
     <Compile Include="Controller\XInputControllerInputSource.cs" />
     <Compile Include="Launcher\ALChColor.cs" />
     <Compile Include="Launcher\Window_ModDescription.xaml.cs">

--- a/Memoria.Launcher/Resources/ListViewStyle.xaml
+++ b/Memoria.Launcher/Resources/ListViewStyle.xaml
@@ -150,7 +150,6 @@
     </Style>
 
     <Style x:Key="{x:Type ListView}" TargetType="ListView">
-        <Setter Property="Focusable" Value="True" />
         <Setter Property="FontSize" Value="14" />
         <Setter Property="Foreground" Value="White" />
         <Setter Property="SnapsToDevicePixels" Value="true" />

--- a/Memoria.Launcher/Resources/ListViewStyle.xaml
+++ b/Memoria.Launcher/Resources/ListViewStyle.xaml
@@ -150,6 +150,7 @@
     </Style>
 
     <Style x:Key="{x:Type ListView}" TargetType="ListView">
+        <Setter Property="Focusable" Value="True" />
         <Setter Property="FontSize" Value="14" />
         <Setter Property="Foreground" Value="White" />
         <Setter Property="SnapsToDevicePixels" Value="true" />


### PR DESCRIPTION
Navigation:
D-Pad - controls
L1/R1 - tabs
A (Cross) - confirm
B (Cyrcle) - cancel
X (Square) - hints
Menu (Start) - OK in screen keyboard overlay

If contoller works in Steam (Big Picture), it also must work in Launcher (with or without Big Picture - doesn't matter).