### PR TITLE
Trance Seek 0.3.37

### DIFF
--- a/MemoriaCatalog.xml
+++ b/MemoriaCatalog.xml
@@ -161,12 +161,12 @@ This is actually a lighter version of Alternate Fantasy, to benefit from its add
 	
 <Mod>
 	<Name>Trance Seek</Name>
-	<Version>0.3.36.2</Version>
+	<Version>0.3.37</Version>
 	<Priority>4</Priority>
 	<InstallationPath>TranceSeek</InstallationPath>
 	<ReleaseDateOriginal>2022-01-28</ReleaseDateOriginal>
-	<ReleaseDate>2025-09-05</ReleaseDate>
-	<MinimumMemoriaVersion>2025-05-12</MinimumMemoriaVersion>
+	<ReleaseDate>2026-09-05</ReleaseDate>
+	<MinimumMemoriaVersion>2025-05-17</MinimumMemoriaVersion>
 	<Author>DV</Author>
 	<IncompatibleWith>Alternate Fantasy,Amazing Quina,Beatrix Mod,Black Cat - Endgame Shop,David Bowie Edition,Freya Game+,Garnet is Main Character,Perfect Stats,Play As Kuja,Playable Character Pack,Tantalus</IncompatibleWith>
 	<Description>
@@ -193,135 +193,144 @@ Don't hesitate to try!
 Recommended language : Français / English (UK)
 Not supported language : Japanese (a lot of things get deleted... need to wait until full release... sorry !)</Description>
 	<PatchNotes>
-------[0.3.36.2]------
-
-{Characters}
-- Zidane will chuckle when a steal succeeds under the effect of "Thief’s Eye"
-- Fixed some bugs with Eiko’s passive under specific conditions.
-- Fixed Vivi’s animations for high-tier spells.
-- Changed Vivi’s SA "Invigorating" to "Last Stand".
-- "Mog Flare" and "Mog Holy" are much less likely to be cast against targets under "Reflect".
-- New texture for Steiner under "Old" status so it’s more visible, especially under magical barriers like Shell.
-- Restored "Aero" and "Aero+" spells to Beatrix’s "Saint Mag" command.
-- Fixed Vivi’s Focus effect with "Dbl Blk" when ATB is set to "Wait Mode".
-- [WIP] Fixed a specific bug where a character remained invisible after a scripted Trance with the accessory "Ghost Scarf", notably with Vivi against Black Waltz 3 in Disc 1.
-- The "Zombie" status no longer prevents fleeing.
-
-{SA / AA Abilities}
-- "What’s That!?" is compatible with Thief’s Eye and applies Zidane’s passive to every target.
-- "What’s That!?" allows repositioning in any situation, even against bosses.
-- "Transmute" and "Mana Well" commands are now properly disabled when Vivi is under Silence.
-- Gil bonuses now stack (from SAs or equipment).
-- Camera sequences for "Eat" and "Cook" are disabled under certain conditions (notably when damage is dealt).
-- Fixed the "Appetite" and "Gluttony" SAs against certain targets, especially humanoids.
-- Fixed the "Demi" spell when cast on multiple targets.
-- Fixed the sequence file for the AA "Dragon’s Crest", which displayed invisible enemies in battle.
-- Fixed the AA "Mog Life".
-- Fixed the MP cost of one of Quina’s blue magics.
-- SOS-type SAs are no longer always reset when a character is revived.
-- Fixed the description of the SA "Voracious".
-- Fixed the SA "Turbo".
-- Fixed the SA "Embrace".
-- Fixed the SA "Propagation" which was changing "Lv.4 Holy" into "Matra Magic".
-- Fixed the SA "Fencing".
-- Fixed the AA "Fenrir", about unlocking its "Wind" version.
-- Adjusted the cost of the SA "Fencing": 3 -> 4.
-- Adjusted the cost of the SA "Presence": 4 -> 3.
-- Adjusted the cost of the SA "Alert": 5 -> 4.
-- The "Attack" command will now change if the weapon element is infused, especially with the SA "Enchanted Blade".
-- Fixed "Atomos" damage on bosses.
-- Fixed the formula of the SA "Invigorating" and slightly adjusted its effect.
-- Slight adjustment to the effect of "Zantetsuken" under "Divine guidance".
-- Fixed the Gravity spell against certain monsters, especially bosses with scripted deaths.
-  With the new Gravity spells added to Vivi, the damage penalty now starts at 2 instead of 1 (damage divided by 2, then 4, 8, 16, 32, etc…).
-- Gravity spells are 50% more effective against "Giant"-type enemies (instead of 100%).
-  They also gain a 25% damage bonus against Giant-type bosses.
-- The abilities "Zeus", "Hikari" and "Zantetsu" have been renamed to "Fulmen", "Sentence" and "Inquisition".
-- Improved the descriptions of Freya’s "Dragon" spells.
-- Fixed and improved the descriptions of several AAs/SAs.
-
-{Items}
-- "Smoke Bomb" no longer has the "IsPhysical" tag.
-- Adjusted some SFX depending on the weapon type thrown by Amarant.
-- Fixed SAs tied to certain items.
-- Fixed the description of the SA "Invigorating".
-- Added a new effect for "Pickpocket".
-- Fixed the description of "Cypress Pile", which didn’t display the correct status effect.
-- Optimized the effect of "Larceny Scepter" in multi-target cases.
-- Adjusted the price of certain items.
-- Fixed the effects of several items, some of which failed to properly trigger a free SA activation.
-- Fixed and improved the descriptions of all weapons to be clearer when using the "Throw" command.
-- Fixed and improved the descriptions of several items.
-
-{Monsters and Bosses}
-- Reworked a majority of AIs so their scripts depend on MAX_HP instead of a fixed value (to better match the different difficulty settings).
-  Some formulas remain unchanged depending on the difficulty, such as Gisamark’s last phase.
-- Reworked code handling buffs/debuffs tied to difficulty (in preparation for the future Garland mode).
-- Added 2 new monsters in the "Pandemonium" dungeon.
-- Fixed Soulcage’s AI.
-- Fixed Thorn’s AI (Disc 1) (+ complete reset of the entire fight due to corruption in the .hws project).
-- Adjusted Hilgigars’s AI.
-- Adjusted Taharka’s AI.
-- Adjusted Baku’s AI.
-- Adjusted Steiner’s AI (first encounter).
-- Adjusted the AI of Malboros.
-- Adjusted the AI of Vices.
-- Adjusted the AI of Magic Vices.
-- Adjusted Beatrix 3’s fight: just a small detail added at the end of the battle.
-- Fixed Kuja’s animations in Disc 3 and improved sequence files.
-- Fixed certain sequence files that still targeted KO’d characters.
-- Fixed a sequence file of "Sand Worm" where the second-position character could end up under the terrain.
-- Fixed a bug against "Sand Worm" where it was possible to resist its "Quicksand" attack.
-- Monsters during the "You Are Not Alone" scene are now considered bosses instead of elite monsters.
-- Added a "mini hack" for monsters when they can’t target anyone in ATB "Wait Mode", notably Freya in 1v1 who could easily spam "Jump" at equal speed.
-- The boss "Arkh" will no longer coo at all! ^^
-- Fixed the "Trouble Knife" attack of Ogres in "Outer Continent, Dirt" which didn’t have the correct sequence file.
-- Fixed the rewards of a boss.
-- Fixed Hilgigars’s max HP, which made Gravity damage inconsistent.
-- Improved the sequence files of certain monsters.
-
-{Fields}
-- Added Beatrix to field 2854 "Hilda Garde 3/Bridge"
-- Fixed a bug in field 2706 "Pand./Hall" where the Beatrix model remained.
-- Fixed a bug in field 2711 "Pand./Control Room" where TurboDialog wasn’t compatible with the elevator control window.
-- Fixed the score window in US during Lindblum’s Festival of the Hunt.
-- Fixed the position of the points window awarded by Fang in US.
-- Fixed NPC dialogues in fields 551 + 563 + 572, which caused a softlock in US during Lindblum’s Festival of the Hunt.
-- Fixed the rewards in the Fossil Roo mining mini-game.
-- Fixed the reward at 5 Frogs in Qu’s Marsh frog catching mini-game.
-
-{Miscellaneous}
-- Fixed certain conditions in Ozma Mode where the level cap was locked in unintended places.
-- SAs are now sorted alphabetically for the StuffListed.txt option.
+ChangeLog too long... please check "ChangeLog_FR+EN_[0.3.37]" in the mod folder.
 	</PatchNotes>
-	<Header>QoL options</Header>
+<Header>QoL Miscellaneous</Header>
+	<SubMod>
+		<Name>Activate Redemption Icon in Battle</Name>
+		<InstallationPath>Options/RedemptionIconInBattle</InstallationPath>
+		<Description>Enable or disable the Redemption stack in battle, next to Beatrix (old version).</Description>
+		<PreviewFile>Options/RedemptionIconInBattle/Thumbnail.jpg</PreviewFile>
+	</SubMod>
+	<SubMod>
+		<Name>Immune Status Effect on Player</Name>
+		<InstallationPath>Options/ImmuneStatusPlayer</InstallationPath>
+		<Description>Active the "Immune Status" SPS effect on players too.</Description>
+		<PreviewFile>Options/ImmuneStatusPlayer/Thumbnail.jpg</PreviewFile>
+		<Default />
+	</SubMod>
+	<SubMod>
+		<Name>Hé hé !</Name>
+		<InstallationPath>Options/HeheZidane</InstallationPath>
+		<Description>Zidane will speak for every steal succeeded.</Description>
+		<PreviewFile>Options/HeheZidane/Thumbnail.jpg</PreviewFile>
+		<Default />
+	</SubMod>
+	<SubMod>
+		<Name>Haste/Slow feature</Name>
+		<InstallationPath>Options/HasteSlowFeature</InstallationPath>
+		<Description>Speed up some animations when an unit is under Haste.
+		Slow down some animations when an unit is under Slow.
+		Quite experimental.</Description>
+		<Default />
+	</SubMod>
+	<SubMod>
+		<Name>Best sorting shops/equipments menu</Name>
+		<InstallationPath>Options/AutoSorterShop</InstallationPath>
+		<Description>Automatically sorts the equipment menu and shops menu
+		so that items are organized more logically
+		(generally by type and then by stats)</Description>
+		<PreviewFile>Options/AutoSorterShop/Thumbnail.jpg</PreviewFile>
+		<Default />
+	</SubMod>
+	<SubMod>
+		<Name>Trance Music</Name>
+		<InstallationPath>Options/TranceMusic</InstallationPath>
+		<Description>Change the BGM Music by a remixed one,
+		when a monster get intro Trance.
+		Disabled by default because may crash the game...</Description>
+	</SubMod>
+	<SubMod>
+		<Name>Party Followers feature</Name>
+		<InstallationPath>Options/FollowersFeature</InstallationPath>
+		<Description>Replicates the feature from FF8 where your party members follow you during a cutscene or on the world map!
+		Compatible only with characters from Trance Seek.
+		Experimental and may cause "strange" situations.</Description>
+		<PreviewFile>Options/FollowersFeature/Thumbnail.jpg</PreviewFile>
+		<Default />
+	</SubMod>
+	<Header>Player Menu QoL</Header>
 	<SubMod>
 		<Name>Enable colored HP in Menu</Name>
-		<InstallationPath>ColoredHP</InstallationPath>
+		<InstallationPath>Options/ColoredHP</InstallationPath>
 		<Description>Enable or disable the colored HP maximum on menu (player + battle).</Description>
-		<Default/>
-		<PreviewFile>ColoredHP/Thumbnail.jpg</PreviewFile>
+		<PreviewFile>Options/ColoredHP/Thumbnail.jpg</PreviewFile>
+		<Default />
 	</SubMod>
 	<SubMod>
 		<Name>Enable colored MP in Menu</Name>
-		<InstallationPath>ColoredMP</InstallationPath>
+		<InstallationPath>Options/ColoredMP</InstallationPath>
 		<Description>Enable or disable the colored MP maximum on menu (player + battle).</Description>
-		<Default/>
-		<PreviewFile>ColoredMP/Thumbnail.jpg</PreviewFile>
+		<PreviewFile>Options/ColoredMP/Thumbnail.jpg</PreviewFile>
+		<Default />
 	</SubMod>
 	<SubMod>
 		<Name>Enable colored magic stones in Menu</Name>
-		<InstallationPath>ColoredGems</InstallationPath>
+		<InstallationPath>Options/ColoredGems</InstallationPath>
 		<Description>Enable or disable the colored gem stones on player menu.</Description>
-		<Default/>
-		<PreviewFile>ColoredGems/Thumbnail.jpg</PreviewFile>
+		<PreviewFile>Options/ColoredGems/Thumbnail.jpg</PreviewFile>
+		<Default />
 	</SubMod>
 	<SubMod>
+		<Name>Boosted SA Indicator (Pink Text)</Name>
+		<InstallationPath>Options/BoostedSAIndicator/PinkText</InstallationPath>
+		<Description>Enable or disable the colored MP maximum on menu (player + battle).</Description>
+		<PreviewFile>Options/BoostedSAIndicator/PinkText/Thumbnail.jpg</PreviewFile>
+		<Group>BoostedSAIndicator</Group>
+		<Default />
+	</SubMod>
+	<SubMod>
+		<Name>Boosted SA Indicator (Fading)</Name>
+		<InstallationPath>Options/BoostedSAIndicator/Fading</InstallationPath>
+		<Description>Enable or disable the colored gem stones on player menu.</Description>
+		<PreviewFile>Options/BoostedSAIndicator/Fading/Thumbnail.jpg</PreviewFile>
+		<Group>BoostedSAIndicator</Group>
+	</SubMod>
+	<SubMod>
+		<Name>Boosted SA Indicator (Disabled)</Name>
+		<InstallationPath>Options/BoostedSAIndicator/Disabled</InstallationPath>
+		<Description>Enable or disable the colored gem stones on player menu.</Description>
+		<PreviewFile>Options/BoostedSAIndicator/Disabled/Thumbnail.jpg</PreviewFile>
+		<Group>BoostedSAIndicator</Group>
+	</SubMod>
+	<Header>Statistics modifier indicator</Header>
+	<SubMod>
+		<Name>Green / Red</Name>
+		<InstallationPath>Options/StatModifierIndicator/GreenRed</InstallationPath>
+		<Description>A feature that checks whether an unity in battle has modified stats and shows a message.
+		It's generally recommended to leave this enabled.
+		Green indicates a stat bonus.
+		Red indicates a stat malus.</Description>
+		<PreviewFile>Options/StatModifierIndicator/GreenRed/Thumbnail.jpg</PreviewFile>
+		<Group>StatModifierIndicator</Group>
+	</SubMod>
+	<SubMod>
+		<Name>Yellow / Purple</Name>
+		<InstallationPath>Options/StatModifierIndicator/YellowPurple</InstallationPath>
+		<Description>A feature that checks whether an unity in battle has modified stats and shows a message.
+		It's generally recommended to leave this enabled.
+		Yellow indicates a stat bonus.
+		Purple indicates a stat malus.</Description>
+		<PreviewFile>Options/StatModifierIndicator/YellowPurple/Thumbnail.jpg</PreviewFile>
+		<Group>StatModifierIndicator</Group>
+		<Default />
+	</SubMod>
+	<SubMod>
+		<Name>Disabled</Name>
+		<InstallationPath>Options/StatModifierIndicator/Disabled</InstallationPath>
+		<Description>Disable the feature.
+		Not recommended if you're discovering the mod for the first time.</Description>
+		<Group>StatModifierIndicator</Group>
+	</SubMod>
+	<Header>Miscellaneous</Header>
+	<SubMod>
 		<Name>Activate StuffListed file</Name>
-		<InstallationPath>StuffListed</InstallationPath>
+		<InstallationPath>Options/StuffListed</InstallationPath>
 		<Description>Enable or disable a feature to list all stuff at each battle start.
-		You can find the file in the folder TranceSeek, called StuffListed.txt</Description>
-		<PreviewFile>StuffListed/Thumbnail.jpg</PreviewFile>
+	You can find the file in the folder TranceSeek, called StuffListed.txt.
+	A handy way to share your build (e.g., a YouTube video) during a battle.
+	</Description>
+		<PreviewFile>Options/StuffListed/Thumbnail.jpg</PreviewFile>
 	</SubMod>
 	<Category>Gameplay</Category>
 	<PreviewFileUrl>https://i.ibb.co/HC3GH4j/Logo-Trance-Seek.png</PreviewFileUrl>


### PR DESCRIPTION
### {Launcher Options}
New options available via the Memoria Launcher! Specifically to toggle "QoL" (Quality of Life) features:

- Activate Redemption Icon in Battle => Displays the "Redemption" effect icon near Beatrix.
The "Redemption" stack count is also displayed in the menu.
- Immune Status Effect on Player => Also displays the particle effect on players.
- Hé hé ! => Zidane will play a sound effect on every successful steal (voice lines are taken from Dissidia 012).
- Haste/Slow feature => Speeds up or slows down the target's "Idle" animations. Experimental.
- Best sorting shops/equipments menu => Improved sorting for shops and the equipment menu (by type, then by price or attack power depending on the menu).
- Trance Music => Changes the music when an enemy enters "Trance". Disabled by default due to stability issues.
- Party Followers feature => Replicates the Final Fantasy VIII feature where party members follow you on the field! Experimental and WIP.

- Boosted SA Indicator (Pink Text) => Indicates if Level 2 is available (meaning the Level 2 SA is available and you have the required cost).
3 variants available:
1) Pink Text: Highlights the SA in a static "Pink" color as an indicator.
2) Fading: Fades the SA color toward the color of the higher-tier SA.
3) Disabled: Disables the feature.

- Statistics modifier indicator => Displays real-time stat changes on units (players or enemies).
3 variants available:
1) Green / Red
2) Yellow / Purple
3) Disabled

### {Features}
- The "Stop" status effect now wears off after a certain duration, just like "Slow".

### {Characters}
- [NEW] New mechanic for Steiner: Each time he protects an ally (via Cover or Protect Girls), he gains a Pluto stack.
You can spend these stacks using the L2/R2 triggers to empower your next Sword Art ability.
- Beatrix's "Redemption" status has a new icon and will be visible on Beatrix's command window (next to her name).
By default, the status is no longer visible in battle, but you can enable it through the mod options in the Memoria launcher.
Beatrix's mechanics remain unchanged; this is strictly a visual update.
- [NEW/WIP] 4 new "Dragon" abilities for Freya => 2 available in this version and the final 2 planned for Disc 4.
Her Dragon mechanic has been slightly reworked so the effect triggers more consistently:
The chance to inflict Dragon on a target (enemy or ally) is cumulative, using the following formula: [(Spirit / 4) + DragonBonus]%
By default, DragonBonus starts at 2 and stacks with each action performed on the target (0, 2, 4, 6, 8, etc.).
This bonus can be modified by specific spears equipped by Freya: for instance, the Mythril Spear grants a bonus of 4 instead of 2 (scaling at 0, 4, 8, 12, etc.).
Once the Dragon effect is applied, this bonus resets.
Additionally, Freya can inflict the Dragon effect using her Attack, Dragon, and Jump commands.
- Vivi completely loses his "Focus" buff if he is KO'd.
- Code optimizations regarding Zidane's stance switching and Eiko's passive, potentially resolving micro-freezes.
- The "Defense" status will no longer prevent a character from spinning around while under the "Confuse" status.

### {SA / AA Abilities}
- [NEW] "Skill" abilities have been revamped!
Most "Skill" abilities have received a slight power increase.
Furthermore, they now feature an additional effect based on the last digit of Zidane's current MP.
- Freya's "Dragon" abilities deal +25% bonus damage if the target has the "Dragon" status.
- Adjustments made to the spell order of the "Dragon" command, as well as the AP requirements for certain abilities.
- "Dragon's Crest" is now a physical attack instead of magical.
- The special effect of "White Draw" has been increased (50% healing instead of 25%).
- The "Luna" AA ability has been reworked.
- Adjustments made to the "Cherry Blossom" AA ability.
- The Dragon effect on the "Six Dragons" AA ability has been modified.
- Reduced the power of the "Six Dragons" AA ability (15 -> 14).
- Adjusted the MP cost of "Slow": 12 -> 20.
- Adjusted the MP cost of "Haste": 20 -> 14.
- Adjusted the MP cost of "Brigand": 48 -> 36.
- Adjusted the MP cost of "Quick Attack": 56 -> 48.
- "Charge!" now properly factors in damage from Zidane's daggers.
- Fixed a bug with the "Appetite" and "Gluttony" SAs, specifically when the target absorbs the fork's elemental affinity.
- Fixed the "Rejuvenate" and "Harmony" SAs so they now properly synergize with each other.
- Updated the behavior of the "Auto-Potion+" SA: the character will now prioritize curing Zombie and Venom.
- New SFX for "Extort" as well as a full rework of the ability.
- The "Brigand" AA ability has been reworked.
- Fixed the "Light Step" SA, which was not granting the advertised evasion bonus. The bonus value is now clearly specified in the description.
- The "Mystic Veil" SA no longer triggers if the target nullifies the incoming damage.
Additionally, a subtle visual effect now appears when "Mystic Veil" triggers.
- The "Doctor" SA now interacts properly with "Chemist+".
- The "Propagation" SA effects have been reworked for better overall balance.
- The "Divine Punishment" SA has been reworked: the Accuracy bonus has been reduced and it no longer ignores the target's Magic Evasion.
- The "Archmage" SA is now also compatible with Summons and Meteor-type spells.
- The "Initiative" SA will no longer prevent getting a full ATB gauge during preemptive strikes.
- The "Locomotion" SA now reduces the duration of "Slow" and "Stop" effects by 75%.
- Modified the formula for the "Add Status+" SA: grants a bonus of [Spirit / 4] instead of [Spirit / 3]. The description has been updated accordingly.
- Adjusted the bonus provided by the "Champion" SA => Level 1: 50% -> 40% / Level 2: 75% -> 80%.
- Fixed the "Dominance" SA, which could trigger Holy despite the description stating otherwise.
- Adjusted the cost of the "Stamina" SA: 4 -> 3, and improved its overall effect.
- Adjusted the cost of the "Proliferation" SA: 7 -> 6.
- Adjusted the cost of the "Divine Punishment" SA: 8 -> 7.
- Increased the potency of the "EX Mode" SA.
- Added the "Float" status effect to the "Tobigeri" AA ability.
- The "Shock" AA ability no longer dispels magical barriers.
- The "Mist" AA ability is now a "Wind" element attack.
- The "White Wind" AA ability has been reworked.
- Fixed the damage formula for "Death Strike".
- Adjusted the power of the "Mind Blast" AA ability: 61 -> 71.
- Healing spells now properly scale with the Magic↑ buff.
- The "0014_DeathScript.cs" script is now less accurate against multiple targets.
- Fixed a bug with the "Absorb" AA ability when Vivi was at 1 HP.
- Fixed a bug with "What's That!?" which could prevent a character from triggering "Cover".
- Changed the target window layout for the "Regen" spell.
- Fixed multiple sequence files.

### {Items}
- Potions and healing spells (Cure, Cura, and Curaga) now share the same SFX, but with distinct visual colors.
Potions display a more pronounced red hue, unlike magical healing spells (which feature a pearlescent glow).
- Slight adjustment to the Ether SFX to distinguish regular Ethers from Hi-Ethers.
- Reduced the stat bonus granted by "Claw" weapons.
- Fixed a bug with the Komodache where its effect erroneously applied to potions (causing randomized damage).
- Modified the effects of Freya's spears.
- The "Mist Fork" can now be synthesized on Disc 2.
- Adjusted the attack power of the "Mist Fork" : 46 -> 44.
- Amarant can now equip a wider variety of gear.
- Fixed the synthesis ingredients required for "Battle Boots".
- Adjustments made to the "Glass Buckle".
- Adjusted the resale price of several items.
- Adjusted Support Abilities (SA) tied to specific equipment pieces.
- Fixed a critical bug caused by the special effect of the "Cursed Coin".
- "Phoenix Pinion" now prioritizes allied targets afflicted with "Doom", taking the active countdown into account.
- Various description fixes.

### {Monsters & Bosses}
- New monster category: Stone Monsters, which reduce Non-elemental damage by 50% (both physical and magical).
Added a sound effect when a Stone Monster is hit by this type of attack.
Due to current game limitations, this category cannot be displayed via Scan, but this restriction should be lifted in an upcoming Memoria update (PR currently pending).

- The OverTrance mechanic is now more responsive: in the previous version, monsters could grant EXP/Gil/AP bonuses before actually entering Trance.
Additionally, non-boss monsters gaining the "Trance" buff through this mechanic now share the same properties as bosses (they inherit the "EasyKill" flag).
A monster now triggers OverTrance every 10 defeated enemies (instead of numbers ending in 9). Multiple monsters can now enter OverTrance in the same battle (if they are different enemy types).
When a non-boss monster enters Trance, the battle music also changes.

- Fixed stats and AI for the second monster during the "You're Not Alone" sequence.
- Adjusted rewards for Meltigemini.
- Reduced the duration of "Slow" on bosses to 20% of its base duration (down from 30%).
- Slightly reduced the potency of "Counter Horn" for Antlions.
- Fixed and adjusted spellcasting for Clipper.
- "Darkside" attacks can now be evaded using "Vanish".
- Adjusted several sequence files, particularly regarding "Channel" behavior.
- The damage bonus on "Poison" attacks no longer applies to players.
- Minor fix to Plant Brain's AI so the battle ends immediately upon victory.
- Minor fix to Kelgar's AI and his "Lupine Attack", which previously failed to cleanse all status effects.
- Optimized specific encounters prone to softlocks, particularly battles forcing a character's Trance (e.g., Zidane and Steiner against Prison Cage).
The engine will now select an alternate party member if the required character is missing (such as when using the "Costume Pack" mod).
- Fixed one of Ragtimer's quiz questions (English localization).
- Additional fix to Kelgar's rewards.
- The "Virus" status effect no longer damages bosses with 10,000 HP remaining that use the "Boss10000HP" variable.
- Fixed an issue where the camera remained stuck at the end of several abilities, such as Cayman's "Mow Down".
- Fixed Poison attacks erroneously using Gravity as their element instead of Poison.
- In the French localization, Succubus was renamed to "Bombo".

### {Field}
- Added a new mysterious NPC in Treno.
- Added a new scene to Beatrix's questline allowing players to exit the area and prevent a softlock (by triggering a Game Over against the boss).
- Added 3 new music tracks to the Chocobo Hot & Cold minigame (including 2 existing in-game tracks).
Music change instructions have also been added to the minigame tutorial.
- New option for Regent Cid's minigame at the Desert Palace: players can earn a reward upon completing it.
Alternatively, players can now skip the first section of the minigame.
- Enabling Hardcore Mode now alters certain field areas (e.g., digging is slightly more difficult in Chocobo Hot & Cold).
- Fixed the blacksmith / synthesis shop in Alexandria (post-destruction).
- Fixed PartyReserve handling in Bran Bal. Changing party members via the Moogle is now disabled.
Party composition can now be adjusted right before the "You're Not Alone" sequence through a newly added dedicated menu.
- Added a warning at the beginning of Beatrix's quest stating that turning back is impossible once started.
- Fixed Doug's shop dialogue on Disc 1.
- Fixed an easter egg that could be triggered without the player being physically present.
- Translated numerous dialogues across all supported languages (items, AAs, and SAs remain untranslated for now due to current Hades Workshop limitations).

### {Miscellaneous}
- Improved and optimized the visual effect of "Auto-Life".
- Implemented a new fix to resolve the "Vanish" bug occurring when a character exits Trance (notably with the Fantôulard).
- Fixed a Memoria issue where back-attack damage was not accounted for (except when players attempted to flee); will be officially fixed in the next Memoria release.
- Physical back-attack damage bonus increased from +25% to +50%.
- Fixed a bug with P.Defense↑ that increased standard Defense instead (an obsolete formula was kept by mistake).
- Refactored and optimized the entire codebase in Memoria.Scripts.TranceSeek.dll.