### PR TITLE
Fix launcher theme not applying on startup

### DIFF
--- a/Memoria.Launcher/MainWindow.cs
+++ b/Memoria.Launcher/MainWindow.cs
@@ -78,7 +78,6 @@ namespace Memoria.Launcher
                 _modFileSystem.DeleteTemporaryDirectory();
             }
             catch { }
-            UpdateLauncherTheme();
             HotfixForMoguriMod();
             Lang.Res["Settings.LauncherWindowTitle"] += " | v" + MemoriaAssemblyCompileDate.ToString("yyyy.MM.dd");
             Lang.Res["Settings.MemoriaEngine"] += " v" + MemoriaAssemblyCompileDate.ToString("yyyy.MM.dd");
@@ -150,7 +149,7 @@ namespace Memoria.Launcher
                     UpdateModSettings();
                     UpdateLauncherTheme();
                 }
-                else if(date < new DateTime(2025, 07, 13))
+                else if (date < new DateTime(2025, 07, 13))
                 {
                     // Make sure to use the new back-end
                     IniFile.MemoriaIni.SetSetting("Audio", "Backend", "1");

--- a/Memoria.Launcher/MainWindow.cs
+++ b/Memoria.Launcher/MainWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
@@ -92,6 +92,7 @@ namespace Memoria.Launcher
             LoadModSettings();
             CheckForValidModFolder();
             UpdateModListInstalled();
+            UpdateLauncherTheme();
             InitializeModsListView();
             InitializeCatalogListView();
             lstDownloads.ItemsSource = DownloadList;


### PR DESCRIPTION
Just called UpdateLauncherTheme() after UpdateLauncherTheme().
This ensures the selected themes updates the launcher upon the start up.
Fixes this https://github.com/Albeoris/Memoria/issues/1496https://github.com/Albeoris/Memoria/issues/1496

Apologies for earlier i realize I've included irrelevant commits. 