### PR TITLE
Re-Add AntiAliasing dropdown option to Launcher Advanced Settings

### DIFF
--- a/Memoria.Launcher/Launcher/Settings.cs
+++ b/Memoria.Launcher/Launcher/Settings.cs
@@ -311,6 +311,12 @@ namespace Memoria.Launcher
             get => _elementssmoothtexture;
             set => SetProperty(ref _elementssmoothtexture, value);
         }
+        private Int16 _antiAliasingChoice;
+        public Int16 AntiAliasingChoice
+        {
+            get => _antiAliasingChoice;
+            set => SetProperty(ref _antiAliasingChoice, value);
+        }
 
 
         private Int16 _rightStickCamera;
@@ -871,6 +877,18 @@ namespace Memoria.Launcher
                     case nameof(DualLanguage):
                         iniFile.SetSetting("Lang", "DualLanguage", $"\"{LANG_CODES[DualLanguage]}\"");
                         break;
+                    case nameof(AntiAliasingChoice):
+                        string aaValue = AntiAliasingChoice switch
+                        {
+                            1 => "2",
+                            2 => "4",
+                            3 => "8",
+                            _ => "0"
+                        };
+                        iniFile.SetSetting("Graphics", "AntiAliasing", aaValue);
+                        if (AntiAliasingChoice > 0)
+                            iniFile.SetSetting("Graphics", "Enabled", "1");
+                        break;
                 }
                 iniFile.Save();
             }
@@ -1196,6 +1214,17 @@ namespace Memoria.Launcher
                 }
                 _dualLanguage = value1;
                 Refresh(nameof(DualLanguage));
+
+                value = iniFile.GetSetting("Graphics", "AntiAliasing");
+                value1isInt = Int16.TryParse(value, out value1);
+                _antiAliasingChoice = (Int16)(value1 switch
+                {
+                    2 => 1,
+                    4 => 2,
+                    8 => 3,
+                    _ => 0
+                });
+                Refresh(nameof(AntiAliasingChoice));
             }
             catch (Exception ex)
             {

--- a/Memoria.Launcher/Launcher/SettingsGrid_Advanced3.cs
+++ b/Memoria.Launcher/Launcher/SettingsGrid_Advanced3.cs
@@ -10,10 +10,10 @@ namespace Memoria.Launcher
         {
             DataContext = (MainWindow)Application.Current.MainWindow;
 
-            // TODO: implement these properly in the launcher
             CreateHeading("Launcher.AdvSettingsTitle");
 
             CreateCheckbox("VSync", "Settings.VSync", "Settings.VSync_Tooltip");
+            CreateCombobox("AntiAliasingChoice", ComboBoxOptions.Literal(["Disabled", "2x MSAA", "4x MSAA", "8x MSAA"]), 50, "Settings.AntiAliasing", "Settings.AntiAliasing_Tooltip");
             CreateCheckbox("SwapConfirmCancel", "Settings.SwapConfirmCancel", "Settings.SwapConfirmCancel_Tooltip");
             CreateCombobox("DualLanguageMode", ComboBoxOptions.Localized(["Settings.DualLanguageModeChoice0", "Settings.DualLanguageModeChoice1", "Settings.DualLanguageModeChoice2"]), 50, "Settings.DualLanguageMode", "Settings.DualLanguageMode_Tooltip");
             CreateCombobox("DualLanguage", ComboBoxOptions.Literal(["English (US)", "English (UK)", "日本語", "Deutsch", "Français", "Italiano", "Español"]), 50, "Settings.DualLanguage", "Settings.DualLanguage_Tooltip");


### PR DESCRIPTION
I'm proposing to restore this in the Launcher. 
It's not a perfect solution but it does the job. We never really removed the feature but just removed in the launcher. 
This time i'm putting it under the Advanced Experimental setting.  