### PR TITLE
Enable tooltips when using a controller

### DIFF
--- a/Memoria.Launcher/Controller/ControllerFocusManager.cs
+++ b/Memoria.Launcher/Controller/ControllerFocusManager.cs
@@ -23,6 +23,8 @@ namespace Memoria.Launcher.Controller
                 throw new ArgumentNullException(nameof(window));
         }
 
+        public Control Current => _focusVisualOwner ?? Keyboard.FocusedElement as Control;
+
         public event Action<Control> FocusChanging;
         public event Action<Control> Focused;
 

--- a/Memoria.Launcher/Controller/ControllerInputModeManager.cs
+++ b/Memoria.Launcher/Controller/ControllerInputModeManager.cs
@@ -54,6 +54,7 @@ namespace Memoria.Launcher.Controller
             _hasControllerPointerPosition = NativePointer.TryGetPosition(out _controllerPointerPosition);
             Mouse.OverrideCursor = Cursors.None;
             _tooltips.CloseAutomaticTooltips();
+            _tooltips.Enable(_focus.Current);
             InstallMouseInputShield();
         }
 

--- a/Memoria.Launcher/Controller/ControllerTooltipPresenter.cs
+++ b/Memoria.Launcher/Controller/ControllerTooltipPresenter.cs
@@ -41,6 +41,13 @@ namespace Memoria.Launcher.Controller
             Show(current);
         }
 
+        public void Enable(Control current = null)
+        {
+            _enabled = true;
+            if (current != null)
+                Show(current);
+        }
+
         public void Disable()
         {
             _enabled = false;


### PR DESCRIPTION
I noticed that help tooltips were not showing when navigating the launcher using a controller. Enabling tooltips in the input mode manager worked initially, but switching back and forth between mouse and controller inputs broke them. Mouse mode turned tooltips off, and re-entering controller mode didn't restore them. 
So basically  I added a focus query and explicit Enable() handler to restore tooltips when switching from mouse to controller input.